### PR TITLE
fix: locate the bug

### DIFF
--- a/src/components/CodemirrorEditor/EditorHeader/index.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/index.vue
@@ -340,10 +340,9 @@ export default {
         const clipboardDiv = document.getElementById(`output`)
         clipboardDiv.innerHTML = mergeCss(clipboardDiv.innerHTML)
         if (this.isMacCodeBlock) {
-          // FIXME 正则语法无法兼容低版本 safari
           clipboardDiv.innerHTML = clipboardDiv.innerHTML.replaceAll(
-            /(<code class="prettyprint.+?(?<=style="))/g,
-            `$1font-family: Menlo, 'Operator Mono', Consolas, Monaco, monospace;`
+            /(<code class="prettyprint[^>]*)(style=")/g,
+            `$1style="font-family: Menlo, 'Operator Mono', Consolas, Monaco, monospace;`
           )
         }
         clipboardDiv.focus()

--- a/src/components/CodemirrorEditor/EditorHeader/index.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/index.vue
@@ -340,6 +340,7 @@ export default {
         const clipboardDiv = document.getElementById(`output`)
         clipboardDiv.innerHTML = mergeCss(clipboardDiv.innerHTML)
         if (this.isMacCodeBlock) {
+          // FIXME 正则语法无法兼容低版本 safari
           clipboardDiv.innerHTML = clipboardDiv.innerHTML.replaceAll(
             /(<code class="prettyprint.+?(?<=style="))/g,
             `$1font-family: Menlo, 'Operator Mono', Consolas, Monaco, monospace;`


### PR DESCRIPTION
使用 Simulator 测试得知，低版本 Safari 无法兼容正则断言语法，并定位问题所在：

<img width="1197" alt="image" src="https://github.com/doocs/md/assets/70502828/b183b789-f6d0-4579-99fa-c1aff5539f8d">

注释后：

<img width="453" alt="image" src="https://github.com/doocs/md/assets/70502828/897098c5-0629-4a7f-ac40-75f73c46fe5e">


close #196 