### PR TITLE
support footnotes syntax

### DIFF
--- a/src/utils/MDFootnotes.ts
+++ b/src/utils/MDFootnotes.ts
@@ -1,0 +1,89 @@
+import type { MarkedExtension, Tokens } from 'marked'
+/**
+ * A marked extension to support footnotes syntax.
+ * Syntax:
+ *  This is a footnote reference[^1][^2].
+ *
+ *  [^1]: .....
+ *  [^2]: .....
+ */
+
+interface MapContent {
+  index: number
+  text: string
+}
+const fnMap = new Map<string, MapContent>()
+
+export default function markedFootnotes(): MarkedExtension {
+  return {
+    extensions: [
+      {
+        name: `footnoteDef`,
+        level: `block`,
+        start(src: string) {
+          fnMap.clear()
+          return src.match(/^\[\^/)?.index
+        },
+        tokenizer(src: string) {
+          const match = src.match(/^\[\^(.*)\]:(.*)/)
+          if (match) {
+            const [raw, fnId, text] = match
+            const index = fnMap.size + 1
+            fnMap.set(fnId, { index, text })
+            return {
+              type: `footnoteDef`,
+              raw,
+              fnId,
+              index,
+              text,
+            }
+          }
+          return undefined
+        },
+        renderer(token: Tokens.Generic) {
+          const { index, text, fnId } = token
+          const fnInner = `
+                <code>${index}.</code> 
+                <span>${text}</span> 
+                    <a id="fnDef-${fnId}" href="#fnRef-${fnId}" style="color: var(--md-primary-color);">\u21A9\uFE0E</a>
+                <br>`
+          if (index === 1) {
+            return `
+            <p style="font-size: 80%;margin: 0.5em 8px;word-break:break-all;">${fnInner}`
+          }
+          if (index === fnMap.size) {
+            return `${fnInner}</p>`
+          }
+          return fnInner
+        },
+      },
+      {
+        name: `footnoteRef`,
+        level: `inline`,
+        start(src: string) {
+          return src.match(/\[\^/)?.index
+        },
+        tokenizer(src: string) {
+          const match = src.match(/^\[\^(.*?)\]/)
+          if (match) {
+            const [raw, fnId] = match
+            if (fnMap.has(fnId)) {
+              return {
+                type: `footnoteRef`,
+                raw,
+                fnId,
+              }
+            }
+          }
+        },
+        renderer(token: Tokens.Generic) {
+          const { fnId } = token
+          const { index } = fnMap.get(fnId) as MapContent
+          return `<sup style="color: var(--md-primary-color);">
+                    <a href="#fnDef-${fnId}" id="fnRef-${fnId}">\[${index}\]</a>
+                </sup>`
+        },
+      },
+    ],
+  }
+}

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -12,6 +12,7 @@ import readingTime from 'reading-time'
 
 import { getStyleString } from '.'
 import markedAlert from './MDAlert'
+import markedFootnotes from './MDFootnotes'
 import { MDKatex } from './MDKatex'
 import markedSlider from './MDSlider'
 
@@ -348,6 +349,7 @@ export function initRenderer(opts: IOpts) {
     MDKatex({ nonStandard: true }, styles(`inline_katex`, `;vertical-align: middle; line-height: 1;`), styles(`block_katex`, `;text-align: center; overflow: auto;`),
     ),
   )
+  marked.use(markedFootnotes())
 
   return {
     buildAddition,


### PR DESCRIPTION
![footnote](https://github.com/user-attachments/assets/29ca332d-4630-4446-af7f-d1ae7631426e)

fix #579 

支持footnotes语法

但是脚注会和自动生成的“微信外链转底部引用”编号重复，也许需要提示用户分开使用。