### PR TITLE
show css editor scroll.

### DIFF
--- a/src/assets/less/theme.less
+++ b/src/assets/less/theme.less
@@ -11,6 +11,7 @@
     .CodeMirror-wrap {
       background-color: @nightCodeMirrorColor;
     }
+
     .output_night {
       .preview {
         background-color: @nightPreviewColor;
@@ -49,6 +50,12 @@
   padding: 0 20px;
   overflow-x: hidden !important;
   overflow-y: scroll !important;
+}
+
+.cssEditor-wrapper {
+  .CodeMirror-scroll {
+    margin-right: 0;
+  }
 }
 
 .CodeMirror-vscrollbar {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -732,7 +732,7 @@ export const useStore = defineStore(`store`, () => {
 
 export const useDisplayStore = defineStore(`display`, () => {
   // 是否展示 CSS 编辑器
-  const isShowCssEditor = ref(false)
+  const isShowCssEditor = useStorage(`isShowCssEditor`, false)
   const toggleShowCssEditor = useToggle(isShowCssEditor)
 
   // 是否展示插入表格对话框


### PR DESCRIPTION
Display the scrollbar of the CSS editor and save its visibility setting in the browser's localStorage.
![image](https://github.com/user-attachments/assets/5d2c1ee1-a3f0-4f03-971c-ced94ba9a069)
