### PR TITLE
fix: include src/extension directory in zip exclusion list

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       `functions/**`,
       `md-cli/**`,
       `scripts/**`,
+      `src/extension/**`,
     ],
   },
   analysis: {


### PR DESCRIPTION
打包firefox source code zip 时，过滤掉 `src/extension` 目录。