### PR TITLE
feat: integrate js-lite-rest for data persistence

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,7 @@
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
     "isomorphic-dompurify": "^2.29.0",
+    "js-lite-rest": "^0.0.5",
     "juice": "^11.0.3",
     "lucide-vue-next": "^0.545.0",
     "marked": "^16.4.0",

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,6 +1,8 @@
 import { initializeMermaid } from '@md/core/utils'
+import JsLiteRest from 'js-lite-rest'
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
+import { data } from '@/stores/defaultData'
 import App from './App.vue'
 
 import { setupComponents } from './utils/setup-components'
@@ -11,13 +13,38 @@ import 'vue-sonner/style.css'
 import '@/assets/index.css'
 import '@/assets/less/theme.less'
 
-// 异步初始化 mermaid，避免初始化顺序问题
-initializeMermaid().catch(console.error)
+;
 
-setupComponents()
+(async function () {
+  const storex = await JsLiteRest.create({
+    history: [],
+    posts: data.posts,
+  }, {
+    savePath: `storex`,
+  })
+  storex.use(async (args: any, next: any) => {
+    const restLog: any = {}
+    if (args[2]) {
+      // 统一处理 vue 包装的可能是响应式的特殊对象
+      args[2] = JSON.parse(JSON.stringify(args[2]))
+    }
+    let result = await next(args)
+    result = JSON.parse(JSON.stringify(result))
+    restLog.args = args
+    restLog.result = result
+    console.debug(`restLog`, args.slice(0, 2).join(`/`), args[2], result.data)
+    return result
+  })
+  window.storex = storex
 
-const app = createApp(App)
+  // 异步初始化 mermaid，避免初始化顺序问题
+  initializeMermaid().catch(console.error)
 
-app.use(createPinia())
+  setupComponents()
 
-app.mount(`#app`)
+  const app = createApp(App)
+
+  app.use(createPinia())
+
+  app.mount(`#app`)
+})()

--- a/apps/web/src/stores/defaultData.ts
+++ b/apps/web/src/stores/defaultData.ts
@@ -1,0 +1,21 @@
+import { v4 as uuid } from 'uuid'
+import DEFAULT_CONTENT from '@/assets/example/markdown.md?raw'
+
+const data = {
+  posts: [
+    {
+      id: uuid(),
+      title: `内容1`,
+      content: DEFAULT_CONTENT,
+      history: [
+        { datetime: new Date().toLocaleString(`zh-cn`), content: DEFAULT_CONTENT },
+      ],
+      createDatetime: new Date(),
+      updateDatetime: new Date(),
+    },
+  ],
+}
+
+export {
+  data,
+}

--- a/apps/web/src/types/global.d.ts
+++ b/apps/web/src/types/global.d.ts
@@ -1,4 +1,5 @@
 interface Window {
+  storex: any
   __MP_Editor_JSAPI__: {
     invoke: (params: {
       apiName: string

--- a/apps/web/src/views/CodemirrorEditor.vue
+++ b/apps/web/src/views/CodemirrorEditor.vue
@@ -420,6 +420,7 @@ function createFormTextArea(dom: HTMLDivElement) {
 
             currentPost.updateDatetime = new Date()
             currentPost.content = value
+            store.putPost(currentPost.id, currentPost)
           }, 300)
         }
       }),
@@ -515,6 +516,10 @@ onMounted(() => {
     currentPost.history.unshift({
       content: currentPost.content,
       datetime: new Date().toLocaleString(`zh-CN`),
+    })
+    window.storex.post(`history`, {
+      postsId: currentPost.id,
+      content: currentPost.content,
     })
 
     currentPost.history.length = Math.min(currentPost.history.length, 10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       isomorphic-dompurify:
         specifier: ^2.29.0
         version: 2.29.0(postcss@8.5.6)
+      js-lite-rest:
+        specifier: ^0.0.5
+        version: 0.0.5
       juice:
         specifier: ^11.0.3
         version: 11.0.3
@@ -6976,6 +6979,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-lite-rest@0.0.5:
+    resolution: {integrity: sha512-kEwr8iaYM/CTYit+NglC5DK4RkZ0U0F2TAt7ufiI71I1Qd3HA1wPV2YhP+ov/nbYuwGAXYonRCYuiRI0rT628Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -18384,6 +18390,8 @@ snapshots:
   jiti@2.5.1: {}
 
   jiti@2.6.1: {}
+
+  js-lite-rest@0.0.5: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
- Add js-lite-rest dependency for local data storage
- Refactor main.ts to initialize storex with posts and history
- Create defaultData.ts to manage initial post data
- Update store methods to use async storex operations
- Add storex to global type definitions
- Enhance CodemirrorEditor with history tracking via storex

把文章和文章历史分别保存到了 indexedDB 中。

<img width="2550" height="1212" alt="image" src="https://github.com/user-attachments/assets/45a6a84a-62e0-4329-87a7-5fb5019ce842" />

为什么这样做？

> 因为当前使用的本地存储大多情况下可能只支持到 5M 体积。如果一篇文章有很多历史或添加了几张 base64 的图片，那么将会很快达到限制导致而出现问题。

为什么使用 lite-rest？

> 它以 restfull api 的形式进行内容操作，在提供便利性的同时，便于后期以 http 或其他形式(可通过中间件)进行扩展。
> 它实际上是类似 axios 的方法。只是没有先把 XMLHttpRequest 这部分后端交互放进去(因为没有后端)，但依然拥有了除此之外的所有代码。例如请求和响应拦截、restfull 操作方法(例如 `store.put("/posts/1")`)。

以后是什么？

> 把所有 store 数据存取都异步化，以支持所有数据上云或平台化的可能性。