### PR TITLE
feat: support 微信外链转引用

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -58,6 +58,11 @@
         "command": "markdown.toggleMacCodeBlock",
         "title": "Toggle Mac Code Block",
         "category": "Markdown Preview"
+      },
+      {
+        "command": "markdown.toggleCiteStatus",
+        "title": "Toggle Cite Status",
+        "category": "Markdown Preview"
       }
     ],
     "menus": {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -34,6 +34,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`markdown.toggleMacCodeBlock`, () => {
       treeDataProvider.updateMacCodeBlock(!treeDataProvider.getCurrentMacCodeBlock())
     }),
+    vscode.commands.registerCommand(`markdown.toggleCiteStatus`, () => {
+      treeDataProvider.updateCiteStatus(!treeDataProvider.getCurrentCiteStatus())
+    }),
   )
 
   const disposable = vscode.commands.registerCommand(`markdown.preview`, () => {
@@ -74,6 +77,7 @@ export function activate(context: vscode.ExtensionContext) {
       const renderer = initRenderer({
         countStatus: treeDataProvider.getCurrentCountStatus(),
         isMacCodeBlock: treeDataProvider.getCurrentMacCodeBlock(),
+        citeStatus: treeDataProvider.getCurrentCiteStatus(),
         legend: `none`,
       })
 

--- a/apps/vscode/src/treeDataProvider.ts
+++ b/apps/vscode/src/treeDataProvider.ts
@@ -11,6 +11,7 @@ export class MarkdownTreeDataProvider implements vscode.TreeDataProvider<vscode.
   private currentFontFamily: string
   private countStatus: boolean
   private isMacCodeBlock: boolean
+  private citeStatus: boolean
   private context: vscode.ExtensionContext
 
   constructor(context: vscode.ExtensionContext) {
@@ -21,6 +22,7 @@ export class MarkdownTreeDataProvider implements vscode.TreeDataProvider<vscode.
     this.currentFontFamily = this.context.workspaceState.get(`markdownPreview.fontFamily`, fontFamilyOptions[0].value)
     this.countStatus = this.context.workspaceState.get(`markdownPreview.countStatus`, false)
     this.isMacCodeBlock = this.context.workspaceState.get(`markdownPreview.isMacCodeBlock`, false)
+    this.citeStatus = this.context.workspaceState.get(`markdownPreview.citeStatus`, false)
   }
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
@@ -39,12 +41,22 @@ export class MarkdownTreeDataProvider implements vscode.TreeDataProvider<vscode.
     this._onDidChangeTreeData.fire(undefined)
   }
 
+  updateCiteStatus(status: boolean): void {
+    this.citeStatus = status
+    this.context.workspaceState.update(`markdownPreview.citeStatus`, status)
+    this._onDidChangeTreeData.fire(undefined)
+  }
+
   getCurrentMacCodeBlock(): boolean {
     return this.isMacCodeBlock
   }
 
   getCurrentCountStatus(): boolean {
     return this.countStatus
+  }
+
+  getCurrentCiteStatus(): boolean {
+    return this.citeStatus
   }
 
   getChildren(element?: vscode.TreeItem): Thenable<vscode.TreeItem[]> {
@@ -56,6 +68,7 @@ export class MarkdownTreeDataProvider implements vscode.TreeDataProvider<vscode.
         new vscode.TreeItem(`主题色`, vscode.TreeItemCollapsibleState.Expanded),
         new vscode.TreeItem(`计数状态`, vscode.TreeItemCollapsibleState.None),
         new vscode.TreeItem(`Mac代码块`, vscode.TreeItemCollapsibleState.None),
+        new vscode.TreeItem(`微信外链转引用`, vscode.TreeItemCollapsibleState.None),
       ].map((item) => {
         if (item.label === `计数状态`) {
           item.command = {
@@ -74,6 +87,16 @@ export class MarkdownTreeDataProvider implements vscode.TreeDataProvider<vscode.
             arguments: [],
           }
           if (this.isMacCodeBlock) {
+            item.iconPath = new vscode.ThemeIcon(`check`)
+          }
+        }
+        else if (item.label === `微信外链转引用`) {
+          item.command = {
+            command: `markdown.toggleCiteStatus`,
+            title: `Toggle Cite Status`,
+            arguments: [],
+          }
+          if (this.citeStatus) {
             item.iconPath = new vscode.ThemeIcon(`check`)
           }
         }


### PR DESCRIPTION
尝试给 vscode 插件增加 “微信外链转引用” 的配置，本地运行了 `pnpm --prefix ./apps/vscode run package` 生成了 `doocs-md-0.0.1.vsix` 插件，但装到 vscode 中报 “There is no data provider registered that can provide view data.”

由于不懂前端，希望社区能帮忙一起看下如何增加这个能力，感谢。
