### PR TITLE
feat(mcp): 添加 primaryColor 支持及 list_colors 工具

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
     "./renderer": "./src/renderer/index.ts",
     "./extensions": "./src/extensions/index.ts",
     "./utils": "./src/utils/index.ts",
-    "./theme": "./src/theme/index.ts"
+    "./theme": "./src/theme/index.ts",
+    "./theme/cssVariables": "./src/theme/cssVariables.ts"
   },
   "dependencies": {
     "@antv/infographic": "^0.2.18",

--- a/packages/mcp-server/polyfill.cjs
+++ b/packages/mcp-server/polyfill.cjs
@@ -1,0 +1,54 @@
+// Preload polyfill for Node.js environment (CJS format for --require)
+// Must be loaded via --require BEFORE the main entry point
+'use strict'
+function noop() {}
+globalThis.MathJax = {
+  texReset() {},
+  tex2svg(latex) {
+    const svgStyle = {}
+    const styleProxy = new Proxy(svgStyle, {
+      set(_, prop, value) { svgStyle[prop] = value; return true },
+      get(_, prop) {
+        if (prop === 'setProperty')
+          return (p, v) => { svgStyle[p] = v }
+        if (prop === 'display')
+          return svgStyle[prop] || ''
+        return svgStyle[prop]
+      },
+    })
+    return {
+      firstChild: {
+        outerHTML: `<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>${latex.replace(/</g, '&lt;')}</mi></math>`,
+        style: styleProxy,
+        getAttribute: () => null,
+        removeAttribute: noop,
+      },
+    }
+  },
+}
+globalThis.window = {
+  MathJax: globalThis.MathJax,
+  addEventListener: noop,
+  removeEventListener: noop,
+  dispatchEvent: () => true,
+  getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  requestAnimationFrame: typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : cb => setTimeout(cb, 16),
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+}
+globalThis.document = {
+  getElementById: () => null,
+  documentElement: { getAttribute: () => null, style: {} },
+  createDocumentFragment: () => ({ appendChild: noop, childNodes: [] }),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  createElement: tag => ({
+    tagName: tag.toUpperCase(),
+    setAttribute: noop,
+    appendChild: noop,
+    innerHTML: '',
+    style: {},
+  }),
+  createTextNode: text => ({ textContent: text, data: text }),
+  body: { appendChild: noop },
+  head: { appendChild: noop },
+}

--- a/packages/mcp-server/polyfill.mjs
+++ b/packages/mcp-server/polyfill.mjs
@@ -1,0 +1,56 @@
+// Preload polyfill for Node.js environment
+// Must be loaded via --import BEFORE the main entry point
+import { writeSync } from 'node:fs'
+
+writeSync(2, '[polyfill] loaded, setting globals\n')
+
+function noop() {}
+globalThis.MathJax = {
+  texReset() {},
+  tex2svg(latex) {
+    const svgStyle = {}
+    const styleProxy = new Proxy(svgStyle, {
+      set(_, prop, value) { svgStyle[prop] = value; return true },
+      get(_, prop) {
+        if (prop === 'setProperty')
+          return (p, v) => { svgStyle[p] = v }
+        if (prop === 'display')
+          return svgStyle[prop] || ''
+        return svgStyle[prop]
+      },
+    })
+    return {
+      firstChild: {
+        outerHTML: `<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>${latex.replace(/</g, '&lt;')}</mi></math>`,
+        style: styleProxy,
+        getAttribute: () => null,
+        removeAttribute: noop,
+      },
+    }
+  },
+}
+globalThis.window = {
+  addEventListener: noop,
+  removeEventListener: noop,
+  dispatchEvent: () => true,
+  getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  requestAnimationFrame: typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : cb => setTimeout(cb, 16),
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+}
+globalThis.document = {
+  getElementById: () => null,
+  documentElement: { getAttribute: () => null, style: {} },
+  createDocumentFragment: () => ({ appendChild: noop, childNodes: [] }),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  createElement: tag => ({
+    tagName: tag.toUpperCase(),
+    setAttribute: noop,
+    appendChild: noop,
+    innerHTML: '',
+    style: {},
+  }),
+  createTextNode: text => ({ textContent: text, data: text }),
+  body: { appendChild: noop },
+  head: { appendChild: noop },
+}

--- a/packages/mcp-server/run.mjs
+++ b/packages/mcp-server/run.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+// Wrapper: sets up polyfills synchronously, then imports the TS entry via tsx.
+// This .mjs file is NOT processed by tsx's import hooks — it runs as plain ESM,
+// so all top-level code executes before the dynamic import() resolves.
+
+function noop() {}
+globalThis.MathJax = {
+  texReset() {},
+  tex2svg(latex) {
+    const svgStyle = {}
+    const styleProxy = new Proxy(svgStyle, {
+      set(_, prop, value) { svgStyle[prop] = value; return true },
+      get(_, prop) {
+        if (prop === 'setProperty')
+          return (p, v) => { svgStyle[p] = v }
+        if (prop === 'display')
+          return svgStyle[prop] || ''
+        return svgStyle[prop]
+      },
+    })
+    return {
+      firstChild: {
+        outerHTML: `<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>${latex.replace(/</g, '&lt;')}</mi></math>`,
+        style: styleProxy,
+        getAttribute: () => null,
+        removeAttribute: noop,
+      },
+    }
+  },
+}
+globalThis.window = {
+  MathJax: globalThis.MathJax,
+  addEventListener: noop,
+  removeEventListener: noop,
+  dispatchEvent: () => true,
+  getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  requestAnimationFrame: typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : cb => setTimeout(cb, 16),
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+}
+globalThis.document = {
+  getElementById: () => null,
+  documentElement: { getAttribute: () => null, style: {} },
+  createDocumentFragment: () => ({ appendChild: noop, childNodes: [] }),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  createElement: tag => ({
+    tagName: tag.toUpperCase(),
+    setAttribute: noop,
+    appendChild: noop,
+    innerHTML: '',
+    style: {},
+  }),
+  createTextNode: text => ({ textContent: text, data: text }),
+  body: { appendChild: noop },
+  head: { appendChild: noop },
+}
+
+// Now dynamically import the TS entry — tsx will compile it on the fly
+import('./src/index.ts')

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,4 +1,42 @@
 #!/usr/bin/env node
+
+import type { ThemeName } from '@md/shared/configs'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { initRenderer } from '@md/core/renderer'
+
+import { generateCSSVariables } from '@md/core/theme/cssVariables'
+import { postProcessHtml, renderMarkdown } from '@md/core/utils'
+import { serviceOptions } from '@md/shared/configs/ai-service-options'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+// colorOptions / themeOptions are defined inline because importing from
+// @md/shared/configs/style or @md/shared/configs/theme triggers
+// theme-css/index.ts which uses Vite's ?raw CSS imports (unsupported in Node.js).
+
+const colorOptions = [
+  { value: `#0F4C81`, label: `经典蓝`, desc: `稳重冷静` },
+  { value: `#009874`, label: `翡翠绿`, desc: `自然平衡` },
+  { value: `#FA5151`, label: `活力橘`, desc: `热情活力` },
+  { value: `#FECE00`, label: `柠檬黄`, desc: `明亮温暖` },
+  { value: `#92617E`, label: `薰衣紫`, desc: `优雅神秘` },
+  { value: `#55C9EA`, label: `天空蓝`, desc: `清爽自由` },
+  { value: `#B76E79`, label: `玫瑰金`, desc: `奢华现代` },
+  { value: `#556B2F`, label: `橄榄绿`, desc: `沉稳自然` },
+  { value: `#333333`, label: `石墨黑`, desc: `内敛极简` },
+  { value: `#A9A9A9`, label: `雾烟灰`, desc: `柔和低调` },
+  { value: `#FFB7C5`, label: `樱花粉`, desc: `浪漫甜美` },
+] as const
+
+const themeOptions = [
+  { value: `default`, label: `经典`, desc: `` },
+  { value: `grace`, label: `优雅`, desc: `@brzhang` },
+  { value: `simple`, label: `简洁`, desc: `@okooo5km` },
+] as const
+
 /**
  * @md MCP Server
  *
@@ -8,25 +46,30 @@
  * Tools provided:
  *   - render_markdown        Convert Markdown text to styled HTML
  *   - list_themes            List all available visual themes
+ *   - list_colors            List all available primary accent colors
  *   - list_ai_services       List all built-in AI service providers
  *   - explain_extensions     Describe supported Markdown extensions
  *   - get_renderer_options   Describe all renderer configuration options
  */
 
-import process from 'node:process'
-import { initRenderer } from '@md/core/renderer'
-import { postProcessHtml, renderMarkdown } from '@md/core/utils'
-import { serviceOptions } from '@md/shared/configs/ai-service-options'
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { z } from 'zod'
+// Load CSS files at runtime (Node.js doesn't support ?raw imports)
+const themeDir = path.resolve(import.meta.dirname, `../../shared/src/configs/theme-css`)
 
-// Theme metadata – kept in sync with @md/shared/configs/theme.ts
-const themeOptions = [
-  { value: `default`, label: `经典`, desc: `` },
-  { value: `grace`, label: `优雅`, desc: `@brzhang` },
-  { value: `simple`, label: `简洁`, desc: `@okooo5km` },
-] as const
+function loadCSSFile(filename: string): string {
+  try {
+    return fs.readFileSync(path.join(themeDir, filename), `utf-8`)
+  }
+  catch (err) {
+    throw new Error(`[md-mcp-server] Failed to load CSS file: ${filename}. Ensure the monorepo source structure is intact.`, { cause: err })
+  }
+}
+
+const baseCSSContent = loadCSSFile(`base.css`)
+const themeMap: Record<string, string> = {
+  default: loadCSSFile(`default.css`),
+  grace: loadCSSFile(`grace.css`),
+  simple: loadCSSFile(`simple.css`),
+}
 
 // ---------------------------------------------------------------------------
 // Server initialisation
@@ -56,6 +99,15 @@ server.registerTool(
         .optional()
         .default(`default`)
         .describe(`Visual theme to apply. One of: default (经典), grace (优雅), simple (简洁).`),
+      primaryColor: z
+        .string()
+        .regex(/^#[0-9A-F]{6}$/i, `Must be a valid 6-digit hex color`)
+        .optional()
+        .default(`#0F4C81`)
+        .describe(
+          `Primary accent color (hex). Use list_colors to see presets. Default: #0F4C81 (经典蓝). `
+          + `This color is applied via CSS variable --md-primary-color and affects headings, links, alerts, etc.`,
+        ),
       isMacCodeBlock: z
         .boolean()
         .optional()
@@ -76,6 +128,11 @@ server.registerTool(
         .optional()
         .default(false)
         .describe(`Whether to prepend a reading-time estimate to the document.`),
+      themeMode: z
+        .enum([`light`, `dark`])
+        .optional()
+        .default(`light`)
+        .describe(`Colour mode used by diagram extensions (e.g. Mermaid, infographic).`),
     },
   },
   (args) => {
@@ -84,12 +141,22 @@ server.registerTool(
       isShowLineNumber: args.isShowLineNumber,
       citeStatus: args.citeStatus,
       countStatus: args.countStatus,
+      themeMode: args.themeMode,
     })
 
     const { html: baseHtml, readingTime } = renderMarkdown(args.markdown, renderer)
-    const processedHtml = postProcessHtml(baseHtml, readingTime, renderer)
-    const containerHtml = renderer.createContainer(processedHtml)
+    let processedHtml = postProcessHtml(baseHtml, readingTime, renderer)
 
+    // Inject theme CSS + primaryColor CSS variable into the output
+    const themeCSS = themeMap[args.theme as ThemeName] || themeMap.default
+    const variablesCSS = generateCSSVariables({
+      primaryColor: args.primaryColor,
+      fontFamily: `-apple-system-font,BlinkMacSystemFont,Helvetica Neue,PingFang SC,Hiragino Sans GB,Microsoft YaHei UI,Microsoft YaHei,Arial,sans-serif`,
+      fontSize: `16px`,
+    })
+    processedHtml = `<style>\n${variablesCSS}\n\n${baseCSSContent}\n\n${themeCSS}\n</style>\n${processedHtml}`
+
+    const containerHtml = renderer.createContainer(processedHtml)
     const { yamlData } = renderer.parseFrontMatterAndContent(args.markdown)
 
     return {
@@ -133,6 +200,36 @@ server.registerTool(
         {
           type: `text`,
           text: JSON.stringify({ themes }),
+        },
+      ],
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: list_colors
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  `list_colors`,
+  {
+    description:
+      `List all available primary accent colors for the doocs/md Markdown editor. `
+      + `Each color is applied via CSS variable --md-primary-color and affects headings, links, alerts, etc. `
+      + `You can also pass any custom hex color string directly to render_markdown.`,
+  },
+  () => {
+    const colors = colorOptions.map(c => ({
+      value: c.value,
+      label: c.label,
+      description: c.desc,
+    }))
+
+    return {
+      content: [
+        {
+          type: `text`,
+          text: JSON.stringify({ colors }),
         },
       ],
     }
@@ -259,7 +356,19 @@ server.registerTool(
       + `Use this to understand what parameters are available when calling render_markdown.`,
   },
   () => {
-    const options = [
+    const rendererOptions = [
+      {
+        name: `theme`,
+        type: `'default' | 'grace' | 'simple'`,
+        default: `default`,
+        description: `Visual theme that controls overall typography, spacing, and color palette.`,
+      },
+      {
+        name: `primaryColor`,
+        type: `string (hex)`,
+        default: `#0F4C81`,
+        description: `Primary accent color applied via --md-primary-color. Affects headings, links, alert accents, etc. Use list_colors to see presets, or pass any hex value.`,
+      },
       {
         name: `isMacCodeBlock`,
         type: `boolean`,
@@ -296,7 +405,7 @@ server.registerTool(
       content: [
         {
           type: `text`,
-          text: JSON.stringify({ options }),
+          text: JSON.stringify({ options: rendererOptions }),
         },
       ],
     }

--- a/packages/shared/src/configs/ai-service-options.ts
+++ b/packages/shared/src/configs/ai-service-options.ts
@@ -227,7 +227,7 @@ export const serviceOptions: ServiceOption[] = [
   {
     value: `302ai`,
     label: `302.AI`,
-    endpoint: ` https://api.302.ai/v1`,
+    endpoint: `https://api.302.ai/v1`,
     models: [`chatgpt-4o-latest`, `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `o1-preview`, `o1-mini`, `claude-3-5-sonnet-latest`, `claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022`, `grok-beta`],
   },
   {


### PR DESCRIPTION

- Add primaryColor parameter to render_markdown and new list_colors tool
- Inline colorOptions/themeOptions to avoid CSS ?raw import issues
- Add run.mjs wrapper and polyfill scripts to fix MathJax/loading timing
- Improve type safety, error handling, and code review feedback