### PR TITLE
fix: update dialog content class to enforce overflow styling

### DIFF
--- a/apps/web/src/components/editor/EditorStateDialog.vue
+++ b/apps/web/src/components/editor/EditorStateDialog.vue
@@ -484,7 +484,7 @@ function applyImportedConfig() {
 
   <!-- 最大化弹窗 -->
   <Dialog :open="isMaximized" @update:open="(val) => isMaximized = val">
-    <DialogContent class="max-h-[90vh] max-w-[90vw] overflow-auto">
+    <DialogContent class="max-h-[90vh] max-w-[90vw]! overflow-auto">
       <DialogHeader>
         <DialogTitle>JSON 全屏预览</DialogTitle>
         <DialogDescription>


### PR DESCRIPTION
调整前后：

<img width="2666" height="2038" alt="image" src="https://github.com/user-attachments/assets/444e11f6-fb92-4cdf-8fc6-229e4d5b8b71" />

<img width="2478" height="2038" alt="image" src="https://github.com/user-attachments/assets/b024f37a-0812-4abf-9279-3b1a6f782397" />
