### PR TITLE
fix: fix the bug of cannot render image

### DIFF
--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -84,6 +84,7 @@ export function activate(context: vscode.ExtensionContext) {
         isUseIndent: false,
         countStatus: treeDataProvider.getCurrentCountStatus(),
         isMacCodeBlock: treeDataProvider.getCurrentMacCodeBlock(),
+        legend: `none`,
       })
       const documentText = editor.document.getText()
       const html = marked.parse(documentText) as string


### PR DESCRIPTION
由于之前的`opts.legend`元素未定义，导致出现异常，在声明`renderer`时，补上了该有的参数。