### PR TITLE
fix: link text break line

### DIFF
--- a/apps/web/src/components/CodemirrorEditor/PostSlider/index.vue
+++ b/apps/web/src/components/CodemirrorEditor/PostSlider/index.vue
@@ -433,12 +433,12 @@ function handleDragEnd() {
 
         <!-- 右侧内容 -->
         <div class="space-y-2 max-h-full flex-1 overflow-y-auto">
-          <p
-            v-for="(line, idx) in (store.getPostById(currentPostId!)?.history[currentHistoryIndex].content ?? '').split('\n')"
-            :key="idx"
+          <div
+            class="whitespace-pre-wrap p-2"
+            style="word-wrap: break-word; overflow-wrap: break-word; word-break: break-all; hyphens: auto;"
           >
-            {{ line }}
-          </p>
+            {{ store.getPostById(currentPostId!)?.history[currentHistoryIndex].content ?? '' }}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
```md
# 探索 Markdown 的奇妙世界

![](https://image.pollinations.ai/prompt/%E4%B8%80%E5%8F%AA%E7%8C%AA%E5%9C%A8%E8%8D%89%E5%8E%9F%E5%A5%94%E8%B7%91%20%2C%20high%20quality?width=512&height=512&nologo=true&seed=792191212)
```