### PR TITLE
fix: update MathJax script

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,10 +92,7 @@
         svg: { fontCache: 'none' },
       }
     </script>
-    <script
-      id="MathJax-script"
-      src="https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/npm/mathjax@3/es5/tex-svg.js"
-    ></script>
+    <script src="https://cdn.bootcdn.net/ajax/libs/mathjax/3.1.2/es5/tex-svg-full.js"></script>
     <script type="module" src="/src/main.ts"></script>
     <script type="module" src="/src/sidepanel.ts"></script>
   </body>


### PR DESCRIPTION
调整 MathJax 版本至 3.1.2，该版本无外部 cdn 加载
