### PR TITLE
feat: make each theme have independent settings (color, font, size, c…

### DIFF
--- a/apps/web/src/stores/theme.ts
+++ b/apps/web/src/stores/theme.ts
@@ -1,38 +1,140 @@
-import type { HeadingLevel, HeadingStyles, HeadingStyleType, ThemeName } from '@md/shared/configs'
+import type { HeadingLevel, HeadingStyles, HeadingStyleType, PerThemeSettings, PerThemeSettingsMap, ThemeName } from '@md/shared/configs'
 import { applyTheme } from '@md/core'
-import { defaultStyleConfig, widthOptions } from '@md/shared/configs'
+import { defaultPerThemeSettings, defaultStyleConfig, widthOptions } from '@md/shared/configs'
 import { useCssEditorStore } from '@/stores/cssEditor'
 import { addPrefix } from '@/utils'
 import { store } from '@/utils/storage'
 
+/** Legacy localStorage keys used before per-theme settings */
+const LEGACY_KEYS = [`fonts`, `size`, `color`, `codeBlockTheme`, `headingStyles`, `isMacCodeBlock`, `isShowLineNumber`]
+
 /**
  * 主题和样式配置 Store
  * 负责管理所有与主题、字体、颜色相关的配置
+ *
+ * 每个主题拥有独立的配置（primaryColor、fontFamily、fontSize、codeBlockTheme、
+ * headingStyles、isShowLineNumber、isMacCodeBlock），切换主题时自动加载对应配置。
  */
 export const useThemeStore = defineStore(`theme`, () => {
-  // 文本主题
+  // 当前选中的主题
   const theme = store.reactive<ThemeName>(addPrefix(`theme`), defaultStyleConfig.theme)
 
-  // 文本字体
-  const fontFamily = store.reactive(`fonts`, defaultStyleConfig.fontFamily)
+  // 每个主题的独立配置（持久化到 localStorage）
+  const themeSettings = store.reactive<PerThemeSettingsMap>(
+    addPrefix(`themeSettings`),
+    {},
+  )
 
-  // 文本大小
-  const fontSize = store.reactive(`size`, defaultStyleConfig.fontSize)
+  // --- Legacy migration: run once on store init ---
+  const hasAnyLegacyKey = LEGACY_KEYS.some(key => localStorage.getItem(key) !== null)
+  const migrationKey = `MD__legacy_migrated`
+  const alreadyMigrated = localStorage.getItem(migrationKey) !== null
 
-  // 主色
-  const primaryColor = store.reactive(`color`, defaultStyleConfig.primaryColor)
+  if (hasAnyLegacyKey && !alreadyMigrated) {
+    const targetTheme = theme.value
+    const existing = themeSettings.value[targetTheme] ?? defaultPerThemeSettings()
+    const settings: PerThemeSettings = { ...existing }
 
-  // 代码块主题
-  const codeBlockTheme = store.reactive(`codeBlockTheme`, defaultStyleConfig.codeBlockTheme)
+    const legacyFont = localStorage.getItem(`fonts`)
+    if (legacyFont)
+      settings.fontFamily = legacyFont
 
-  // 图注格式
-  const legend = store.reactive(`legend`, defaultStyleConfig.legend)
+    const legacySize = localStorage.getItem(`size`)
+    if (legacySize)
+      settings.fontSize = legacySize
 
-  // 是否开启 Mac 代码块
-  const isMacCodeBlock = store.reactive(`isMacCodeBlock`, defaultStyleConfig.isMacCodeBlock)
+    const legacyColor = localStorage.getItem(`color`)
+    if (legacyColor)
+      settings.primaryColor = legacyColor
 
-  // 是否开启代码块行号显示
-  const isShowLineNumber = store.reactive(`isShowLineNumber`, defaultStyleConfig.isShowLineNumber)
+    const legacyCodeTheme = localStorage.getItem(`codeBlockTheme`)
+    if (legacyCodeTheme)
+      settings.codeBlockTheme = legacyCodeTheme
+
+    const legacyHeading = localStorage.getItem(`headingStyles`)
+    if (legacyHeading) {
+      try {
+        settings.headingStyles = JSON.parse(legacyHeading)
+      }
+      catch { /* ignore parse error */ }
+    }
+
+    const legacyMacBlock = localStorage.getItem(`isMacCodeBlock`)
+    if (legacyMacBlock !== null)
+      settings.isMacCodeBlock = legacyMacBlock === `true`
+
+    const legacyLineNum = localStorage.getItem(`isShowLineNumber`)
+    if (legacyLineNum !== null)
+      settings.isShowLineNumber = legacyLineNum === `true`
+
+    themeSettings.value = {
+      ...themeSettings.value,
+      [targetTheme]: settings,
+    }
+
+    // Mark migration as done
+    localStorage.setItem(migrationKey, `1`)
+
+    // Clean up legacy keys
+    for (const key of LEGACY_KEYS) {
+      localStorage.removeItem(key)
+    }
+  }
+
+  // 获取当前主题的配置（不存在时返回默认值）
+  const currentSettings = computed<PerThemeSettings>(() => {
+    return themeSettings.value[theme.value] ?? defaultPerThemeSettings()
+  })
+
+  // --- Per-theme computed properties ---
+  // 使用 computed({ get, set }) 保持与现有 UI 组件的 Ref API 兼容
+
+  const primaryColor = computed<string>({
+    get: () => currentSettings.value.primaryColor,
+    set: (v: string) => { setThemeField(`primaryColor`, v) },
+  })
+
+  const fontFamily = computed<string>({
+    get: () => currentSettings.value.fontFamily,
+    set: (v: string) => { setThemeField(`fontFamily`, v) },
+  })
+
+  const fontSize = computed<string>({
+    get: () => currentSettings.value.fontSize,
+    set: (v: string) => { setThemeField(`fontSize`, v) },
+  })
+
+  const codeBlockTheme = computed<string>({
+    get: () => currentSettings.value.codeBlockTheme,
+    set: (v: string) => { setThemeField(`codeBlockTheme`, v) },
+  })
+
+  const headingStyles = computed<HeadingStyles>({
+    get: () => currentSettings.value.headingStyles,
+    set: (v: HeadingStyles) => { setThemeField(`headingStyles`, v) },
+  })
+
+  const isShowLineNumber = computed<boolean>({
+    get: () => currentSettings.value.isShowLineNumber,
+    set: (v: boolean) => { setThemeField(`isShowLineNumber`, v) },
+  })
+
+  const isMacCodeBlock = computed<boolean>({
+    get: () => currentSettings.value.isMacCodeBlock,
+    set: (v: boolean) => { setThemeField(`isMacCodeBlock`, v) },
+  })
+
+  /** 更新当前主题的某个字段 */
+  function setThemeField<K extends keyof PerThemeSettings>(key: K, value: PerThemeSettings[K]) {
+    const t = theme.value
+    const existing = themeSettings.value[t] ?? defaultPerThemeSettings()
+    themeSettings.value = {
+      ...themeSettings.value,
+      [t]: { ...existing, [key]: value },
+    }
+  }
+
+  // --- Global (non-theme) properties ---
 
   // 是否开启微信外链接底部引用
   const isCiteStatus = store.reactive(`isCiteStatus`, defaultStyleConfig.isCiteStatus)
@@ -46,11 +148,11 @@ export const useThemeStore = defineStore(`theme`, () => {
   // 是否开启两端对齐
   const isUseJustify = store.reactive(addPrefix(`use_justify`), false)
 
+  // 图注格式
+  const legend = store.reactive(`legend`, defaultStyleConfig.legend)
+
   // 预览宽度
   const previewWidth = store.reactive(`previewWidth`, widthOptions[0].value)
-
-  // 标题样式
-  const headingStyles = store.reactive<HeadingStyles>(`headingStyles`, defaultStyleConfig.headingStyles)
 
   // 计算属性
   const fontSizeNumber = computed(() => Number(fontSize.value.replace(`px`, ``)))
@@ -63,29 +165,23 @@ export const useThemeStore = defineStore(`theme`, () => {
   const toggleUseIndent = useToggle(isUseIndent)
   const toggleUseJustify = useToggle(isUseJustify)
 
-  // 重置样式
+  // 重置样式（仅重置当前主题的配置）
   const resetStyle = () => {
+    themeSettings.value = {
+      ...themeSettings.value,
+      [theme.value]: defaultPerThemeSettings(),
+    }
     isCiteStatus.value = defaultStyleConfig.isCiteStatus
-    isMacCodeBlock.value = defaultStyleConfig.isMacCodeBlock
-    isShowLineNumber.value = defaultStyleConfig.isShowLineNumber
     isCountStatus.value = defaultStyleConfig.isCountStatus
-
-    theme.value = defaultStyleConfig.theme
-    fontFamily.value = defaultStyleConfig.fontFamily
-    fontSize.value = defaultStyleConfig.fontSize
-    primaryColor.value = defaultStyleConfig.primaryColor
-    codeBlockTheme.value = defaultStyleConfig.codeBlockTheme
-    legend.value = defaultStyleConfig.legend
-    headingStyles.value = { ...defaultStyleConfig.headingStyles }
-
     isUseIndent.value = false
     isUseJustify.value = false
   }
 
   // 设置标题样式
   const setHeadingStyle = (level: HeadingLevel, style: HeadingStyleType) => {
+    const existing = headingStyles.value
     headingStyles.value = {
-      ...headingStyles.value,
+      ...existing,
       [level]: style === `default` ? undefined : style,
     }
   }
@@ -143,6 +239,7 @@ export const useThemeStore = defineStore(`theme`, () => {
   return {
     // State
     theme,
+    themeSettings,
     fontFamily,
     fontSize,
     fontSizeNumber,

--- a/apps/web/src/stores/theme.ts
+++ b/apps/web/src/stores/theme.ts
@@ -9,6 +9,81 @@ import { store } from '@/utils/storage'
 const LEGACY_KEYS = [`fonts`, `size`, `color`, `codeBlockTheme`, `headingStyles`, `isMacCodeBlock`, `isShowLineNumber`]
 
 /**
+ * Run legacy migration synchronously before store.reactive installs its watch.
+ * Returns the migrated PerThemeSettingsMap (or {} if nothing to migrate).
+ */
+function migrateLegacySettingsSync(currentTheme: ThemeName): PerThemeSettingsMap {
+  let hasAnyLegacyKey = false
+  try {
+    hasAnyLegacyKey = LEGACY_KEYS.some(key => localStorage.getItem(key) !== null)
+  }
+  catch { return {} }
+  if (!hasAnyLegacyKey)
+    return {}
+
+  const migrationKey = addPrefix(`legacy_migrated`)
+  try {
+    if (localStorage.getItem(migrationKey) !== null)
+      return {}
+  }
+  catch { return {} }
+
+  const existingMapRaw = localStorage.getItem(addPrefix(`themeSettings`))
+  const existingMap: PerThemeSettingsMap = existingMapRaw ? JSON.parse(existingMapRaw) : {}
+
+  const defaults = defaultPerThemeSettings()
+  const settings: PerThemeSettings = { ...existingMap[currentTheme] ?? defaults }
+
+  const legacyFont = localStorage.getItem(`fonts`)
+  if (legacyFont)
+    settings.fontFamily = legacyFont
+
+  const legacySize = localStorage.getItem(`size`)
+  if (legacySize)
+    settings.fontSize = legacySize
+
+  const legacyColor = localStorage.getItem(`color`)
+  if (legacyColor)
+    settings.primaryColor = legacyColor
+
+  const legacyCodeTheme = localStorage.getItem(`codeBlockTheme`)
+  if (legacyCodeTheme)
+    settings.codeBlockTheme = legacyCodeTheme
+
+  const legacyHeading = localStorage.getItem(`headingStyles`)
+  if (legacyHeading) {
+    try { settings.headingStyles = JSON.parse(legacyHeading) }
+    catch { /* ignore parse error */ }
+  }
+
+  const legacyMacBlock = localStorage.getItem(`isMacCodeBlock`)
+  if (legacyMacBlock !== null)
+    settings.isMacCodeBlock = legacyMacBlock === `true`
+
+  const legacyLineNum = localStorage.getItem(`isShowLineNumber`)
+  if (legacyLineNum !== null)
+    settings.isShowLineNumber = legacyLineNum === `true`
+
+  const result: PerThemeSettingsMap = { ...existingMap, [currentTheme]: settings }
+
+  // Persist the merged map so store.reactive will pick it up
+  try { localStorage.setItem(addPrefix(`themeSettings`), JSON.stringify(result)) }
+  catch { /* quota error — non-critical */ }
+
+  // Mark migration as done
+  try { localStorage.setItem(migrationKey, `1`) }
+  catch { /* ignore */ }
+
+  // Clean up legacy keys
+  for (const key of LEGACY_KEYS) {
+    try { localStorage.removeItem(key) }
+    catch { /* ignore */ }
+  }
+
+  return result
+}
+
+/**
  * 主题和样式配置 Store
  * 负责管理所有与主题、字体、颜色相关的配置
  *
@@ -16,70 +91,21 @@ const LEGACY_KEYS = [`fonts`, `size`, `color`, `codeBlockTheme`, `headingStyles`
  * headingStyles、isShowLineNumber、isMacCodeBlock），切换主题时自动加载对应配置。
  */
 export const useThemeStore = defineStore(`theme`, () => {
+  // --- Legacy migration: run BEFORE reactive so initial value is correct ---
+  const initialTheme = (() => {
+    try { return localStorage.getItem(addPrefix(`theme`)) ?? defaultStyleConfig.theme }
+    catch { return defaultStyleConfig.theme }
+  })()
+  const migratedSettings = migrateLegacySettingsSync(initialTheme as ThemeName)
+
   // 当前选中的主题
   const theme = store.reactive<ThemeName>(addPrefix(`theme`), defaultStyleConfig.theme)
 
   // 每个主题的独立配置（持久化到 localStorage）
   const themeSettings = store.reactive<PerThemeSettingsMap>(
     addPrefix(`themeSettings`),
-    {},
+    migratedSettings,
   )
-
-  // --- Legacy migration: run once on store init ---
-  const hasAnyLegacyKey = LEGACY_KEYS.some(key => localStorage.getItem(key) !== null)
-  const migrationKey = `MD__legacy_migrated`
-  const alreadyMigrated = localStorage.getItem(migrationKey) !== null
-
-  if (hasAnyLegacyKey && !alreadyMigrated) {
-    const targetTheme = theme.value
-    const existing = themeSettings.value[targetTheme] ?? defaultPerThemeSettings()
-    const settings: PerThemeSettings = { ...existing }
-
-    const legacyFont = localStorage.getItem(`fonts`)
-    if (legacyFont)
-      settings.fontFamily = legacyFont
-
-    const legacySize = localStorage.getItem(`size`)
-    if (legacySize)
-      settings.fontSize = legacySize
-
-    const legacyColor = localStorage.getItem(`color`)
-    if (legacyColor)
-      settings.primaryColor = legacyColor
-
-    const legacyCodeTheme = localStorage.getItem(`codeBlockTheme`)
-    if (legacyCodeTheme)
-      settings.codeBlockTheme = legacyCodeTheme
-
-    const legacyHeading = localStorage.getItem(`headingStyles`)
-    if (legacyHeading) {
-      try {
-        settings.headingStyles = JSON.parse(legacyHeading)
-      }
-      catch { /* ignore parse error */ }
-    }
-
-    const legacyMacBlock = localStorage.getItem(`isMacCodeBlock`)
-    if (legacyMacBlock !== null)
-      settings.isMacCodeBlock = legacyMacBlock === `true`
-
-    const legacyLineNum = localStorage.getItem(`isShowLineNumber`)
-    if (legacyLineNum !== null)
-      settings.isShowLineNumber = legacyLineNum === `true`
-
-    themeSettings.value = {
-      ...themeSettings.value,
-      [targetTheme]: settings,
-    }
-
-    // Mark migration as done
-    localStorage.setItem(migrationKey, `1`)
-
-    // Clean up legacy keys
-    for (const key of LEGACY_KEYS) {
-      localStorage.removeItem(key)
-    }
-  }
 
   // 获取当前主题的配置（不存在时返回默认值）
   const currentSettings = computed<PerThemeSettings>(() => {
@@ -173,6 +199,7 @@ export const useThemeStore = defineStore(`theme`, () => {
     }
     isCiteStatus.value = defaultStyleConfig.isCiteStatus
     isCountStatus.value = defaultStyleConfig.isCountStatus
+    legend.value = defaultStyleConfig.legend
     isUseIndent.value = false
     isUseJustify.value = false
   }

--- a/packages/shared/src/configs/style.ts
+++ b/packages/shared/src/configs/style.ts
@@ -1,4 +1,5 @@
 import type { IConfigOption } from '../types'
+import type { ThemeName } from './theme-css'
 import { themeOptions } from './theme'
 
 export const fontFamilyOptions: IConfigOption[] = [
@@ -273,3 +274,27 @@ export const defaultStyleConfig = {
   legend: legendOptions[3].value,
   headingStyles: defaultHeadingStyles as HeadingStyles,
 }
+
+export interface PerThemeSettings {
+  primaryColor: string
+  fontFamily: string
+  fontSize: string
+  codeBlockTheme: string
+  headingStyles: HeadingStyles
+  isShowLineNumber: boolean
+  isMacCodeBlock: boolean
+}
+
+export function defaultPerThemeSettings(): PerThemeSettings {
+  return {
+    primaryColor: defaultStyleConfig.primaryColor,
+    fontFamily: defaultStyleConfig.fontFamily,
+    fontSize: defaultStyleConfig.fontSize,
+    codeBlockTheme: defaultStyleConfig.codeBlockTheme,
+    headingStyles: { ...defaultStyleConfig.headingStyles },
+    isShowLineNumber: defaultStyleConfig.isShowLineNumber,
+    isMacCodeBlock: defaultStyleConfig.isMacCodeBlock,
+  }
+}
+
+export type PerThemeSettingsMap = Partial<Record<ThemeName, PerThemeSettings>>


### PR DESCRIPTION
…ode theme)

Previously all themes shared the same primaryColor, fontFamily, fontSize, codeBlockTheme, headingStyles, isShowLineNumber, and isMacCodeBlock. Now each theme stores its own configuration in a single localStorage key (MD__themeSettings), and switching themes automatically loads the corresponding settings.

Added backward-compatible migration that reads legacy localStorage keys and merges them into the current theme's settings on first load.