### PR TITLE
feat: filter out 'vite-plugin-Radar' from Vite plugins

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
   },
   vite: () => ({
     ...ViteConfig,
+    plugins: ViteConfig.plugins!.filter(plugin =>
+      typeof plugin === `object`
+      && plugin !== null
+      && !(`name` in plugin && plugin.name === `vite-plugin-Radar`),
+    ),
     base: `/`,
   }),
 })


### PR DESCRIPTION
remove ga when run in extension