### PR TITLE
feat: xiaohongshu platform sync

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -39,7 +39,7 @@ const allowPost = computed(() => extensionInstalled.value && form.value.accounts
 const platformCategories = [
   {
     name: `媒体平台`,
-    platforms: [`wechat`, `toutiao`, `zhihu`, `baijiahao`, `wangyihao`, `sohu`, `weibo`, `bilibili`, `sspai`, `twitter`, `douyin`],
+    platforms: [`wechat`, `toutiao`, `zhihu`, `baijiahao`, `wangyihao`, `sohu`, `weibo`, `bilibili`, `sspai`, `twitter`, `douyin`, `xiaohongshu`],
   },
   {
     name: `博客平台`,
@@ -193,6 +193,7 @@ function getPlatformUrl(type: string): string {
     modelscope: 'https://modelscope.cn/learn/create',
     volcengine: 'https://developer.volcengine.com/articles/draft',
     douyin: 'https://creator.douyin.com/creator-micro/content/post/article?default-tab=5&enter_from=publish_page&media_type=article&type=new',
+    xiaohongshu: 'https://creator.xiaohongshu.com/publish/publish?from=menu&target=article',
   }
   return urls[type] || '#'
 }


### PR DESCRIPTION
## Summary
Add support for Xiaohongshu (小红书) platform in the COSE browser extension, enabling users to sync articles directly to Xiaohongshu. This update includes a new modular platform configuration, API-based login detection with real user profile retrieval, and clipboard-based content filling that preserves original styling.

## Changes
### Browser Extension (cose/)
#### Platform Configuration:
* Added Xiaohongshu to the platform registry with official icon (https://www.xiaohongshu.com/favicon.ico)
* Created new `src/platforms/xiaohongshu.js` to encapsulate all Xiaohongshu-specific logic (platform config, login detection, content filler)
* Integrated Xiaohongshu into `src/platforms/index.js` for centralized platform management
* Added Xiaohongshu domain permissions (https://*.xiaohongshu.com/*) to `manifest.json`
* Added "storage" permission to enable user session caching

#### Login Detection:
* Implemented API-based authentication using `GET https://creator.xiaohongshu.com/api/galaxy/user/info`
* Retrieves real user profile data including:
  * username: Actual username from `data.userName` or `data.redId`
  * avatar: User avatar URL from `data.userAvatar`
  * userId: Unique user identifier from `data.userId`
* Returns `{ loggedIn: true, username, avatar }` when authenticated
* Gracefully handles unauthenticated state by returning `{ loggedIn: false }`
* Implements session caching with 7-day expiration to reduce redundant API calls
* Uses `chrome.scripting.executeScript` to bypass cross-domain cookie restrictions

#### Content Sync Workflow:
* Clipboard-Based Approach: Uses the same sync method as WeChat Official Account to preserve original styling with CSS
* Implemented special workflow in `syncToPlatform()`:
  * Navigate to Xiaohongshu publish page: `https://creator.xiaohongshu.com/publish/publish?from=menu&target=article`
  * Auto-click "新的创作" (New Creation) button to activate editor
  * Wait for ne-engine rich text editor to load
  * Fill title using native setter approach
  * Paste content via `ClipboardEvent` into ne-engine editor

#### Content Filler:
* Created dedicated Xiaohongshu sync handler in `background.js`
* Technical Challenge Solved: Xiaohongshu requires clicking "新的创作" button before editor becomes available
* Title Filling Method:
  * Locate title input using placeholder or class selectors
  * Use `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` to bypass React's controlled component
  * Dispatch `input`, `change`, and `blur` events for React recognition
* Content Filling Method:
  * Access `.ne-engine[contenteditable="true"]` element
  * Create `ClipboardEvent` with `DataTransfer` containing HTML content
  * Dispatch paste event to trigger ne-engine's native paste handler
* Why Clipboard Method: Direct innerHTML manipulation loses styling. Clipboard paste preserves the original CSS formatting from the Markdown editor.

### Web Application (apps/web/)
#### Platform Integration:
* Added Xiaohongshu platform entry to `inject.js` for frontend display
* Added Xiaohongshu login URL configuration in `PostInfo.vue`

## Technical Details
### ne-engine Integration:
* Xiaohongshu's editor uses ne-engine rich text editor framework
* The editor is only accessible after clicking "新的创作" button
* Uses contenteditable div with class `.ne-engine` for content editing

### React Controlled Component Bypass:
* React's controlled components intercept normal value assignments
* Using `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` directly calls the native setter
* Combined with `InputEvent` dispatch with proper event bubbling for React state sync

### Clipboard HTML Preservation:
* The Markdown editor's copy button generates styled HTML with inline CSS
* Using `ClipboardEvent` with `DataTransfer.setData('text/html', content)` preserves all styling
* This matches the WeChat Official Account sync approach for consistency

### API Authentication:
* Xiaohongshu uses creator platform API for authentication
* The `/api/galaxy/user/info` endpoint returns user info with success/error codes
* Response structure: `{ success: true, code: 0, data: { userName, userAvatar, userId } }`

### Cross-Domain Cookie Handling:
* Content scripts cannot access cross-domain cookies due to browser security
* Solution: Use `chrome.scripting.executeScript` to run API calls in page context
* Cache results in `chrome.storage.local` with expiration timestamps

### Modular Architecture:
* Following the pattern established for other platforms, all Xiaohongshu logic is self-contained in `xiaohongshu.js`
* Separates concerns: platform config and login detection
* Content sync handled in `background.js` with special workflow for button clicking

## Testing
### Installation:
Install/Reload the COSE extension.

### Logged-Out Test:
1. Ensure you are logged out of Xiaohongshu (https://creator.xiaohongshu.com/)
2. Open the Markdown editor publish dialog
3. Verify Xiaohongshu shows "登录" (Login) status
4. Click the login link and confirm it navigates to the Xiaohongshu login page

### Logged-In Test:
1. Log in to Xiaohongshu in the browser
2. Reopen the publish dialog
3. Verify Xiaohongshu shows the correct username and avatar image
4. Confirm logged-in status is displayed

### Sync Test:
1. Select Xiaohongshu and click "确定" (Confirm) to sync
2. Confirm the extension opens `https://creator.xiaohongshu.com/publish/publish?from=menu&target=article`
3. Wait for "新的创作" button to be clicked automatically (should complete within 3 seconds)
4. Wait for editor initialization (should complete within 5 seconds)
5. Confirm the Title is correctly populated in the title input field
6. Confirm the Content is correctly rendered in the editor with proper formatting:
   * Headings rendered with correct styles
   * Code blocks with syntax highlighting preserved
   * Lists, links, and other elements properly formatted
   * Original CSS styling maintained

## Files Changed
* cose/src/platforms/xiaohongshu.js
* cose/src/platforms/index.js
* cose/src/inject.js
* cose/src/content.js
* cose/src/background.js
* cose/manifest.json
* apps/web/src/components/editor/editor-header/PostInfo.vue
