### PR TITLE
feat: 调整导出 HTML 文件的样式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
@@ -41,4 +40,3 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
-.history/

--- a/src/assets/scripts/util.js
+++ b/src/assets/scripts/util.js
@@ -240,11 +240,13 @@ export function downloadMD(doc) {
  * @param {HTML生成内容} htmlStr
  */
 export function exportHTML(htmlStr) {
-  const downLink = document.createElement('a')
+  const downLink = document.createElement("a");
 
-  downLink.download = 'content.html';
+  downLink.download = "content.html";
   downLink.style.display = "none";
-  let blob = new Blob([`<html><head><meta charset="utf-8" /></head><body><div style="width: 750px; margin: auto;">${htmlStr}</div></body></html>`])
+  let blob = new Blob([
+    `<html><head><meta charset="utf-8" /></head><body><div style="width: 750px; margin: auto;">${htmlStr}</div></body></html>`,
+  ]);
 
   downLink.href = URL.createObjectURL(blob);
   document.body.appendChild(downLink);

--- a/src/components/CodemirrorEditor/header.vue
+++ b/src/components/CodemirrorEditor/header.vue
@@ -29,11 +29,7 @@
         content="导出 HTML"
         placement="bottom-start"
       >
-        <i
-          class="el-icon-document"
-          size="medium"
-          @click="$emit('export')"
-        ></i>
+        <i class="el-icon-document" size="medium" @click="$emit('export')"></i>
       </el-tooltip>
       <!-- 页面重置 -->
       <el-tooltip


### PR DESCRIPTION
我发现还有人关注这个 issue，所以继续改了一下

有人说图片比例不对，我为导出 HTML 设置了最大宽度，设置了 750px，二倍图在 PC 展示，使用这个宽度应该是显示效果比较好的一个比例；  
然后增加了 charset，我自己用 safari 查看到处的文件会乱码，所以也修一下。  