### PR TITLE
feat: add violet (紫罗兰) theme

### DIFF
--- a/packages/shared/src/configs/theme-css/index.ts
+++ b/packages/shared/src/configs/theme-css/index.ts
@@ -7,6 +7,7 @@ import baseCSS from './base.css?raw'
 import defaultCSS from './default.css?raw'
 import graceCSS from './grace.css?raw'
 import simpleCSS from './simple.css?raw'
+import violetCSS from './violet.css?raw'
 
 /**
  * 基础样式 CSS
@@ -20,6 +21,7 @@ export const themeMap = {
   default: defaultCSS,
   grace: graceCSS,
   simple: simpleCSS,
+  violet: violetCSS,
 } as const
 
 export type ThemeName = keyof typeof themeMap

--- a/packages/shared/src/configs/theme-css/violet.css
+++ b/packages/shared/src/configs/theme-css/violet.css
@@ -1,0 +1,244 @@
+/**
+ * MD 紫罗兰主题 (violet)
+ * 清爽现代风格，适合技术教程和工具分享类文章
+ */
+
+/* ==================== 标题样式 ==================== */
+h1 {
+  display: table;
+  padding: 0.3em 1.2em;
+  border-bottom: 3px solid var(--md-primary-color);
+  margin: 2em auto 1em;
+  color: hsl(var(--foreground));
+  font-size: calc(var(--md-font-size) * 1.3);
+  font-weight: bold;
+  text-align: center;
+  letter-spacing: 0.05em;
+}
+
+h2 {
+  display: inline-block;
+  padding: 0.25em 0.8em;
+  margin: 3em 8px 1.5em;
+  color: #fff;
+  background: var(--md-primary-color);
+  font-size: calc(var(--md-font-size) * 1.15);
+  font-weight: bold;
+  border-radius: 4px;
+  letter-spacing: 0.05em;
+}
+
+h3 {
+  padding-left: 10px;
+  border-left: 4px solid var(--md-primary-color);
+  margin: 2em 8px 0.75em 0;
+  color: hsl(var(--foreground));
+  font-size: calc(var(--md-font-size) * 1.08);
+  font-weight: bold;
+  line-height: 1.3;
+}
+
+h4 {
+  margin: 2em 8px 0.5em;
+  color: var(--md-primary-color);
+  font-size: calc(var(--md-font-size) * 1);
+  font-weight: bold;
+}
+
+h5 {
+  margin: 1.5em 8px 0.5em;
+  color: var(--md-primary-color);
+  font-size: calc(var(--md-font-size) * 1);
+  font-weight: bold;
+}
+
+h6 {
+  margin: 1.5em 8px 0.5em;
+  font-size: calc(var(--md-font-size) * 1);
+  color: var(--md-primary-color);
+}
+
+/* ==================== 段落 ==================== */
+p {
+  margin: 1.5em 8px;
+  letter-spacing: 0.05em;
+  color: hsl(var(--foreground));
+}
+
+/* ==================== 引用块 ==================== */
+blockquote {
+  font-style: normal;
+  padding: 0.8em 1em;
+  border-left: 4px solid var(--md-primary-color);
+  border-radius: 0 6px 6px 0;
+  color: hsl(var(--foreground));
+  background: rgba(107, 70, 225, 0.04);
+  margin-bottom: 1em;
+}
+
+blockquote > p {
+  display: block;
+  font-size: 0.95em;
+  letter-spacing: 0.05em;
+  color: hsl(var(--foreground));
+  margin: 0;
+}
+
+/* ==================== 代码块 ==================== */
+pre.code__pre,
+.hljs.code__pre {
+  font-size: 90%;
+  overflow-x: auto;
+  border-radius: 6px;
+  padding: 0 !important;
+  line-height: 1.5;
+  margin: 10px 8px;
+  border: 1px solid rgba(107, 70, 225, 0.12);
+}
+
+pre.code__pre > code,
+.hljs.code__pre > code {
+  display: -webkit-box;
+  padding: 0.5em 1em 1em;
+  overflow-x: auto;
+  text-indent: 0;
+  color: inherit;
+  background: none;
+  white-space: nowrap;
+  margin: 0;
+}
+
+/* ==================== 图片 ==================== */
+img {
+  display: block;
+  max-width: 100%;
+  margin: 0.1em auto 0.5em;
+  border-radius: 6px;
+}
+
+figcaption,
+.md-figcaption {
+  text-align: center;
+  color: #888;
+  font-size: 0.8em;
+}
+
+/* ==================== 列表 ==================== */
+ol {
+  padding-left: 1.2em;
+  margin-left: 0;
+  color: hsl(var(--foreground));
+}
+
+ul {
+  list-style: circle;
+  padding-left: 1.2em;
+  margin-left: 0;
+  color: hsl(var(--foreground));
+}
+
+li {
+  display: block;
+  margin: 0.3em 8px;
+  color: hsl(var(--foreground));
+}
+
+/* ==================== 分隔线 ==================== */
+hr {
+  border: none;
+  height: 1px;
+  margin: 2em 0;
+  background: linear-gradient(
+    to right,
+    transparent,
+    rgba(107, 70, 225, 0.2),
+    transparent
+  );
+}
+
+/* ==================== 行内代码 ==================== */
+code {
+  font-size: 90%;
+  color: var(--md-primary-color);
+  background: rgba(107, 70, 225, 0.06);
+  padding: 2px 5px;
+  border-radius: 3px;
+}
+
+/* ==================== 强调 ==================== */
+em {
+  font-style: italic;
+  font-size: inherit;
+}
+
+/* ==================== 链接 ==================== */
+a {
+  color: var(--md-primary-color);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(107, 70, 225, 0.3);
+}
+
+a:hover {
+  border-bottom-color: var(--md-primary-color);
+}
+
+/* ==================== 粗体 ==================== */
+strong {
+  color: var(--md-primary-color);
+  font-weight: bold;
+  font-size: inherit;
+}
+
+/* ==================== 表格 ==================== */
+table {
+  color: hsl(var(--foreground));
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 1em 8px;
+  border: 1px solid rgba(107, 70, 225, 0.15);
+}
+
+thead {
+  font-weight: bold;
+  color: #fff;
+}
+
+th {
+  padding: 0.4em 0.6em;
+  color: #fff;
+  word-break: keep-all;
+  background: var(--md-primary-color);
+  border: none;
+}
+
+td {
+  border: 1px solid rgba(107, 70, 225, 0.1);
+  padding: 0.4em 0.6em;
+  color: hsl(var(--foreground));
+  word-break: keep-all;
+}
+
+tr:nth-child(even) td {
+  background: rgba(107, 70, 225, 0.03);
+}
+
+/* ==================== 标记高亮 ==================== */
+.markup-highlight {
+  background-color: var(--md-primary-color);
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+}
+
+.markup-underline {
+  text-decoration: underline;
+  text-decoration-color: var(--md-primary-color);
+}
+
+.markup-wavyline {
+  text-decoration: underline wavy;
+  text-decoration-color: var(--md-primary-color);
+  text-decoration-thickness: 2px;
+}

