### PR TITLE
fix: wrong directory

### DIFF
--- a/docker/latest/Dockerfile.nginx
+++ b/docker/latest/Dockerfile.nginx
@@ -3,4 +3,4 @@ ARG VER_NGX="1.21.6-alpine"
 FROM --platform=$BUILDPLATFORM doocs/md:latest-assets AS assets
 FROM --platform=$TARGETPLATFORM nginx:${VER_NGX}
 LABEL MAINTAINER="ylb<contact@yanglibin.info>"
-COPY --from=assets /app /usr/share/nginx/html
+COPY --from=assets /app/assets /usr/share/nginx/html

--- a/docker/latest/Dockerfile.static
+++ b/docker/latest/Dockerfile.static
@@ -5,7 +5,7 @@ FROM --platform=$TARGETPLATFORM lipanski/docker-static-website
 
 WORKDIR /home/static
 
-COPY --from=assets /app /home/static
+COPY --from=assets /app/assets /home/static
 
 EXPOSE 80
 


### PR DESCRIPTION
`*-nginx` 与 `*-static` 系列构建镜像时静态资源路径错误