### PR TITLE
refactor: move local folder menu item from View to File menu

### DIFF
--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Download, FileCode, FileCog, FileText, FolderKanban, Package, Upload } from 'lucide-vue-next'
+import { Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Upload } from 'lucide-vue-next'
 import { useEditorStore } from '@/stores/editor'
 import { useExportStore } from '@/stores/export'
 import { useUIStore } from '@/stores/ui'
@@ -18,7 +18,7 @@ const editorStore = useEditorStore()
 const exportStore = useExportStore()
 const uiStore = useUIStore()
 
-const { isOpenPostSlider } = storeToRefs(uiStore)
+const { isOpenPostSlider, isOpenFolderPanel } = storeToRefs(uiStore)
 const { toggleShowTemplateDialog } = uiStore
 
 const importMarkdownContent = useImportMarkdownContent()
@@ -60,6 +60,14 @@ function exportEditorContent2PDF() {
       文件
     </MenubarSubTrigger>
     <MenubarSubContent class="w-56">
+      <!-- 本地文件夹 -->
+      <MenubarItem @click="isOpenFolderPanel = !isOpenFolderPanel">
+        <FolderOpen class="mr-2 size-4" />
+        本地文件夹
+      </MenubarItem>
+
+      <MenubarSeparator />
+
       <!-- 导入子菜单 -->
       <MenubarSub>
         <MenubarSubTrigger>
@@ -136,6 +144,14 @@ function exportEditorContent2PDF() {
       文件
     </MenubarTrigger>
     <MenubarContent class="w-56" align="start">
+      <!-- 本地文件夹 -->
+      <MenubarItem @click="isOpenFolderPanel = !isOpenFolderPanel">
+        <FolderOpen class="mr-2 size-4" />
+        本地文件夹
+      </MenubarItem>
+
+      <MenubarSeparator />
+
       <!-- 导入子菜单 -->
       <MenubarSub>
         <MenubarSubTrigger>

--- a/apps/web/src/components/editor/editor-header/ViewDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/ViewDropdown.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { widthOptions } from '@md/shared/configs'
-import { FileCode, FolderOpen, Monitor, Moon, Palette, PanelLeft, Smartphone, Sun } from 'lucide-vue-next'
+import { FileCode, Monitor, Moon, Palette, PanelLeft, Smartphone, Sun } from 'lucide-vue-next'
 import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 
@@ -15,7 +15,7 @@ const { asSub } = toRefs(props)
 const uiStore = useUIStore()
 const themeStore = useThemeStore()
 
-const { isDark, isEditOnLeft, isShowCssEditor, isOpenRightSlider, isOpenFolderPanel } = storeToRefs(uiStore)
+const { isDark, isEditOnLeft, isShowCssEditor, isOpenRightSlider } = storeToRefs(uiStore)
 const { previewWidth } = storeToRefs(themeStore)
 
 // Get mobile and desktop width values
@@ -121,10 +121,6 @@ function setPreviewMode(width: string) {
         <FileCode class="mr-2 h-4 w-4" />
         CSS 编辑器
       </MenubarItem>
-      <MenubarItem @click="isOpenFolderPanel = !isOpenFolderPanel">
-        <FolderOpen class="mr-2 h-4 w-4" />
-        本地文件夹
-      </MenubarItem>
     </MenubarSubContent>
   </MenubarSub>
 
@@ -219,10 +215,6 @@ function setPreviewMode(width: string) {
       <MenubarItem @click="isShowCssEditor = !isShowCssEditor">
         <FileCode class="mr-2 h-4 w-4" />
         CSS 编辑器
-      </MenubarItem>
-      <MenubarItem @click="isOpenFolderPanel = !isOpenFolderPanel">
-        <FolderOpen class="mr-2 h-4 w-4" />
-        本地文件夹
       </MenubarItem>
     </MenubarContent>
   </MenubarMenu>


### PR DESCRIPTION
- Moved "Local Folder" menu item from View dropdown to File dropdown
- Changed from submenu to direct menu item for easier access
- Removed unused FolderOpen icon and isOpenFolderPanel reference from ViewDropdown