### PR TITLE
fix: 修复图片未提供title时显示null的问题

### DIFF
--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -296,7 +296,8 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
     image({ href, title, text }: Tokens.Image): string {
       const subText = styledContent(`figcaption`, transform(opts.legend!, text, title))
-      return `<figure><img src="${href}" title="${title}" alt="${text}"/>${subText}</figure>`
+      const titleAttr = title ? ` title="${title}"` : ``
+      return `<figure><img src="${href}"${titleAttr} alt="${text}"/>${subText}</figure>`
     },
 
     link({ href, title, text, tokens }: Tokens.Link): string {


### PR DESCRIPTION
## 📝 描述

修复了当 Markdown 图片未提供 title 参数时,渲染的 HTML 中显示 `title="null"` 的问题。

## 🔗 相关 Issue

Closes #1129

## 🎯 变更内容

### 修改文件

- `packages/core/src/renderer/renderer-impl.ts`

### 具体变更

在 `image` 方法中添加了条件判断:

- 当 `title` 为 `null` 或 `undefined` 时,不渲染 `title` 属性
- 当 `title` 有值时,正常渲染 `title` 属性

**修改前:**

```typescript
image({ href, title, text }: Tokens.Image): string {
  const subText = styledContent(`figcaption`, transform(opts.legend!, text, title))
  return `<figure><img src="${href}" title="${title}" alt="${text}"/>${subText}</figure>`
}
```

**修改后:**

```typescript
image({ href, title, text }: Tokens.Image): string {
  const subText = styledContent(`figcaption`, transform(opts.legend!, text, title))
  const titleAttr = title ? ` title="${title}"` : ``
  return `<figure><img src="${href}"${titleAttr} alt="${text}"/>${subText}</figure>`
}
```

## ✅ 测试

### 测试场景 1: 没有 title 的图片

```markdown
![图片](https://example.com/image.png)
```

**期望结果:** 生成的 `<img>` 标签**不包含** `title` 属性
**实际结果:** ✅ 通过

### 测试场景 2: 有 title 的图片

```markdown
![图片](https://example.com/image.png '这是标题')
```

**期望结果:** 生成的 `<img>` 标签包含 `title="这是标题"`
**实际结果:** ✅ 通过

### 测试场景 3: 只有 alt 的图片

```markdown
![Alt文本](https://example.com/image.png)
```

**期望结果:** 生成的 `<img>` 标签**不包含** `title` 属性
**实际结果:** ✅ 通过

## 📊 影响范围

- ✅ **向后兼容**: 已有 title 的图片不受影响
- ✅ **无破坏性变更**: 只是移除了 `title="null"` 的情况
- ✅ **改善用户体验**: 鼠标悬停时不再显示 "null" 提示
- ✅ **影响范围小**: 仅修改图片渲染逻辑,不影响其他功能

## 📸 截图/演示

### 修复前

- 鼠标悬停在没有 title 的图片上会显示 "null" 提示

### 修复后

- 鼠标悬停在没有 title 的图片上不显示任何提示
- 有 title 的图片正常显示 title 内容

## ✔️ 检查清单

- [x] 代码遵循项目的代码规范
- [x] 已在本地测试所有相关场景
- [x] 不引入任何破坏性变更
- [x] 修改不影响其他功能(如 slider、link 等)
- [x] 提交信息遵循项目规范
