### PR TITLE
fix(deps): upgrade uuid to ^14.0.0 and unify usage

### DIFF
--- a/apps/web/src/components/ai/chat-box/AIAssistantPanel.vue
+++ b/apps/web/src/components/ai/chat-box/AIAssistantPanel.vue
@@ -14,6 +14,7 @@ import {
   Settings,
   Trash2,
 } from 'lucide-vue-next'
+import { v4 as uuidv4 } from 'uuid'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -123,14 +124,14 @@ onMounted(async () => {
   messages.value = saved
     ? JSON.parse(saved).map((msg: ChatMessage) => ({
         ...msg,
-        id: msg.id || crypto.randomUUID(),
+        id: msg.id || uuidv4(),
       }))
     : getDefaultMessages()
   await scrollToBottom(true)
 })
 
 function getDefaultMessages(): ChatMessage[] {
-  return [{ role: `assistant`, content: `你好，我是 AI 助手，有什么可以帮你的？`, id: crypto.randomUUID() }]
+  return [{ role: `assistant`, content: `你好，我是 AI 助手，有什么可以帮你的？`, id: uuidv4() }]
 }
 
 function generateConversationTitle(): string {
@@ -151,7 +152,7 @@ async function autoSaveCurrentConversation() {
     return
 
   if (!currentConversationId.value) {
-    currentConversationId.value = crypto.randomUUID()
+    currentConversationId.value = uuidv4()
 
     const conversation = {
       id: currentConversationId.value,
@@ -189,7 +190,7 @@ async function loadConversation(id: string) {
   if (saved.length > 0) {
     messages.value = saved.map(msg => ({
       ...msg,
-      id: msg.id || crypto.randomUUID(),
+      id: msg.id || uuidv4(),
     }))
     currentConversationId.value = id
     await store.setJSON(memoryKey, messages.value)

--- a/apps/web/src/stores/cssEditor.ts
+++ b/apps/web/src/stores/cssEditor.ts
@@ -2,7 +2,7 @@ import type { EditorView } from '@codemirror/view'
 import { Compartment, EditorState } from '@codemirror/state'
 import { EditorView as CMEditorView } from '@codemirror/view'
 import { cssSetup, DEFAULT_CUSTOM_THEME, theme as editorTheme } from '@md/shared'
-import { v4 as uuid } from 'uuid'
+import { v4 as uuidv4 } from 'uuid'
 import { addPrefix, downloadFile, sanitizeTitle } from '@/utils'
 import { store } from '@/utils/storage'
 
@@ -48,7 +48,7 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
 
     // 如果没有任何 tab，初始化默认方案
     if (cssContentConfig.value.tabs.length === 0) {
-      const defaultId = uuid()
+      const defaultId = uuidv4()
       cssContentConfig.value.tabs = [{
         id: defaultId,
         title: `方案1`,
@@ -63,7 +63,7 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
 
     cssContentConfig.value.tabs = cssContentConfig.value.tabs.map((tab, index) => ({
       ...tab,
-      id: tab.id ?? uuid(),
+      id: tab.id ?? uuidv4(),
       createDatetime: tab.createDatetime ?? new Date(now.getTime() + index),
       updateDatetime: tab.updateDatetime ?? new Date(now.getTime() + index),
     }))
@@ -129,7 +129,7 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     const content = initialContent || DEFAULT_CSS_CONTENT
     const now = new Date()
     cssContentConfig.value.tabs.push({
-      id: uuid(),
+      id: uuidv4(),
       name,
       title: name,
       content,
@@ -148,7 +148,7 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
 
   // 重置 CSS 配置
   const resetCssConfig = () => {
-    const defaultId = uuid()
+    const defaultId = uuidv4()
     cssContentConfig.value = {
       active: defaultId,
       tabs: [

--- a/apps/web/src/stores/post.ts
+++ b/apps/web/src/stores/post.ts
@@ -1,5 +1,5 @@
 import type { Post } from '@/types/post'
-import { v4 as uuid } from 'uuid'
+import { v4 as uuidv4 } from 'uuid'
 import DEFAULT_CONTENT from '@/assets/example/markdown.md?raw'
 import { addPrefix } from '@/utils'
 import { store } from '@/utils/storage'
@@ -14,7 +14,7 @@ export const usePostStore = defineStore(`post`, () => {
   // 内容列表
   const posts = store.reactive<Post[]>(addPrefix(`posts`), [
     {
-      id: uuid(),
+      id: uuidv4(),
       title: `内容1`,
       content: DEFAULT_CONTENT,
       history: [
@@ -34,7 +34,7 @@ export const usePostStore = defineStore(`post`, () => {
       const now = Date.now()
       return {
         ...post,
-        id: post.id ?? uuid(),
+        id: post.id ?? uuidv4(),
         createDatetime: post.createDatetime ?? new Date(now + index),
         updateDatetime: post.updateDatetime ?? new Date(now + index),
       }
@@ -68,7 +68,7 @@ export const usePostStore = defineStore(`post`, () => {
   // 添加文章
   const addPost = (title: string, parentId: string | null = null) => {
     const newPost: Post = {
-      id: uuid(),
+      id: uuidv4(),
       title,
       content: `# ${title}`,
       history: [
@@ -106,7 +106,7 @@ export const usePostStore = defineStore(`post`, () => {
       }
 
       const allIdsToDelete = [id, ...getChildIds(id)]
-      allIdsToDelete.forEach(toDelId => {
+      allIdsToDelete.forEach((toDelId) => {
         const idx = findIndexById(toDelId)
         if (idx !== -1) {
           posts.value.splice(idx, 1)

--- a/apps/web/src/stores/quickCommands.ts
+++ b/apps/web/src/stores/quickCommands.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid'
 import { ref, watch } from 'vue'
 import { store } from '@/utils/storage'
 
@@ -63,7 +64,7 @@ export const useQuickCommands = defineStore(`quickCommands`, () => {
 
   // ---------- CRUD ----------
   function add(label: string, template: string) {
-    const id = crypto.randomUUID()
+    const id = uuidv4()
     commands.value.push(hydrate({ id, label, template }))
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ overrides:
   underscore@<1.13.8: 1.13.8
   undici@^6: ^8.1.0
   undici@^7: ^8.1.0
+  uuid: ^14.0.0
   workbox-build>source-map: 0.7.4
   yauzl: ^3.3.0
 
@@ -7084,8 +7085,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+  undici@8.2.0:
+    resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -7188,16 +7189,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
   uzip@0.20201231.0:
@@ -11426,7 +11419,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 8.1.0
+      undici: 8.2.0
       whatwg-mimetype: 4.0.0
 
   cheerio@1.2.0:
@@ -11440,7 +11433,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 8.1.0
+      undici: 8.2.0
       whatwg-mimetype: 4.0.0
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
@@ -13130,7 +13123,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.1.0
+      undici: 8.2.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -13630,7 +13623,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.4.0
       ts-dedent: 2.2.0
-      uuid: 11.1.1
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -13870,7 +13863,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 8.1.0
+      undici: 8.2.0
       workerd: 1.20260426.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -13986,7 +13979,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.7.4
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       which: 2.0.2
 
   node-releases@2.0.38: {}
@@ -15306,7 +15299,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@8.1.0: {}
+  undici@8.2.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -15447,11 +15440,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.1: {}
-
   uuid@14.0.0: {}
-
-  uuid@8.3.2: {}
 
   uzip@0.20201231.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ overrides:
   underscore@<1.13.8: 1.13.8
   undici@^6: ^8.1.0
   undici@^7: ^8.1.0
+  uuid: ^14.0.0
   workbox-build>source-map: 0.7.4
   yauzl: ^3.3.0
 


### PR DESCRIPTION
- Add pnpm.overrides to force all transitive deps to uuid ^14.0.0, fixing the missing buffer bounds check CVE (v3/v5/v6 silent partial writes, patched in 14.0.0)
- Standardize uuid import alias to `uuidv4` across all files (post.ts had `v4 as uuid`)
- Replace all `crypto.randomUUID()` calls with `uuidv4()` (quickCommands.ts, AIAssistantPanel.vue)