### PR TITLE
feat: add GDScript syntax highlighting support for markdown rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.777.0",
         "@aws-sdk/s3-request-presigner": "^3.777.0",
+        "@exercism/highlightjs-gdscript": "^0.0.1",
         "@ssttevee/multipart-parser": "^0.1.9",
         "@vee-validate/yup": "^4.15.0",
         "@vueuse/core": "^12.5.0",
@@ -2501,6 +2502,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@exercism/highlightjs-gdscript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/@exercism/highlightjs-gdscript/-/highlightjs-gdscript-0.0.1.tgz",
+      "integrity": "sha512-LiCFDhXCr3iIEGESHEsSCpCI7qNa2suHcrBWeOYSEtEwCXc+IQpEh5i4K8qPcOMJB9ckVOgLgbSNML8TyvPCVg==",
+      "license": "MIT"
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.777.0",
     "@aws-sdk/s3-request-presigner": "^3.777.0",
+    "@exercism/highlightjs-gdscript": "^0.0.1",
     "@ssttevee/multipart-parser": "^0.1.9",
     "@vee-validate/yup": "^4.15.0",
     "@vueuse/core": "^12.5.0",

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -8,3 +8,8 @@ interface Window {
     }) => void
   }
 }
+
+// eslint-disable-next-line
+declare module '@exercism/highlightjs-gdscript' {
+  export default LanguageFn
+}

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -3,6 +3,7 @@ import type { RendererObject, Tokens } from 'marked'
 import type { ReadTimeResults } from 'reading-time'
 import type { ExtendedProperties, IOpts, ThemeStyles } from '@/types'
 import type { RendererAPI } from '@/types/renderer-types'
+import gdscript from '@exercism/highlightjs-gdscript'
 import { cloneDeep, toMerged } from 'es-toolkit'
 import frontMatter from 'front-matter'
 import hljs from 'highlight.js'
@@ -15,6 +16,8 @@ import markedFootnotes from './MDFootnotes'
 import { MDKatex } from './MDKatex'
 import markedSlider from './MDSlider'
 import { markedToc } from './MDToc'
+
+hljs.registerLanguage(`gdscript`, gdscript)
 
 marked.setOptions({
   breaks: true,


### PR DESCRIPTION
- 支持 GDScript 代码块高亮
- 扩展库没有 type，手动补充类型声明
- ESLint 会强制将字符串改为反引号，但类型声明不支持反引号写法，所以屏蔽