### PR TITLE
feat: Add moca theme

### DIFF
--- a/src/config/style.ts
+++ b/src/config/style.ts
@@ -102,6 +102,11 @@ export const colorOptions: IConfigOption[] = [
     value: `#FFB7C5`,
     desc: `浪漫甜美`,
   },
+  {
+    label: `摩卡`,
+    value: `#519325`,
+    desc: `深沉优雅`,
+  },
 ]
 
 export const widthOptions: IConfigOption[] = [

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -587,10 +587,24 @@ const simpleTheme = toMerged(defaultTheme, {
   },
 })
 
+const mocaTheme = toMerged(defaultTheme, {
+  // Initially, no overrides are needed here, as we want it to be based on defaultTheme.
+  // The --md-primary-color will be inherited and should pick up the new color
+  // from the style.ts settings automatically if the theme selection mechanism
+  // correctly applies the chosen primary color.
+  // If specific overrides for moca theme are needed later, they can be added here.
+  base: {
+    // Example: If we wanted to ensure --md-primary-color is explicitly set,
+    // though it should not be necessary if the global theme color is applied.
+    // '--md-primary-color': '#519325', // This is just an example.
+  },
+});
+
 export const themeMap = {
   default: defaultTheme,
   grace: graceTheme,
   simple: simpleTheme,
+  moca: mocaTheme,
 }
 
 export const themeOptions: IConfigOption<keyof typeof themeMap>[] = [
@@ -608,5 +622,10 @@ export const themeOptions: IConfigOption<keyof typeof themeMap>[] = [
     label: `简洁`,
     value: `simple`,
     desc: `@okooo5km`,
+  },
+  {
+    label: `摩卡`,
+    value: `moca`,
+    desc: `深沉优雅`,
   },
 ]


### PR DESCRIPTION
Adds a new 'moca' theme to the application.

This includes:
- Defining the primary color for moca (#519325) in `src/config/style.ts`.
- Creating a `mocaTheme` object in `src/config/theme.ts`, based on `defaultTheme`.
- Registering the `mocaTheme` in the `themeMap`.
- Adding 'Moca' (摩卡) to the `themeOptions` to make it selectable in the UI.