### PR TITLE
fix: preserve spaces to prevent WeChat removal

### DIFF
--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -251,10 +251,17 @@ export function initRenderer(opts: IOpts): RendererAPI {
       }
       const langText = lang.split(` `)[0]
       const language = hljs.getLanguage(langText) ? langText : `plaintext`
+
       let highlighted = hljs.highlight(text, { language }).value
 
-      highlighted = highlighted.replace(/(<span[^>]*>[^<]*<\/span>)(\s+)(<span[^>]*>)/g, (_, span1, spaces, span2) => {
-        return span1.replace(/<\/span>$/, `${spaces}</span>`) + span2
+      // 处理两个完整 span 标签之间的空格
+      highlighted = highlighted.replace(/(<span[^>]*>[^<]*<\/span>)(\s+)(<span[^>]*>[^<]*<\/span>)/g, (_, span1, spaces, span2) => {
+        return span1 + span2.replace(/^(<span[^>]*>)/, `$1${spaces}`)
+      })
+
+      // 处理 span 标签开始前的空格
+      highlighted = highlighted.replace(/(\s+)(<span[^>]*>)/g, (_, spaces, span) => {
+        return span.replace(/^(<span[^>]*>)/, `$1${spaces}`)
       })
 
       // tab to 4 spaces


### PR DESCRIPTION
微信会移除单独 `span` 的空格，如以下标签会被剔除：

```html
<span leaf>&nbsp;</span>
```

因此需要将空格和 `span` 进行合并。

原来的正则表达式 `/(<span[^>]*>[^<]*<\/span>)(\s+)(<span[^>]*>)/g` 只匹配：

- 完整的第一个 `span` 标签
- 空格
- 第二个 `span` 标签的开始部分

增加两种情况：

1. 处理两个完整 `span` 标签之间的空格 `/(<span[^>]*>[^<]*<\/span>)(\s+)(<span[^>]*>[^<]*<\/span>)/g`：
    - 匹配两个完整的 span 标签之间的空格
    - 将空格移到第二个 span 标签内部
2. 处理 `span` 标签开始前的空格 `/(\s+)(<span[^>]*>)/g`

#894 

```yaml
# 已隐藏部分配置，限于篇幅这里仅展示关键 action
jobs:
  build:
    runs-on: host
    outputs:  # 声明作业的输出变量
      datetime: ${{ steps.datetime.outputs.datetime }}
    steps:
    #.....省去拉取源码等其他配置....
      - name: Cache dependencies
        # 官方地址: actions/cache@v4
        uses: http://git.luhome.com/actions/cache@v4
        id: yarn-cache
        with:
          # 配置需要缓存的路径
          path: |
            ~/.cache/yarn
            .next/cache
            node_modules
          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
          restore-keys: |
            ${{ runner.os }}-yarn-
```

```ts
// 测试代码
public test(): boolean {
    const scaledMatrix: number[][] = [];
  
    let hasFallen = false;
    for (let y = BOARD_HEIGHT - 2; y >= 0; y--) {
        for (let x = 0; x < BOARD_WIDTH; x++) {
            const cell = this.getCell(x, y);
            if (cell == 1) {
               continue;
            }        
        }
    }
    return hasFallen;
}
```

<img width="593" height="523" alt="image" src="https://github.com/user-attachments/assets/1b35676b-718c-4ff7-90d3-0dd8c25d0c05" />

<img width="593" height="404" alt="image" src="https://github.com/user-attachments/assets/0c7c4d6a-7471-4244-a017-5078067b9fe0" />
