### PR TITLE
feat: update mp oss to save quota

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -360,8 +360,13 @@ async function mpFileUpload(file: File) {
   }
 
   let url = `https://api.weixin.qq.com/cgi-bin/material/add_material?access_token=${access_token}&type=image`
+  const fileSizeInMB = file.size / (1024 * 1024)
+  const fileType = file.type.toLowerCase()
+  if (fileSizeInMB < 1 && (fileType === `image/jpeg` || fileType === `image/png`)) {
+    url = `https://api.weixin.qq.com/cgi-bin/media/uploadimg?access_token=${access_token}`
+  }
   if (proxyOrigin) {
-    url = `${proxyOrigin}/cgi-bin/material/add_material?access_token=${access_token}&type=image`
+    url = url.replace(`https://api.weixin.qq.com`, proxyOrigin)
   }
 
   const res = await fetch<any, { url: string }>(url, requestOptions)


### PR DESCRIPTION
节省微信素材库使用额度。
根据官方文档，小图片上传到另外一个接口
https://developers.weixin.qq.com/doc/offiaccount/Asset_Management/Adding_Permanent_Assets.html
>5、"上传图文消息内的图片获取URL"接口所上传的图片，不占用公众号的素材库中图片数量的100000个的限制，图片仅支持jpg/png格式，大小必须在1MB以下。