### PR TITLE
feat: sspai platform sync and rerank

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -35,6 +35,38 @@ const form = ref<Post>({
 
 const allowPost = computed(() => extensionInstalled.value && form.value.accounts.some(a => a.checked))
 
+// 平台优先级排序（按用户规模从大到小）
+const platformPriority: Record<string, number> = {
+  // 第一梯队
+  wechat: 1, // 微信公众号
+  toutiao: 2, // 今日头条
+  baijiahao: 3, // 百家号
+  // 第二梯队
+  zhihu: 4, // 知乎
+  wangyihao: 5, // 网易号
+  tencentcloud: 6, // 腾讯云
+  // 第三梯队
+  csdn: 7, // CSDN
+  segmentfault: 8, // 思否
+  cnblogs: 9, // 博客园
+  juejin: 10, // 掘金
+  cto51: 11, // 51CTO
+  oschina: 12, // 开源中国
+  // 第四梯队
+  infoq: 13, // InfoQ
+  jianshu: 14, // 简书
+  sspai: 15, // 少数派
+  medium: 16, // Medium
+}
+
+const sortedAccounts = computed(() => {
+  return [...form.value.accounts].sort((a, b) => {
+    const priorityA = platformPriority[a.type] ?? 99
+    const priorityB = platformPriority[b.type] ?? 99
+    return priorityA - priorityB
+  })
+})
+
 async function prePost() {
   if (extensionInstalled.value && allAccounts.value.length === 0) {
     await getAccounts()
@@ -122,6 +154,7 @@ function getPlatformUrl(type: string): string {
     wangyihao: 'https://mp.163.com/login.html',
     tencentcloud: 'https://cloud.tencent.com/developer',
     medium: 'https://medium.com/m/signin',
+    sspai: 'https://sspai.com/login',
   }
   return urls[type] || '#'
 }
@@ -163,7 +196,7 @@ onBeforeMount(() => {
           发布
         </Button>
       </DialogTrigger>
-      <DialogContent class="max-w-lg max-h-[85vh] overflow-y-auto">
+      <DialogContent class="!w-[750px] !max-w-[95vw] max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>发布</DialogTitle>
           <DialogDescription>
@@ -208,11 +241,11 @@ onBeforeMount(() => {
           <Label class="w-10 text-end">
             平台
           </Label>
-          <div class="flex-1 grid grid-cols-1 gap-y-2">
+          <div class="flex-1 grid grid-cols-2 gap-x-8 gap-y-2">
             <div
-              v-for="account in form.accounts"
+              v-for="account in sortedAccounts"
               :key="account.uid"
-              class="flex items-center gap-2"
+              class="flex items-center gap-2 whitespace-nowrap"
             >
               <CheckboxRoot
                 v-model:checked="account.checked"


### PR DESCRIPTION
## Summary

Reorganize platform display order in the publish dialog based on user scale (from largest to smallest), and add support for Sspai (少数派) platform. This update improves user experience by prioritizing high-traffic platforms and expands platform coverage to include the digital lifestyle media platform Sspai.

## Changes

### Web Application (apps/web/)

**Platform Display Optimization:**

- Reorganized platform list from alphabetical sorting to user-scale-based priority sorting
- Changed dialog layout from single column to two columns for better space utilization
- Adjusted dialog width to 750px for optimal display of two-column layout
- Added `whitespace-nowrap` to prevent platform names from wrapping

**Priority Sorting Implementation:**

Created `platformPriority` mapping with four tiers based on user scale:

- **Tier 1 (Billion-level users):** 微信公众号, 今日头条, 百家号
- **Tier 2 (Ten-million-level users):** 知乎, 网易号, 腾讯云开发者社区
- **Tier 3 (Million to ten-million-level users):** CSDN, 思否, 博客园, 掘金, 51CTO, 开源中国
- **Tier 4 (Niche platforms):** InfoQ, 简书, 少数派, Medium

**Sspai Platform Support:**

- Added Sspai to the platform registry with platform URL (https://sspai.com/login)
- Integrated Sspai into the `platformPriority` sorting configuration

## Technical Details

**Sorting Implementation:**

```typescript
const platformPriority: Record<string, number> = {
  wechat: 1,        // 微信公众号
  toutiao: 2,       // 今日头条
  baijiahao: 3,     // 百家号
  zhihu: 4,         // 知乎
  wangyihao: 5,     // 网易号
  tencentcloud: 6,  // 腾讯云
  csdn: 7,          // CSDN
  segmentfault: 8,  // 思否
  cnblogs: 9,       // 博客园
  juejin: 10,       // 掘金
  cto51: 11,        // 51CTO
  oschina: 12,      // 开源中国
  infoq: 13,        // InfoQ
  jianshu: 14,      // 简书
  sspai: 15,        // 少数派
  medium: 16,       // Medium
}
```

**Computed Property for Sorted Accounts:**

- Created `sortedAccounts` computed property to dynamically sort platforms
- Platforms not in the priority map default to priority 99 (displayed last)
- Sorting is performed on each render to handle dynamic account lists

**Layout Changes:**

- Changed grid from `grid-cols-1` to `grid-cols-2` for two-column display
- Set `gap-x-8` for horizontal spacing and `gap-y-2` for vertical spacing
- Dialog width changed from default `max-w-lg` (512px) to `!w-[750px]`

## Testing

### Visual Test

1. Open the Markdown editor publish dialog
2. Verify platforms are displayed in two columns
3. Confirm platform order follows the priority (微信公众号 first, Medium last)
4. Verify all platform names display horizontally without wrapping

### Sorting Test

1. Confirm 微信公众号 and 今日头条 appear in the first row
2. Confirm 百家号 and 知乎 appear in the second row
3. Confirm 少数派 and Medium appear in the last row
4. Verify any unknown platforms appear at the end

## Files Changed

- `apps/web/src/components/editor/editor-header/PostInfo.vue`
  - Added `platformPriority` constant for platform sorting order
  - Added `sortedAccounts` computed property
  - Updated `DialogContent` class for wider dialog
  - Updated platform grid layout to two columns
  - Added `getPlatformUrl` entry for Sspai
