### PR TITLE
fix: add null check for editor instance in post content watch

### DIFF
--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -230,8 +230,9 @@ export const useStore = defineStore(`store`, () => {
    ********************************/
   watch(currentPostId, () => {
     const post = getPostById(currentPostId.value)
-    if (post)
-      toRaw(editor.value!).setValue(post.content)
+    if (post) {
+      editor.value && toRaw(editor.value).setValue(post.content)
+    }
   })
 
   onMounted(() => {


### PR DESCRIPTION
取消空值断言，消除首次进入站点无缓存时，出现的赋值错误。