### PR TITLE
fix: mermaid text color

### DIFF
--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -330,4 +330,11 @@ export async function processClipboardContent(primaryColor: string) {
     grand.innerHTML = ``
     grand.appendChild(section)
   })
+
+  // fix: mermaid 部分文本颜色被 stroke 覆盖
+  clipboardDiv.innerHTML = clipboardDiv.innerHTML
+    .replace(
+      /<tspan([^>]*)>/g,
+      `<tspan$1 style="fill: #333333 !important; color: #333333 !important; stroke: none !important;">`,
+    )
 }


### PR DESCRIPTION
close: #280 

```md
sequenceDiagram;
  participant a as 一一一;
  participant b as 二二二;
  participant c as 三三三;
  participant d as 四四四;
  participant e as 呜呜呜呜呜呜呜;
  participant f as 杀死嗲佛到货还代发还发货i阿护肤i阿法ifAsif服hhfashafhah
```
<img width="581" height="89" alt="image" src="https://github.com/user-attachments/assets/858ed361-3894-4893-8644-e24c6badc7d7" />
