### PR TITLE
fix: preview container height overflow

### DIFF
--- a/src/assets/less/app.less
+++ b/src/assets/less/app.less
@@ -77,7 +77,7 @@ section {
   position: relative;
   margin: 0 -20px;
   width: 375px;
-  min-height: 100vh;
+  min-height: 100%;
   padding: 20px;
   font-size: 14px;
   box-sizing: border-box;


### PR DESCRIPTION
少量内容时，滚动条总是常驻