### PR TITLE
refactor(css-editor): use id as unique identifier for css scheme tabs

### DIFF
--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -57,10 +57,6 @@ function editTabName() {
     return
   }
 
-  if (!cssEditorStore.validatorTabName(editInputVal.value)) {
-    toast.error(`不能与现有方案重名`)
-    return
-  }
   cssEditorStore.renameTab(editInputVal.value)
   isOpenEditDialog.value = false
   toast.success(`修改成功`)
@@ -75,11 +71,6 @@ const baseThemeForNew = ref<'blank' | 'default' | 'grace' | 'simple'>('blank')
 async function addTab() {
   if (!(addInputVal.value).trim()) {
     toast.error(`新建失败，方案名不可为空`)
-    return
-  }
-
-  if (!cssEditorStore.validatorTabName(addInputVal.value)) {
-    toast.error(`不能与现有方案重名`)
     return
   }
 
@@ -109,10 +100,10 @@ async function addTab() {
 }
 
 const isOpenDelTabConfirmDialog = ref(false)
-const delTargetName = ref(``)
+const delTargetId = ref(``)
 
-function removeHandler(targetName: string) {
-  delTargetName.value = targetName
+function removeHandler(targetId: string) {
+  delTargetId.value = targetId
   isOpenDelTabConfirmDialog.value = true
 }
 
@@ -123,20 +114,20 @@ function delTab() {
     return
   }
 
-  let activeName = cssContentConfig.value.active
-  if (activeName === delTargetName.value) {
+  let activeId = cssContentConfig.value.active
+  if (activeId === delTargetId.value) {
     tabs.forEach((tab, index) => {
-      if (tab.name === delTargetName.value) {
+      if (tab.id === delTargetId.value) {
         const nextTab = tabs[index + 1] || tabs[index - 1]
         if (nextTab) {
-          activeName = nextTab.name
+          activeId = nextTab.id
         }
       }
     })
   }
 
-  cssEditorStore.tabChanged(activeName)
-  cssContentConfig.value.tabs = tabs.filter(tab => tab.name !== delTargetName.value)
+  cssEditorStore.tabChanged(activeId)
+  cssContentConfig.value.tabs = tabs.filter(tab => tab.id !== delTargetId.value)
 
   toast.success(`删除成功`)
 }
@@ -173,9 +164,8 @@ function createFromViewTheme() {
   isOpenAddDialog.value = true
 }
 
-function tabChanged(tabName: string | number) {
-  console.log(`tabChanged`, tabName)
-  cssEditorStore.tabChanged(tabName as string)
+function tabChanged(tabId: string | number) {
+  cssEditorStore.tabChanged(tabId as string)
   // 切换后滚动到活跃的 tab
   scrollToActiveTab()
 }
@@ -205,7 +195,7 @@ onMounted(() => {
 
 // 导出合并后的主题
 function exportCurrentTheme() {
-  const currentTab = cssContentConfig.value.tabs.find(tab => tab.name === cssContentConfig.value.active)
+  const currentTab = cssContentConfig.value.tabs.find(tab => tab.id === cssContentConfig.value.active)
   if (!currentTab) {
     toast.error(`未找到当前方案`)
     return
@@ -256,21 +246,21 @@ function exportCurrentTheme() {
           :key="item.name"
           class="group/tab relative flex items-center gap-1.5 shrink-0 h-full px-3 text-xs transition-colors duration-150"
           :class="{
-            'css-tab-active text-foreground font-medium': cssContentConfig.active === item.name,
-            'text-muted-foreground hover:text-foreground': cssContentConfig.active !== item.name,
+            'css-tab-active text-foreground font-medium': cssContentConfig.active === item.id,
+            'text-muted-foreground hover:text-foreground': cssContentConfig.active !== item.id,
           }"
-          @click="tabChanged(item.name)"
+          @click="tabChanged(item.id)"
         >
           <span class="truncate max-w-[100px]">{{ item.title }}</span>
 
           <!-- 活跃 tab 下划线指示器 -->
           <span
-            v-if="cssContentConfig.active === item.name"
+            v-if="cssContentConfig.active === item.id"
             class="absolute bottom-0 left-2 right-2 h-[2px] rounded-full bg-primary"
           />
 
           <!-- 活跃 tab 操作: 更多菜单 -->
-          <DropdownMenu v-if="cssContentConfig.active === item.name">
+          <DropdownMenu v-if="cssContentConfig.active === item.id">
             <DropdownMenuTrigger as-child>
               <span
                 class="inline-flex items-center justify-center size-4 rounded text-muted-foreground/60 hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 transition-colors duration-100 cursor-pointer"
@@ -287,7 +277,7 @@ function exportCurrentTheme() {
               <DropdownMenuItem
                 v-if="cssContentConfig.tabs.length > 1"
                 class="text-destructive focus:text-destructive"
-                @click.stop="removeHandler(item.name)"
+                @click.stop="removeHandler(item.id)"
               >
                 <X class="mr-2 size-4" /> 删除
               </DropdownMenuItem>

--- a/apps/web/src/stores/cssEditor.ts
+++ b/apps/web/src/stores/cssEditor.ts
@@ -2,6 +2,7 @@ import type { EditorView } from '@codemirror/view'
 import { Compartment, EditorState } from '@codemirror/state'
 import { EditorView as CMEditorView } from '@codemirror/view'
 import { cssSetup, DEFAULT_CUSTOM_THEME, theme as editorTheme } from '@md/shared'
+import { v4 as uuid } from 'uuid'
 import { addPrefix } from '@/utils'
 import { store } from '@/utils/storage'
 
@@ -13,9 +14,12 @@ const DEFAULT_CSS_CONTENT = DEFAULT_CUSTOM_THEME
 export interface CssContentConfig {
   active: string
   tabs: {
+    id: string
     title: string
     name: string
     content: string
+    createDatetime: Date
+    updateDatetime: Date
   }[]
 }
 
@@ -30,29 +34,50 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
   const cssEditor = ref<EditorView | null>(null)
   const cssEditorThemeCompartment = ref<Compartment | null>(null)
 
-  /**
-   * 自定义 CSS 内容
-   * @deprecated 在后续版本中将会移除
-   */
-  const cssContent = store.reactive(`__css_content`, DEFAULT_CSS_CONTENT)
-
   // CSS 内容配置
   const cssContentConfig = store.reactive<CssContentConfig>(addPrefix(`css_content_config`), {
-    active: `方案1`,
-    tabs: [
-      {
+    active: ``,
+    tabs: [],
+  })
+
+  // 兼容旧数据：补齐缺失的 id / createDatetime / updateDatetime，并将 active 迁移为 id
+  onBeforeMount(() => {
+    const now = new Date()
+
+    // 如果没有任何 tab，初始化默认方案
+    if (cssContentConfig.value.tabs.length === 0) {
+      const defaultId = uuid()
+      cssContentConfig.value.tabs = [{
+        id: defaultId,
         title: `方案1`,
         name: `方案1`,
-        content: cssContent.value || DEFAULT_CSS_CONTENT,
-      },
-    ],
+        content: DEFAULT_CSS_CONTENT,
+        createDatetime: now,
+        updateDatetime: now,
+      }]
+      cssContentConfig.value.active = defaultId
+      return
+    }
+
+    cssContentConfig.value.tabs = cssContentConfig.value.tabs.map((tab, index) => ({
+      ...tab,
+      id: tab.id ?? uuid(),
+      createDatetime: tab.createDatetime ?? new Date(now.getTime() + index),
+      updateDatetime: tab.updateDatetime ?? new Date(now.getTime() + index),
+    }))
+
+    // 将旧的 active（name）迁移为 id
+    const activeById = cssContentConfig.value.tabs.find(t => t.id === cssContentConfig.value.active)
+    if (!activeById) {
+      // 旧数据中 active 存的是 name，找到对应 tab 再存 id
+      const activeByName = cssContentConfig.value.tabs.find(t => t.name === cssContentConfig.value.active)
+      cssContentConfig.value.active = activeByName?.id ?? cssContentConfig.value.tabs[0].id
+    }
   })
 
   // 获取当前激活的 Tab
   const getCurrentTab = () => {
-    return cssContentConfig.value.tabs.find((tab) => {
-      return tab.name === cssContentConfig.value.active
-    })!
+    return cssContentConfig.value.tabs.find(tab => tab.id === cssContentConfig.value.active)!
   }
 
   // 获取当前 Tab 的内容
@@ -78,12 +103,9 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
   }
 
   // 切换 Tab
-  const tabChanged = (name: string) => {
-    console.log(`tabChanged`, name)
-    cssContentConfig.value.active = name
-    const content = cssContentConfig.value.tabs.find((tab) => {
-      return tab.name === name
-    })!.content
+  const tabChanged = (id: string) => {
+    cssContentConfig.value.active = id
+    const content = cssContentConfig.value.tabs.find(tab => tab.id === id)!.content
     setCssEditorValue(content)
 
     // 触发回调以刷新渲染
@@ -97,19 +119,23 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     const tab = getCurrentTab()
     tab.title = name
     tab.name = name
-    cssContentConfig.value.active = name
+    // active 存的是 id，重命名不需要更新 active
   }
 
   // 添加 CSS 方案
   const addCssContentTab = (name: string, initialContent?: string) => {
     const content = initialContent || DEFAULT_CSS_CONTENT
+    const now = new Date()
     cssContentConfig.value.tabs.push({
+      id: uuid(),
       name,
       title: name,
       content,
+      createDatetime: now,
+      updateDatetime: now,
     })
-    cssContentConfig.value.active = name
-    console.log(`addCssContentTab`, name)
+    const newTab = cssContentConfig.value.tabs[cssContentConfig.value.tabs.length - 1]
+    cssContentConfig.value.active = newTab.id
     setCssEditorValue(content)
 
     // 触发回调以刷新渲染（使用新方案的 CSS）
@@ -118,20 +144,19 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     }
   }
 
-  // 验证 Tab 名称
-  const validatorTabName = (val: string) => {
-    return cssContentConfig.value.tabs.every(({ name }) => name !== val)
-  }
-
   // 重置 CSS 配置
   const resetCssConfig = () => {
+    const defaultId = uuid()
     cssContentConfig.value = {
-      active: `方案 1`,
+      active: defaultId,
       tabs: [
         {
+          id: defaultId,
           title: `方案 1`,
           name: `方案 1`,
           content: DEFAULT_CSS_CONTENT,
+          createDatetime: new Date(),
+          updateDatetime: new Date(),
         },
       ],
     }
@@ -168,7 +193,9 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
         CMEditorView.updateListener.of((update) => {
           if (update.docChanged) {
             const content = update.state.doc.toString()
-            getCurrentTab().content = content
+            const tab = getCurrentTab()
+            tab.content = content
+            tab.updateDatetime = new Date()
             onUpdate(content)
           }
         }),
@@ -188,11 +215,6 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
         effects: cssEditorThemeCompartment.value.reconfigure(editorTheme(isDark.value)),
       })
     }
-  })
-
-  // 清空过往历史记录
-  onMounted(() => {
-    cssContent.value = ``
   })
 
   // 滚动到指定标题级别的 CSS 区域并选中
@@ -252,7 +274,6 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     tabChanged,
     renameTab,
     addCssContentTab,
-    validatorTabName,
     resetCssConfig,
     initCssEditor,
     scrollToHeading,

--- a/apps/web/src/views/CodemirrorEditor.vue
+++ b/apps/web/src/views/CodemirrorEditor.vue
@@ -151,6 +151,10 @@ watch(isOpenRightSlider, () => {
   nextTick(redistributePanelSizes)
 })
 
+onMounted(() => {
+  nextTick(redistributePanelSizes)
+})
+
 // --- 进度条 ---
 const progressValue = computed(() => editorPanelCompRef.value?.progressValue ?? 0)
 


### PR DESCRIPTION

- Change `active` field to store tab `id` instead of `name`
- Update `getCurrentTab`, `tabChanged` to look up tabs by `id`
- Fix `renameTab` to not update `active` (id is stable across renames)
- Fix `addCssContentTab` and `resetCssConfig` to set `active` to new tab's `id`
- Add migration in `onBeforeMount` to convert legacy `active` (name) to `id`
- Remove duplicate tab name validation from store and UI