### PR TITLE
refactor: clean up output file naming in build configuration

### DIFF
--- a/src/modules/build-extension.ts
+++ b/src/modules/build-extension.ts
@@ -37,9 +37,6 @@ export default defineWxtModule({
       if (config.build?.rollupOptions?.input && config.build?.rollupOptions?.output) {
         const input = config.build?.rollupOptions.input as Record<string, string>
         const wxtOutput = config.build?.rollupOptions.output as OutputOptions
-        wxtOutput.chunkFileNames = `chunks/[name].js`
-        wxtOutput.entryFileNames = `chunks/[name].js`
-        wxtOutput.assetFileNames = `assets/[name].[ext]`
         if (input.options || input.sidepanel) {
           wxtOutput.manualChunks = (id) => {
             if (id.includes(`node_modules`)) {
@@ -47,6 +44,8 @@ export default defineWxtModule({
                 return `prettier`
               if (id.includes(`katex`))
                 return `katex`
+              if (id.includes(`diagram`) || id.includes(`Diagram`))
+                return `diagram`
               if (id.includes(`mermaid`))
                 return `mermaid`
               if (id.includes(`cytoscape`))
@@ -55,9 +54,6 @@ export default defineWxtModule({
                 return `hljs`
             }
           }
-        }
-        if (input.background) {
-          wxtOutput.entryFileNames = `[name].js`
         }
       }
     })

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
       && plugin !== null
       && !(`name` in plugin && plugin.name === `vite-plugin-Radar`),
     ),
+    define: undefined,
     build: undefined,
     base: `/`,
   }),


### PR DESCRIPTION
remove `define` option in `vite.config.ts`
build output files now are with the same hash in file names in each builds