### PR TITLE
fix(mcp-server): fix broken startup and KaTeX polyfill issues

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -6,7 +6,7 @@
       "args": [
         "--import",
         "tsx/esm",
-        "${workspaceFolder}/packages/mcp-server/src/index.ts"
+        "${workspaceFolder}/packages/mcp-server/run.mjs"
       ],
       "cwd": "${workspaceFolder}/packages/mcp-server"
     }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -54,7 +54,7 @@ Add to `.vscode/mcp.json` in the project root (already included in this repo):
     "md": {
       "type": "stdio",
       "command": "node",
-      "args": ["--import", "tsx/esm", "${workspaceFolder}/packages/mcp-server/src/index.ts"],
+      "args": ["--import", "tsx/esm", "${workspaceFolder}/packages/mcp-server/run.mjs"],
       "cwd": "${workspaceFolder}/packages/mcp-server"
     }
   }
@@ -75,7 +75,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
       "args": [
         "--import",
         "tsx/esm",
-        "C:/path/to/md/packages/mcp-server/src/index.ts"
+        "C:/path/to/md/packages/mcp-server/run.mjs"
       ],
       "cwd": "C:/path/to/md/packages/mcp-server"
     }
@@ -94,7 +94,7 @@ Add to `.cursor/mcp.json` at the project root:
   "mcpServers": {
     "md": {
       "command": "node",
-      "args": ["--import", "tsx/esm", "packages/mcp-server/src/index.ts"],
+      "args": ["--import", "tsx/esm", "packages/mcp-server/run.mjs"],
       "cwd": "packages/mcp-server"
     }
   }
@@ -108,7 +108,7 @@ Use the same stdio pattern:
 ```json
 {
   "command": "node",
-  "args": ["--import", "tsx/esm", "/absolute/path/to/packages/mcp-server/src/index.ts"],
+  "args": ["--import", "tsx/esm", "/absolute/path/to/packages/mcp-server/run.mjs"],
   "cwd": "/absolute/path/to/packages/mcp-server"
 }
 ```
@@ -147,5 +147,5 @@ pnpm --filter @md/mcp-server dev
 To test manually, pipe a valid JSON-RPC `initialize` message to stdin or use [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
 ```bash
-npx @modelcontextprotocol/inspector node --import tsx/esm src/index.ts
+npx @modelcontextprotocol/inspector node --import tsx/esm run.mjs
 ```

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,8 +8,8 @@
     "md-mcp": "src/index.ts"
   },
   "scripts": {
-    "start": "tsx src/index.ts",
-    "dev": "tsx watch src/index.ts"
+    "start": "node --import tsx/esm run.mjs",
+    "dev": "node --import tsx/esm --watch run.mjs"
   },
   "dependencies": {
     "@md/core": "workspace:*",

--- a/packages/mcp-server/polyfill.mjs
+++ b/packages/mcp-server/polyfill.mjs
@@ -1,8 +1,5 @@
 // Preload polyfill for Node.js environment
 // Must be loaded via --import BEFORE the main entry point
-import { writeSync } from 'node:fs'
-
-writeSync(2, '[polyfill] loaded, setting globals\n')
 
 function noop() {}
 globalThis.MathJax = {
@@ -30,6 +27,7 @@ globalThis.MathJax = {
   },
 }
 globalThis.window = {
+  MathJax: globalThis.MathJax,
   addEventListener: noop,
   removeEventListener: noop,
   dispatchEvent: () => true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ overrides:
   underscore@<1.13.8: 1.13.8
   undici@^6: ^8.1.0
   undici@^7: ^8.1.0
+  jsdom>undici: ^7.25.0
   uuid: ^14.0.0
   workbox-build>source-map: 0.7.4
   yauzl: ^3.3.0
@@ -7085,6 +7086,10 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.2.0:
     resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
     engines: {node: '>=22.19.0'}
@@ -13123,7 +13128,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.2.0
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -15298,6 +15303,8 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@7.19.2: {}
+
+  undici@7.25.0: {}
 
   undici@8.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ overrides:
   glob@<8: ^13.0.6
   glob@^10: ^13.0.6
   inflight: npm:@hishprorg/voluptates-laborum@^2.0.0
+  jsdom>undici: ^7.25.0
   lodash-es: ^4.18.1
   markdown-it: ^14.1.1
   minimatch: ^10.2.5


### PR DESCRIPTION
- Switch mcp.json and package.json scripts to use run.mjs as entrypoint so DOM/MathJax polyfills are set up before tsx loads the TS source
- Fix polyfill.mjs: add missing window.MathJax reference and remove leftover writeSync debug output
- Pin jsdom>undici to ^7.25.0 via pnpm-workspace.yaml overrides to prevent pnpm from resolving it to undici@8 which dropped lib/handler/wrap-handler.js, causing the server to crash on startup