### PR TITLE
fix: update platform URLs to editor pages

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -224,7 +224,8 @@ async function getAccounts(): Promise<void> {
 }
 
 function post() {
-  form.value.accounts = form.value.accounts.filter(a => a.checked)
+  // 从 allAccounts 获取用户选择的平台（checkbox 绑定在 allAccounts 上）
+  form.value.accounts = allAccounts.value.filter(a => a.checked && a.loggedIn)
   postTaskDialogVisible.value = true
   dialogVisible.value = false
 }
@@ -243,23 +244,23 @@ function getPlatformUrl(type: string): string {
     zhihu: 'https://www.zhihu.com/signin',
     toutiao: 'https://mp.toutiao.com',
     segmentfault: 'https://segmentfault.com/user/login',
-    cnblogs: 'https://account.cnblogs.com/signin',
-    oschina: 'https://www.oschina.net/home/login',
-    cto51: 'https://home.51cto.com/index',
-    infoq: 'https://account.geekbang.org/infoq/login/sms',
+    cnblogs: 'https://i.cnblogs.com/articles/edit',
+    oschina: 'https://my.oschina.net/blog/write',
+    cto51: 'https://blog.51cto.com/blogger/publish?&newBloger=2',
+    infoq: 'https://xie.infoq.cn/draft/',
     jianshu: 'https://www.jianshu.com/sign_in',
     baijiahao: 'https://baijiahao.baidu.com',
-    wangyihao: 'https://mp.163.com/login.html',
+    wangyihao: 'https://mp.163.com/subscribe_v4/index.html#/article-publish',
     tencentcloud: 'https://cloud.tencent.com/developer',
     medium: 'https://medium.com/m/signin',
-    sspai: 'https://sspai.com/login',
+    sspai: 'https://sspai.com/write',
     sohu: 'https://mp.sohu.com/mpfe/v4/login',
     bilibili: 'https://passport.bilibili.com/login',
     weibo: 'https://passport.weibo.com/sso/signin',
     aliyun: 'https://account.aliyun.com/login/login.htm',
-    huaweicloud: 'https://auth.huaweicloud.com/authui/login.html?service=https%3A%2F%2Fbbs.huaweicloud.com%2F&locale=zh-cn#/login',
+    huaweicloud: 'https://bbs.huaweicloud.com/blogs/article',
     huaweidev: 'https://developer.huawei.com/consumer/cn/blog/create',
-    twitter: 'https://x.com/i/flow/login',
+    twitter: 'https://x.com/compose/articles/edit/',
     qianfan: 'https://qianfan.cloud.baidu.com/qianfandev/topic/create',
     alipayopen: 'https://open.alipay.com/portal/forum/post/add#article',
     modelscope: 'https://modelscope.cn/learn/create',
@@ -414,7 +415,7 @@ onBeforeMount(() => {
                         :src="account.avatar"
                         alt=""
                         class="ml-1 h-4 w-4 rounded-full object-cover"
-                        referrerpolicy="no-referrer"
+                        crossorigin="anonymous"
                         @error="(e: Event) => (e.target as HTMLImageElement).style.display = 'none'"
                       >
                       <span class="text-sm text-muted-foreground">@{{ account.displayName }}</span>


### PR DESCRIPTION
## Changes
- Update platform URLs from login pages to their respective editor/publish pages (cnblogs, oschina, 51cto, infoq, wangyihao, sspai, huaweicloud, twitter)
- Fix post() to read checked accounts from allAccounts instead of form.accounts, ensuring only logged-in and selected platforms are submitted
- Switch avatar image attribute from referrerpolicy="no-referrer" to crossorigin="anonymous" for better cross-origin image loading
