### PR TITLE
fix: the background and font colors are the same when bolding the h2 title (#749)

### DIFF
--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -395,6 +395,10 @@ export const useStore = defineStore(`store`, () => {
           overflow-x: auto;
           text-indent: 0;
         }
+
+        h2 strong {
+          color: inherit !important;
+        }
       </style>
     `
 


### PR DESCRIPTION
fix bug[#749 ]
在h2 strong时继承父级颜色