--- a/packages/shared/src/configs/theme.ts
+++ b/packages/shared/src/configs/theme.ts
@@ -20,6 +20,11 @@ export const themeOptionsMap = {
     value: `simple`,
     desc: `@okooo5km`,
   },
+  violet: {
+    label: `紫罗兰`,
+    value: `violet`,
+    desc: `清爽现代，适合技术教程`,
+  },
 }
 
 export const themeOptions: IConfigOption<ThemeName>[] = [
@@ -37,5 +42,10 @@ export const themeOptions: IConfigOption<ThemeName>[] = [
     label: `简洁`,
     value: `simple`,
     desc: `@okooo5km`,
+  },
+  {
+    label: `紫罗兰`,
+    value: `violet`,
+    desc: `清爽现代，适合技术教程`,
   },
 ]


### PR DESCRIPTION
## Summary

- 新增「紫罗兰」主题（violet），清爽现代风格，适合技术教程和工具分享类文章
- 主题使用 `var(--md-primary-color)` 变量，用户可在编辑器中自定义主题色
- 默认推荐色值 `#6B46E1`

## 改动文件

- `packages/shared/src/configs/theme-css/violet.css`：新增主题 CSS
- `packages/shared/src/configs/theme-css/index.ts`：注册新主题
- `packages/shared/src/configs/theme.ts`：添加主题选项

## 主题特点

- H2 使用圆角实色背景，视觉层次清晰
- 引用块使用主题色半透明背景，不抢视线
- 表格使用主题色表头 + 斑马纹，手机端可读性好
- 链接使用主题色 + 底部细线，区分度适中
- 行内代码使用主题色浅底，与正文有区分

## Test plan

- [ ] 在编辑器中选择「紫罗兰」主题，预览效果
- [ ] 切换主题色为 `#6B46E1`，检查所有元素的颜色是否正确
- [ ] 在手机端预览表格、代码块、引用块的显示效果
- [ ] 测试暗色模式下的显示效果

🤖 Generated with [Claude Code](https://claude.com/claude-code)