### PR TITLE
fix: correct line splitting in PostSlider history content display

### DIFF
--- a/src/components/CodemirrorEditor/PostSlider.vue
+++ b/src/components/CodemirrorEditor/PostSlider.vue
@@ -388,7 +388,7 @@ function handleDragEnd() {
             <!-- 右侧内容 -->
             <div class="space-y-2 max-h-full w-[500px] overflow-y-auto">
               <p
-                v-for="(line, idx) in (store.getPostById(currentPostId!)?.history[currentHistoryIndex].content ?? '').split('\\n')"
+                v-for="(line, idx) in (store.getPostById(currentPostId!)?.history[currentHistoryIndex].content ?? '').split('\n')"
                 :key="idx"
               >
                 {{ line }}


### PR DESCRIPTION
修正段落分割正则