### PR TITLE
fix: conditionally render dropdown separator based on post count

### DIFF
--- a/apps/web/src/components/editor/post-slider/PostItem.vue
+++ b/apps/web/src/components/editor/post-slider/PostItem.vue
@@ -214,7 +214,7 @@ function applyTemplate(postId: string) {
           <DropdownMenuItem @click.stop="applyTemplate(post.id)">
             <FileInput class="mr-2 size-4" /> 应用模板
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
+          <DropdownMenuSeparator v-if="posts.length > 1" />
           <DropdownMenuItem
             v-if="posts.length > 1"
             class="text-destructive focus:text-destructive"


### PR DESCRIPTION
不可删除时，不显示最后一条分割线：

<img width="1254" height="612" alt="image" src="https://github.com/user-attachments/assets/051fe5bb-b999-43c4-862b-9b742f494aaf" />
