### PR TITLE
fix: code style in `grace` and `simlpe` theme.

### DIFF
--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -354,7 +354,6 @@ const graceTheme = toMerged(defaultTheme, {
     },
 
     'code': {
-      'white-space': `pre-wrap`,
       'font-family': `'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace`,
     },
 
@@ -546,7 +545,6 @@ const simpleTheme = toMerged(defaultTheme, {
     },
 
     code: {
-      'white-space': `pre-wrap`,
       'font-family': `'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace`,
     },
 

--- a/src/views/CodemirrorEditor.vue
+++ b/src/views/CodemirrorEditor.vue
@@ -486,7 +486,7 @@ const isOpenHeadingSlider = ref(false)
                 </div>
               </div>
             </div>
-            <BackTop target="preview" :right="20" :bottom="20" />
+            <BackTop target="preview" :right="isMobile ? 24 : 20" :bottom="isMobile ? 90 : 20" />
           </div>
           <div
             class="bg-background absolute left-0 top-0 border rounded-2 rounded-lt-none p-2 text-sm shadow"


### PR DESCRIPTION
fix #611 
**before:**
![before](https://github.com/user-attachments/assets/b9b15423-72b2-4d10-8964-adbe4dc9de49)
**after:**
![after](https://github.com/user-attachments/assets/2bb40221-b445-4a3b-a95d-68ceee75f7e4)

And fix a bug in #664 because I didn't consider the style in mobile type.
**before:**
![before-btn](https://github.com/user-attachments/assets/f3c9d521-993f-4cf2-8143-945725ebea90)
**after:**
![after-btn](https://github.com/user-attachments/assets/965932d7-bad9-466f-8138-64f3cacabe07)
