### PR TITLE
feat: cnblogs platform sync

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -113,6 +113,7 @@ function getPlatformUrl(type: string): string {
     zhihu: 'https://www.zhihu.com/signin',
     toutiao: 'https://mp.toutiao.com',
     segmentfault: 'https://segmentfault.com/user/login',
+    cnblogs: 'https://account.cnblogs.com/signin',
   }
   return urls[type] || '#'
 }


### PR DESCRIPTION
## Summary

Add support for Cnblogs (博客园) platform in the COSE browser extension, enabling users to sync articles directly to Cnblogs.

## Changes

### Browser Extension (`cose/`)
- **Platform Configuration**: Added Cnblogs to the `PLATFORMS` array with icon, URLs, and metadata
- **Editor Integration**: Implemented content injection for Cnblogs' editor with the following features:
  - Support for both `#md-editor` and `textarea.not-resizable` selectors
  - Added 500ms delay to ensure editor is fully loaded
  - Automatic focus on the editor after content injection
- **Login Detection**: Added `cnblogs.com` hostname detection in getPlatformFiller()

### Web App (`apps/web/`)
- Added Cnblogs login URL to getPlatformUrl() in PostInfo.vue

## Technical Details

- Cnblogs uses a traditional textarea-based editor with optional Markdown support
- The implementation includes a fallback mechanism to handle different editor versions
- Added proper error handling for editor element detection
- Removed unnecessary comments and optimized code structure

## Testing

1. Install the COSE extension
2. Log in to Cnblogs in the browser
3. Open the MD editor and verify Cnblogs appears in the platform list
4. Click "Sync to Cnblogs" and confirm:
   - The editor is automatically focused
   - Content is properly injected into the editor
   - Both title and content are preserved
5. Test with different content types (Markdown, code blocks, images)

## Notes

- Requires users to be logged in to Cnblogs before syncing
- Supports both new and old versions of Cnblogs' editor interface
- The extension will automatically detect the appropriate editor element