### PR TITLE
fix: Toaster did not follow the theme of app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
+import { Toaster } from '@/components/ui/sonner'
 import CodemirrorEditor from '@/views/CodemirrorEditor.vue'
+
+const store = useStore()
 </script>
 
 <template>
   <CodemirrorEditor />
+  <Toaster
+    rich-colors
+    position="top-center"
+    :theme="store.isDark ? 'dark' : 'light'"
+  />
 </template>
 
 <style lang="less">

--- a/src/components/CodemirrorEditor/EditorHeader/index.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/index.vue
@@ -231,8 +231,6 @@ function copy() {
       <Button variant="outline" size="icon" @click="store.isOpenRightSlider = !store.isOpenRightSlider">
         <Settings class="size-4" />
       </Button>
-
-      <Toaster rich-colors position="top-center" />
     </div>
   </header>
 </template>

--- a/src/components/CodemirrorEditor/EditorHeader/index.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Toaster } from '@/components/ui/sonner'
 import {
   altSign,
   ctrlKey,


### PR DESCRIPTION
- 修复 toast 通知一直为亮色样式
- 移动 <Toaster> 至根组件