### PR TITLE
fix: mac code block display exception

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -183,9 +183,9 @@ export const useStore = defineStore(`store`, {
               height: 25px;
               background-color: transparent;
               background-image: url("https://doocs.oss-cn-shenzhen.aliyuncs.com/img/123.svg");
-              background-position: 14px 10px;
+              background-position: 14px 10px!important;
               background-repeat: no-repeat;
-              background-size: 40px;
+              background-size: 40px!important;
             }
 
             .hljs.code__pre {


### PR DESCRIPTION
fix #285

原因：当设备处于深色模式时，公众号网页会生成了一些适配代码，最终导致渲染异常。

![image](https://github.com/doocs/md/assets/70502828/a00be742-561a-4252-b112-b9375b24557d)
