### PR TITLE
fix: include src/extension directory in zip exclusion list

### DIFF
--- a/apps/web/wxt.config.ts
+++ b/apps/web/wxt.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       `functions/**`,
       `md-cli/**`,
       `scripts/**`,
+      `src/extension/**`,
     ],
   },
   analysis: {


### PR DESCRIPTION
为firefox 打包源码zip 排除更多文件