### PR TITLE
fix:  style of format menu

### DIFF
--- a/src/components/CodemirrorEditor/EditorHeader/index.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/index.vue
@@ -484,8 +484,7 @@ export default {
 }
 
 .format-item {
-  .padding-left-3;
-  width: 180px;
+  width: 220px;
 
   kbd {
     font-size: 0.75em;


### PR DESCRIPTION
宽度过窄导致内容换行。

<img width="410" alt="image" src="https://github.com/doocs/md/assets/70502828/17f5665e-03bc-4293-8bec-d8b1717ca206">
