### PR TITLE
fix: `parentId` not reset

### DIFF
--- a/src/components/CodemirrorEditor/PostSlider.vue
+++ b/src/components/CodemirrorEditor/PostSlider.vue
@@ -12,12 +12,15 @@ const addPostInputVal = ref(``)
 watch(isOpenAddDialog, (o) => {
   if (o) {
     addPostInputVal.value = ``
+    parentId.value = null
   }
 })
 
 function openAddPostDialog(id: string) {
-  parentId.value = id
   isOpenAddDialog.value = true
+  nextTick(() => {
+    parentId.value = id
+  })
 }
 
 function addPost() {
@@ -367,7 +370,7 @@ function handleDragEnd() {
               <li
                 v-for="(item, idx) in store.getPostById(currentPostId!)?.history"
                 :key="item.datetime"
-                class="hover:text-primary-foreground hover:bg-primary/90 h-8 w-full inline-flex cursor-pointer items-center gap-2 rounded px-2 text-sm transition-colors"
+                class="hover:bg-primary/90 hover:text-primary-foreground h-8 w-full inline-flex cursor-pointer items-center gap-2 rounded px-2 text-sm transition-colors"
                 :class="{
                   'bg-primary text-primary-foreground shadow-lg dark:border dark:border-primary':
                     currentHistoryIndex === idx,


### PR DESCRIPTION
使用过子菜单添加文章后，导致后续顶部按钮的添加操作不会在根目录下生成。