### PR TITLE
fix: improve file extension extraction to handle multiple dots in fil…

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -65,7 +65,8 @@ function getDir() {
  */
 function getDateFilename(filename: string) {
   const currentTimestamp = new Date().getTime()
-  const fileSuffix = filename.split(`.`)[1]
+  // 获取最后一个点号后的内容作为文件扩展名
+  const fileSuffix = filename.split('.').pop()
   return `${currentTimestamp}-${uuidv4()}.${fileSuffix}`
 }
 


### PR DESCRIPTION
当上传图片的文件名中含有多于一个"."时，原先的方式会提取错误的字符串作为上传文件的拓展名。可以直接取最后一个点后的内容作为拓展名。