### PR TITLE
fix: WeChat remove standalone spaces in code blocks

### DIFF
--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -252,6 +252,11 @@ export function initRenderer(opts: IOpts): RendererAPI {
       const langText = lang.split(` `)[0]
       const language = hljs.getLanguage(langText) ? langText : `plaintext`
       let highlighted = hljs.highlight(text, { language }).value
+
+      highlighted = highlighted.replace(/(<span[^>]*>[^<]*<\/span>)(\s+)(<span[^>]*>)/g, (_, span1, spaces, span2) => {
+        return span1.replace(/<\/span>$/, `${spaces}</span>`) + span2
+      })
+
       // tab to 4 spaces
       highlighted = highlighted.replace(/\t/g, `    `)
       highlighted = highlighted


### PR DESCRIPTION
微信会去除单个空格，导致空格丢失。

fix:
- #894 

<img width="628" height="620" alt="image" src="https://github.com/user-attachments/assets/9f3e481b-887c-4673-8636-de525991e5b0" />

