### PR TITLE
feat: zhihu platform sync

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -110,6 +110,7 @@ function getPlatformUrl(type: string): string {
     csdn: 'https://blog.csdn.net',
     juejin: 'https://juejin.cn',
     wechat: 'https://mp.weixin.qq.com',
+    zhihu: 'https://www.zhihu.com/signin',
   }
   return urls[type] || '#'
 }


### PR DESCRIPTION
## Summary

Add Zhihu platform sync support for the COSE v1.0.3 feature.

## Changes

- Add `zhihu: 'https://www.zhihu.com/signin'` to getPlatformUrl() in PostInfo.vue
- Enables proper redirect to Zhihu login page when clicking the Zhihu account link

## Related

Works with [COSE browser extension](https://github.com/doocs/cose) `v1.0.3` for multi-platform article sync.