### PR TITLE
refactor: move importMarkdownContent to composables and update imports

### DIFF
--- a/src/components/CodemirrorEditor/EditorContextMenu.vue
+++ b/src/components/CodemirrorEditor/EditorContextMenu.vue
@@ -6,7 +6,6 @@ const {
   exportEditorContent2HTML,
   exportEditorContent2MD,
   formatContent,
-  importMarkdownContent,
   importDefaultContent,
   copyToClipboard,
   pasteFromClipboard,
@@ -20,6 +19,8 @@ const {
   toggleShowInsertMpCardDialog,
   toggleShowUploadImgDialog,
 } = useDisplayStore()
+
+const importMarkdownContent = useImportMarkdownContent()
 </script>
 
 <template>

--- a/src/components/CodemirrorEditor/EditorHeader/FileDropdown.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/FileDropdown.vue
@@ -12,11 +12,12 @@ const {
 const {
   exportEditorContent2HTML,
   exportEditorContent2MD,
-  importMarkdownContent,
   downloadAsCardImage,
 } = store
 
 const editorStateDialogVisible = ref(false)
+
+const importMarkdownContent = useImportMarkdownContent()
 </script>
 
 <template>

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,0 +1,26 @@
+export function useImportMarkdownContent() {
+  const store = useStore()
+  const { open, reset, onChange } = useFileDialog({
+    accept: `.md`,
+  })
+
+  onChange((files) => {
+    if (files == null || files.length === 0) {
+      return
+    }
+
+    const file = files[0]
+    const reader = new FileReader()
+    reader.readAsText(file)
+    reader.onload = (event) => {
+      store.editor!.setValue(event.target!.result as string)
+      toast.success(`文档导入成功`)
+    }
+  })
+
+  // 导入 Markdown 文档
+  return () => {
+    reset()
+    open()
+  }
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -630,32 +630,7 @@ export const useStore = defineStore(`store`, () => {
     }
   }
 
-  // 导入 Markdown 文档
-  const importMarkdownContent = () => {
-    const body = document.body
-    const input = document.createElement(`input`)
-    input.type = `file`
-    input.name = `filename`
-    input.accept = `.md`
-    input.onchange = () => {
-      const file = input.files![0]
-      if (!file) {
-        return
-      }
-
-      const reader = new FileReader()
-      reader.readAsText(file)
-      reader.onload = (event) => {
-        editor.value!.setValue(event.target!.result as string)
-        toast.success(`文档导入成功`)
-      }
-    }
-
-    body.appendChild(input)
-    input.click()
-    body.removeChild(input)
-  }
-
+  // 是否打开重置样式对话框
   const isOpenConfirmDialog = ref(false)
 
   // 重置样式
@@ -709,7 +684,6 @@ export const useStore = defineStore(`store`, () => {
     exportEditorContent2MD,
     downloadAsCardImage,
 
-    importMarkdownContent,
     importDefaultContent,
     clearContent,
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
     && visualizer({ emitFile: true, filename: `stats.html` }),
     AutoImport({
       imports: [`vue`, `pinia`, `@vueuse/core`],
-      dirs: [`./src/stores`, `./src/utils/toast`],
+      dirs: [`./src/stores`, `./src/utils/toast`, `./src/composables`],
     }),
     Components({
       resolvers: [],


### PR DESCRIPTION
拆分 `importMarkdownContent()` 为自定义 hook 