### PR TITLE
fix: 修复自定义图床报错问题

### DIFF
--- a/apps/web/src/utils/file.ts
+++ b/apps/web/src/utils/file.ts
@@ -743,7 +743,7 @@ async function formCustomUpload(content: string, file: File) {
     }
     // Use Function constructor instead of eval
     // eslint-disable-next-line no-new-func
-    const fn = new Function(`return ${str}`)()
+    const fn = new Function(`return (${str})`)()
     fn(exportObj).catch((err: any) => {
       console.error(err)
       reject(err)


### PR DESCRIPTION
配置了自定义图床，上传图片报错 “Function(...)(...) is not a function”。
文件 apps\web\src\utils\file.ts
```
  const str = `
    async (CUSTOM_ARG) => {
      ${customConfig}
    }
  `
...
    const fn = new Function(`return ${str}`)()
```
str 被替换后会变成
```
const fn = new Function( return
  async (CUSTOM_ARG) => {
      ...
    }
)()
```
return 单独占一行，直接返回了，导致fn变成了undefined，后续执行报错。已修复。