### PR TITLE
fix: don't paste file name when pasting image & support drop in image…

### DIFF
--- a/src/views/CodemirrorEditor.vue
+++ b/src/views/CodemirrorEditor.vue
@@ -244,6 +244,7 @@ function initEditor() {
           continue
         }
         uploadImage(pasteFile)
+        e.preventDefault()
       }
     }
   })
@@ -305,6 +306,7 @@ function mdLocalToRemote() {
         else {
           const file = await handle.getFile()
           console.log(`file`, file)
+          beforeUpload(file) && uploadImage(file)
         }
       })
     }


### PR DESCRIPTION
don't paste file name when pasting image & support drop in image to upload