### PR TITLE
feat: huaweidev platform sync

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -160,6 +160,7 @@ function getPlatformUrl(type: string): string {
     weibo: 'https://passport.weibo.com/sso/signin',
     aliyun: 'https://account.aliyun.com/login/login.htm',
     huaweicloud: 'https://auth.huaweicloud.com/authui/login.html?service=https%3A%2F%2Fbbs.huaweicloud.com%2F&locale=zh-cn#/login',
+    huaweidev: 'https://developer.huawei.com/consumer/cn/blog/create',
   }
   return urls[type] || '#'
 }


### PR DESCRIPTION
## Summary

Add support for Huawei Developer (华为开发者文章) platform in the COSE browser extension, enabling users to sync articles directly to Huawei Developer Blog. This update includes a new modular platform configuration, cookie + API-based login detection with real user profile retrieval, and ACE Editor (Markdown) based content filling.

## Changes

### Browser Extension (cose/)

**Platform Configuration:**
- Added Huawei Developer to the platform registry with official icon (https://developer.huawei.com/favicon.ico)
- Created new `src/platforms/huaweidev.js` to encapsulate all Huawei Developer-specific logic (platform config, login detection)
- Integrated Huawei Developer into `src/platforms/index.js` for centralized platform management
- Added Huawei Developer domain permissions (`https://developer.huawei.com/*`) to `manifest.json`

**Login Detection:**
- Implemented cookie + API-based authentication using `developer_userinfo`, `developer_userdata` cookies and POST `https://svc-drcn.developer.huawei.com/codeserver/Common/v1/delegate`
- Retrieves real user profile data including:
  - `username`: Actual display name from `userInfo.displayName` or `userInfo.loginID`
  - `avatar`: User avatar URL from `userInfo.headPictureURL`
- Returns `{ loggedIn: true, username, avatar }` when authenticated
- Gracefully handles unauthenticated state by returning `{ loggedIn: false }`

**Content Sync Workflow:**
- Markdown-Based Approach: Uses ACE Editor (Markdown editor) for content filling, preserving original Markdown formatting
- Implemented proper workflow in `syncToPlatform()`:
  1. Navigate to Huawei Developer editor: `https://developer.huawei.com/consumer/cn/blog/create`
  2. Wait for editor toolbar to load (async loading requires extended timeout)
  3. Detect current editor mode (Rich Text vs Markdown)
  4. Click "MD编辑器" button to switch to Markdown mode if needed
  5. Handle confirmation dialogs automatically (温馨提示, MD切换确认)
  6. Fill title using native setter approach for React compatibility
  7. Fill content directly into ACE Editor using `ace.edit().session.setValue()`

**Content Filler:**
- Created dedicated Huawei Developer sync handler in `background.js`
- Technical Challenges Solved:
  - Huawei Developer uses CKEditor with a custom "MD编辑器" toggle button to switch to ACE Editor (Markdown mode)
  - Editor toolbar is asynchronously loaded, requiring extended wait times (up to 15 seconds)
  - Multiple modal dialogs (Ant Design Modal) appear during editor switching, requiring automatic handling

**Title Filling Method:**
- Locate `input[placeholder*="标题"]`
- Use `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` to bypass React's controlled component
- Dispatch `input` and `change` events for React recognition

**Content Filling Method:**
- Access ACE Editor instance via `ace.edit(aceEditorElement)`
- Use `editor.session.setValue(markdown)` to set Markdown content directly
- Why Markdown Method: Huawei Developer's blog editor natively supports Markdown with ACE Editor, preserving original formatting without conversion

**Dialog Handling:**
- Implemented polling-based dialog checker (more reliable than MutationObserver)
- Automatically handles:
  - "温馨提示" (unsaved changes warning) - clicks "取消" (Cancel)
  - "Markdown切换确认" (editor switch confirmation) - clicks "确认" (Confirm)
- Supports both Ant Design Modal and HTML5 dialog elements

### Web Application (apps/web/)

**Platform Integration:**
- Added Huawei Developer platform entry to `inject.js` for frontend display

## Technical Details

**ACE Editor Integration:**
- Huawei Developer's Markdown editor uses ACE Editor (cloud9 IDE's code editor)
- ACE Editor provides direct API access via `ace.edit()` for content manipulation
- The editor supports syntax highlighting and Markdown preview

**CKEditor Toggle:**
- The page initially loads with CKEditor (rich text editor)
- A custom "MD编辑器" button (implemented as `a.cke_button__cktomd`) toggles to ACE Editor
- The toggle triggers confirmation dialogs that must be handled programmatically

**API Authentication:**
- Huawei Developer uses Huawei ID account cookies (`developer_userinfo`, `developer_userdata`) for auth
- The `/codeserver/Common/v1/delegate` endpoint requires:
  - `x-hd-csrf`: CSRF token from cookie
  - `x-hd-date`: ISO timestamp
  - `x-hd-serialno`: Random serial number
- Request body: `{ svc: 'GOpen.User.getInfo', reqType: 0, reqJson: '{"getNickName":"1"}' }`
- Response structure: `{ returnCode: '0', resJson: '{"displayName":"...", "headPictureURL":"..."}' }`

**Modular Architecture:**
- Following the pattern established for other platforms, all Huawei Developer logic is self-contained in `huaweidev.js`
- Separates concerns: platform config and login detection
- Content sync handled in `background.js` with platform-specific logic

## Testing

**Installation**
- Install/Reload the COSE extension.

**Logged-Out Test**
1. Ensure you are logged out of Huawei Developer (https://developer.huawei.com/)
2. Open the Markdown editor publish dialog
3. Verify Huawei Developer shows "登录" (Login) status
4. Click the login link and confirm it navigates to the Huawei Developer login page

**Logged-In Test**
1. Log in to Huawei Developer in the browser
2. Reopen the publish dialog
3. Verify Huawei Developer shows the correct username and avatar image
4. Confirm logged-in status is displayed

**Sync Test**
1. Select Huawei Developer and click "确定" (Confirm) to sync
2. Confirm the extension opens `https://developer.huawei.com/consumer/cn/blog/create`
3. Wait for editor initialization (should complete within 5-6 seconds due to async toolbar loading)
4. Confirm any dialogs are automatically handled
5. Confirm the Title is correctly populated in the title input field
6. Confirm the Content is correctly rendered in the ACE Editor with proper Markdown formatting:
   - Headings with correct syntax (`#`, `##`, etc.)
   - Code blocks with triple backticks preserved
   - Lists, links, and other Markdown elements properly formatted
   - Original Markdown structure maintained

## Files Changed

- `cose/src/platforms/huaweidev.js`
- `cose/src/platforms/index.js`
- `cose/src/inject.js`
- `cose/src/background.js`
- `cose/manifest.json`
- `apps/web/src/components/editor/editor-header/PostInfo.vue`