### PR TITLE
fix: add the `<mp-common-profile>` tag whitelist to DOMPurify

### DIFF
--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -362,7 +362,9 @@ export const useStore = defineStore(`store`, () => {
 
     outputTemp = div.innerHTML
 
-    outputTemp = DOMPurify.sanitize(outputTemp)
+    outputTemp = DOMPurify.sanitize(outputTemp, {
+      ADD_TAGS: ['mp-common-profile'],
+    })
 
     // 阅读时间及字数统计
     outputTemp = renderer.buildReadingTime(readingTimeResult) + outputTemp


### PR DESCRIPTION
过滤时，保留 `<mp-common-profile>` 标签