### PR TITLE
fix: not replace <pre> in list

### DIFF
--- a/src/assets/scripts/renderers/wx-renderer.js
+++ b/src/assets/scripts/renderers/wx-renderer.js
@@ -141,7 +141,7 @@ class WxRenderer {
         )}><span><%s/></span>${text}</li>`;
 
       renderer.list = (text, ordered, start) => {
-        text = text.replace(/<\/*p.*?>/g, "");
+        text = text.replace(/<\/*p .*?>/g, "").replace(/<\/*p>/g, "");
         let segments = text.split(`<%s/>`);
         if (!ordered) {
           text = segments.join("• ");

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -178,6 +178,7 @@ const mutations = {
             display: -webkit-box;
             padding: 0.5em 1em 1em;
             overflow-x: auto;
+            text-indent: 0;
           }
         </style>
       `


### PR DESCRIPTION
目前如果在list中写code，pre标签会被替换掉，导致code样式不正确