### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Save PR id
         id: pr
-        run: echo "::set-output name=id::$(<pr-id.txt)"
+        run: echo "id=$(<pr-id.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Download dist artifact
         uses: dawidd6/action-download-artifact@v2
@@ -73,7 +73,7 @@ jobs:
 
       - name: Save PR id
         id: pr
-        run: echo "::set-output name=id::$(<pr-id.txt)"
+        run: echo "id=$(<pr-id.txt)" >> "$GITHUB_OUTPUT"
 
       - name: The job failed
         uses: actions-cool/maintain-one-comment@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter