### PR TITLE
feat: huaweicloud platform sync

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -159,6 +159,7 @@ function getPlatformUrl(type: string): string {
     bilibili: 'https://passport.bilibili.com/login',
     weibo: 'https://passport.weibo.com/sso/signin',
     aliyun: 'https://account.aliyun.com/login/login.htm',
+    huaweicloud: 'https://auth.huaweicloud.com/authui/login.html?service=https%3A%2F%2Fbbs.huaweicloud.com%2F&locale=zh-cn#/login',
   }
   return urls[type] || '#'
 }


### PR DESCRIPTION
## Summary

Add support for Huawei Cloud Developer Blog (华为云开发者博客) platform in the COSE browser extension, enabling users to sync articles directly to Huawei Cloud. This update includes a new modular platform configuration, page-based login detection with real user profile retrieval via scripting API, and Markdown-based content filling using Huawei Cloud's native TinyMCE Markdown editor.

## Changes

### Browser Extension (cose/)

#### Platform Configuration:
- Added Huawei Cloud to the platform registry with official icon (`https://www.huaweicloud.com/favicon.ico`)
- Created new `src/platforms/huaweicloud.js` to encapsulate all Huawei Cloud-specific logic (platform config, login detection)
- Integrated Huawei Cloud into `src/platforms/index.js` for centralized platform management
- Added Huawei Cloud domain permissions (`https://*.huaweicloud.com/*`) to `manifest.json`

#### Login Detection:
- Implemented cookie + page-based API authentication using `ua`, `SessionID` cookies and `GET https://devdata.huaweicloud.com/rest/developer/fwdu/rest/developer/user/hdcommunityservice/v1/member/get-personal-info`
- Uses `chrome.scripting.executeScript` to call API from an existing Huawei Cloud page context (required for CORS)
- Retrieves real user profile data including:
  - `username`: Actual username from `data.memAlias` or `data.memName`
  - `avatar`: User avatar URL from `data.memPhoto`
- Returns `{ loggedIn: true, username, avatar }` when authenticated
- Gracefully handles unauthenticated state by returning `{ loggedIn: false }`

#### Content Sync Workflow:
- **Markdown-Based Approach**: Uses direct Markdown injection since Huawei Cloud has a native Markdown editor powered by TinyMCE
- Implemented proper workflow in `syncToPlatform()`:
  1. Navigate to Huawei Cloud editor: `https://bbs.huaweicloud.com/blogs/article`
  2. Wait for page to fully load (3 seconds)
  3. Auto-switch to Markdown editor mode if not already selected
  4. Handle confirmation dialog when switching editor modes
  5. Fill title using standard input event dispatch
  6. Fill Markdown content via `tinymceModal.currentEditor.setContent()`
  7. Auto-click "保存草稿" (Save Draft) button

#### Content Filler:
- Created dedicated Huawei Cloud sync handler in `background.js`
- **Technical Challenge Solved**: Huawei Cloud uses TinyMCE editor with a custom `tinymceModal` wrapper, requiring access to the global editor instance
- **Editor Mode Detection**:
  - Check `window.tinymceModal.currentEditorType` for current mode
  - Auto-click "Markdown格式编辑" tab if in rich text mode
  - Handle confirmation dialog by clicking "确定" button
- **Title Filling Method**:
  - Locate `input[placeholder*="标题"]`
  - Use standard value assignment with `input` and `change` event dispatch
- **Content Filling Method**:
  - Access `window.tinymceModal.currentEditor`
  - Call `editor.setContent(markdown)` to inject Markdown content
- **Why Markdown Method**: Huawei Cloud Developer Blog uses a native Markdown editor (TinyMCE-based), so raw Markdown content is directly injected, preserving the original Markdown formatting.

### Web Application (apps/web/)

#### Platform Integration:
- Added Huawei Cloud platform entry to `inject.js` for frontend display
- Added login URL mapping: `https://auth.huaweicloud.com/authui/login.html?service=https%3A%2F%2Fbbs.huaweicloud.com%2F&locale=zh-cn#/login`

## Technical Details

### Page-Based API Authentication:
- Huawei Cloud's user info API requires same-origin requests due to CORS restrictions
- Uses `chrome.scripting.executeScript` to execute fetch from an existing Huawei Cloud tab
- Extracts CSRF token from cookies for API authentication
- Response structure: `{ memName, memAlias, memPhoto, ... }`

### TinyMCE Editor Integration:
- Huawei Cloud uses TinyMCE editor wrapped in a custom `tinymceModal` object
- The editor supports both rich text and Markdown modes
- `tinymceModal.currentEditorType` indicates current mode ('markdown' or 'richtext')
- `tinymceModal.currentEditor.setContent()` is used to inject content

### Editor Mode Switching:
- If user is in rich text mode, auto-switch to Markdown mode
- Click "Markdown格式编辑" tab to initiate switch
- Handle confirmation dialog by clicking "确定" button
- Wait for editor to reinitialize after mode switch

### Auto-Save Draft:
- After content injection, auto-click "保存草稿" link
- Ensures content is preserved even if user navigates away

### Modular Architecture:
- Following the pattern established for other platforms, all Huawei Cloud logic is self-contained in `huaweicloud.js`
- Separates concerns: platform config and login detection
- Content sync handled in `background.js` alongside other platforms

## Testing

### Installation
1. Install/Reload the COSE extension.

### Logged-Out Test
1. Ensure you are logged out of Huawei Cloud (`https://bbs.huaweicloud.com/`)
2. Open the Markdown editor publish dialog
3. Verify Huawei Cloud shows "登录" (Login) status
4. Click the login link and confirm it navigates to the Huawei Cloud login page

### Logged-In Test
1. Log in to Huawei Cloud in the browser
2. Open any Huawei Cloud page (e.g., `https://bbs.huaweicloud.com/`)
3. Reopen the publish dialog
4. Verify Huawei Cloud shows the correct username and avatar image
5. Confirm logged-in status is displayed

### Sync Test
1. Select Huawei Cloud and click "确定" (Confirm) to sync
2. Confirm the extension opens `https://bbs.huaweicloud.com/blogs/article`
3. Wait for editor initialization (should complete within 6-7 seconds including mode switch)
4. Confirm the editor is in Markdown mode
5. Confirm the Title is correctly populated in the title input field
6. Confirm the Content is correctly rendered in the Markdown editor:
   - Raw Markdown syntax preserved
   - Headings, code blocks, lists properly formatted
   - Original Markdown structure maintained
7. Confirm draft is auto-saved

## Files Changed

- `cose/src/platforms/huaweicloud.js`
- `cose/src/platforms/index.js`
- `cose/src/inject.js`
- `cose/src/background.js`
- `cose/manifest.json`
- `apps/web/src/components/editor/editor-header/PostInfo.vue`