### PR TITLE
feat: modelscope platform sync

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -47,7 +47,7 @@ const platformCategories = [
   },
   {
     name: `云平台及开发者社区`,
-    platforms: [`tencentcloud`, `aliyun`, `huaweicloud`, `huaweidev`, `qianfan`, `alipayopen`],
+    platforms: [`tencentcloud`, `aliyun`, `huaweicloud`, `huaweidev`, `qianfan`, `alipayopen`, `modelscope`],
   },
 ]
 
@@ -190,6 +190,7 @@ function getPlatformUrl(type: string): string {
     twitter: 'https://x.com/i/flow/login',
     qianfan: 'https://qianfan.cloud.baidu.com/qianfandev/topic/create',
     alipayopen: 'https://open.alipay.com/portal/forum/post/add#article',
+    modelscope: 'https://modelscope.cn/learn/create',
   }
   return urls[type] || '#'
 }


### PR DESCRIPTION
## Summary
Add support for ModelScope (魔搭社区) platform in the COSE browser extension, enabling users to sync articles directly to ModelScope. This update includes a new modular platform configuration, API-based login detection with real user profile retrieval, and Markdown-based content filling with automatic rich text conversion.

## Changes

### Browser Extension (cose/)

**Platform Configuration:**
- Added ModelScope to the platform registry with official icon
- Created new [src/platforms/modelscope.js] to encapsulate all ModelScope-specific logic (platform config, login detection)
- Integrated ModelScope into [src/platforms/index.js] for centralized platform management
- Added ModelScope domain permissions (`https://*.modelscope.cn/*`) to [manifest.json]

**Login Detection:**
- Implemented API-based authentication using `GET https://modelscope.cn/api/v1/users/login/info`
- Retrieves real user profile data including:
  - **username**: User's nickname from `data.NickName` or fallback to `data.Name`
  - **avatar**: User avatar URL from `data.Avatar`
- Returns `{ loggedIn: true, username, avatar }` when authenticated (`response.Success && response.Data.Name`)
- Gracefully handles unauthenticated state by returning `{ loggedIn: false }`

**Content Sync Workflow:**
- **Markdown-Based Approach**: ModelScope's editor natively supports Markdown input, so content is injected as Markdown text
- Implemented proper workflow in `syncToPlatform()`:
  - Navigate to ModelScope editor: `https://modelscope.cn/learn/create`
  - Fill Markdown content into textarea via paste event or native setter fallback
  - Automatically click "转为富文本" (Convert to Rich Text) button to render styled content

**Content Filler:**
- Created dedicated ModelScope sync handler in [background.js]
- **Technical Challenge Solved**: ModelScope uses Cangjie (仓颉) rich text editor with a two-step workflow: Markdown input → rich text conversion
- **Content Filling Method**:
  - Locate `textarea` element in the editor
  - Dispatch `ClipboardEvent` with `text/plain` data containing Markdown content
  - Fallback: Use `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set` to bypass controlled component
  - Dispatch `InputEvent` and `change` events for proper state sync
- **Rich Text Conversion**:
  - Wait for "转为富文本" button to appear (using `data-testid="menu-item-markdownToDoc"` selector)
  - Fallback: Search by text content matching "转为富文本"
  - Retry mechanism with 5 attempts at 500ms intervals
- **Why Markdown Method**: ModelScope's Cangjie editor handles Markdown-to-rich-text conversion natively, preserving formatting through the platform's built-in converter.

### Web Application (apps/web/)

**Platform Integration:**
- Added ModelScope platform entry to [inject.js] for frontend display
- Added ModelScope to the "云平台及开发者社区" (Cloud Platforms & Developer Communities) category in [PostInfo.vue]

## Technical Details

**Cangjie Editor Integration:**
- ModelScope uses Cangjie (仓颉), Alibaba's rich text editor framework
- The editor has a textarea for Markdown input and a `[data-cangjie-editable="true"]` element for rich text editing
- Content flow: Markdown → textarea → "转为富文本" button → rendered rich text

**Textarea Value Setting:**
- React/Vue controlled components intercept normal value assignments
- Using `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set` directly calls the native setter
- Combined with `InputEvent` dispatch with `inputType: 'insertText'` for proper framework state sync

**API Authentication:**
- ModelScope uses standard session-based authentication
- The `/api/v1/users/login/info` endpoint returns user info when authenticated
- Response structure: `{ Success: true, Data: { Name, NickName, Avatar, ... } }`

**Modular Architecture:**
- Following the pattern established for other platforms, all ModelScope logic is self-contained in [modelscope.js]
- Separates concerns: platform config and login detection
- Content sync handled in [background.js] with platform-specific logic for Cangjie editor

## Testing

### Installation
Install/Reload the COSE extension.

### Logged-Out Test
1. Ensure you are logged out of ModelScope (https://modelscope.cn/)
2. Open the Markdown editor publish dialog
3. Verify ModelScope shows "登录" (Login) status
4. Click the login link and confirm it navigates to the ModelScope login page

### Logged-In Test
1. Log in to ModelScope in the browser
2. Reopen the publish dialog
3. Verify ModelScope shows the correct username and avatar image
4. Confirm logged-in status is displayed

### Sync Test
1. Select ModelScope and click "确定" (Confirm) to sync
2. Confirm the extension opens `https://modelscope.cn/learn/create`
3. Wait for editor initialization (should complete within 2-3 seconds)
4. Confirm the Markdown content is correctly populated in the textarea
5. Confirm the "转为富文本" button is automatically clicked
6. Confirm the Content is correctly rendered in the editor with proper formatting:
   - Headings rendered with correct styles
   - Code blocks properly formatted
   - Lists, links, and other elements properly displayed

## Files Changed
- [apps/web/src/components/editor/editor-header/PostInfo.vue]