### PR TITLE
feat: add close buttons to all side panels and mobile overlay for folder panel

### DIFF
--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -312,9 +312,8 @@ function exportCurrentTheme() {
           <Download class="size-3.5" />
         </button>
 
-        <!-- 移动端关闭 -->
+        <!-- 关闭 -->
         <button
-          v-if="isMobile"
           class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
           @click="uiStore.isShowCssEditor = false"
         >

--- a/apps/web/src/components/editor/FolderSourcePanel.vue
+++ b/apps/web/src/components/editor/FolderSourcePanel.vue
@@ -11,11 +11,28 @@ import {
 import { useFolderFileSync } from '@/composables/useFolderFileSync'
 import { useFolderSourceStore } from '@/stores/folderSource'
 import { usePostStore } from '@/stores/post'
+import { useUIStore } from '@/stores/ui'
 import FolderTree from './FolderTree.vue'
 
 const folderSourceStore = useFolderSourceStore()
 const postStore = usePostStore()
+const uiStore = useUIStore()
 const { setCurrentFilePath } = useFolderFileSync()
+
+const { isMobile, isOpenFolderPanel } = storeToRefs(uiStore)
+
+// 控制是否启用动画
+const enableAnimation = ref(false)
+
+watch(isOpenFolderPanel, () => {
+  if (isMobile.value) {
+    enableAnimation.value = true
+  }
+})
+
+watch(isMobile, () => {
+  enableAnimation.value = false
+})
 
 const {
   currentFolderHandle,
@@ -83,7 +100,23 @@ async function handleOpenFile(node: any) {
 </script>
 
 <template>
-  <div class="folder-source-panel h-full flex flex-col">
+  <!-- 移动端遮罩层 -->
+  <Transition name="fade">
+    <div
+      v-if="isMobile && isOpenFolderPanel"
+      class="fixed inset-0 bg-black/40 backdrop-blur-sm z-40"
+      @click="isOpenFolderPanel = false"
+    />
+  </Transition>
+
+  <div
+    class="folder-source-panel h-full flex flex-col"
+    :class="{
+      'fixed top-0 left-0 z-55 w-full bg-background border-r border-border shadow-xl': isMobile,
+      'animate-slider': isMobile && enableAnimation,
+    }"
+    :style="isMobile ? { transform: isOpenFolderPanel ? 'translateX(0)' : 'translateX(-100%)' } : undefined"
+  >
     <!-- 头部工具栏 -->
     <div class="panel-header sticky top-0 z-10 bg-background border-b p-2">
       <div class="flex items-center justify-between mb-2">
@@ -91,15 +124,27 @@ async function handleOpenFile(node: any) {
           <FolderTreeIcon class="h-4 w-4" />
           本地文件夹
         </h3>
-        <Button
-          v-if="currentFolderHandle"
-          variant="ghost"
-          size="sm"
-          class="h-7 w-7 p-0"
-          @click="handleCloseFolder"
-        >
-          <X class="h-3 w-3" />
-        </Button>
+        <div class="flex items-center gap-1">
+          <Button
+            v-if="currentFolderHandle"
+            variant="ghost"
+            size="sm"
+            class="h-7 w-7 p-0"
+            title="关闭文件夹"
+            @click="handleCloseFolder"
+          >
+            <FolderClosed class="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="h-7 w-7 p-0"
+            title="关闭面板"
+            @click="isOpenFolderPanel = false"
+          >
+            <X class="h-3 w-3" />
+          </Button>
+        </div>
       </div>
 
       <!-- 操作按钮 -->
@@ -212,5 +257,21 @@ async function handleOpenFile(node: any) {
 
 .file-tree-container {
   min-height: 100%;
+}
+
+/* 移动端侧边栏动画 */
+.animate-slider {
+  transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* 遮罩动画 */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 200ms ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -520,9 +520,8 @@ function handleDragEnd() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <!-- 移动端关闭 -->
+        <!-- 关闭 -->
         <button
-          v-if="isMobile"
           class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150 ml-0.5"
           @click="isOpenPostSlider = false"
         >

--- a/apps/web/src/views/CodemirrorEditor.vue
+++ b/apps/web/src/views/CodemirrorEditor.vue
@@ -186,13 +186,13 @@ onUnmounted(() => {
           </ResizablePanel>
           <ResizableHandle class="hidden md:block" />
           <ResizablePanel
-            :default-size="isOpenFolderPanel ? 15 : 0"
-            :max-size="isOpenFolderPanel ? 25 : 0"
-            :min-size="isOpenFolderPanel ? 10 : 0"
+            :default-size="!isMobile && isOpenFolderPanel ? 15 : 0"
+            :max-size="!isMobile && isOpenFolderPanel ? 25 : 0"
+            :min-size="!isMobile && isOpenFolderPanel ? 10 : 0"
           >
             <FolderSourcePanel />
           </ResizablePanel>
-          <ResizableHandle v-if="isOpenFolderPanel" class="hidden md:block" />
+          <ResizableHandle v-if="!isMobile && isOpenFolderPanel" class="hidden md:block" />
 
           <!-- 主内容区域 (嵌套灵动布局) -->
           <ResizablePanel :min-size="30">


### PR DESCRIPTION

- Always show close button in PostSlider and CssEditor (removed mobile-only restriction)
- Add panel close (X) button to FolderSourcePanel header
- Add mobile full-screen overlay with slide-in animation to FolderSourcePanel
- Collapse folder panel in ResizablePanelGroup on mobile (let component handle its own display)