### PR TITLE
fix: correct ordered list start number rendering

### DIFF
--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -216,7 +216,8 @@ const defaultTheme: Theme = {
   inline: {
     listitem: {
       'text-indent': `-1em`,
-      'display': `block`,
+      'display': `flex`,
+      'align-items': `center`,
       'margin': `0.2em 8px`,
       'color': `var(--el-text-color-regular)`,
     },

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -216,8 +216,7 @@ const defaultTheme: Theme = {
   inline: {
     listitem: {
       'text-indent': `-1em`,
-      'display': `flex`,
-      'align-items': `center`,
+      'display': `block`,
       'margin': `0.2em 8px`,
       'color': `var(--el-text-color-regular)`,
     },

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -193,11 +193,11 @@ export function initRenderer(opts: IOpts) {
       return styledContent(`listitem`, `${prefix}${content}`, `li`)
     },
 
-    list({ ordered, items }: Tokens.List): string {
+    list({ ordered, items, start = 1 }: Tokens.List): string {
       const listItems = []
       for (let i = 0; i < items.length; i++) {
         isOrdered = ordered
-        listIndex = i
+        listIndex = Number(start) + i - 1
         const item = items[i]
         listItems.push(this.listitem(item))
       }


### PR DESCRIPTION
- 修复有序列表序号渲染错误

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/237694da-d52e-421f-a759-1b3e780c47a1">

而在 marked 中：

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/302be64d-c480-41cb-b7d4-9080d5eaf1e0">

- 无序列表嵌套有序列表样式错误

<img width="1448" alt="image" src="https://github.com/user-attachments/assets/32d2b2e6-ebc4-409e-a8a8-a893ab3642bc">

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/974c0e65-60fd-413e-88e0-1e691b8ce8e8">
