### PR TITLE
fix: correct @codemirror/view patch for Alt+Shift key handling

### DIFF
--- a/patches/@codemirror__view@6.43.0.patch
+++ b/patches/@codemirror__view@6.43.0.patch
@@ -20,8 +20,8 @@ index cfb44591c515154334d9896228db3b86c5a863e6..efc071a1dbac9a33e85f01034f1c42c9
              !(browser.windows && event.ctrlKey && event.altKey) &&
              // Alt-combinations on macOS tend to be typed characters
 -            !(browser.mac && event.altKey && !(event.ctrlKey || event.metaKey)) &&
-+            !(browser.mac && event.altKey && !event.shiftKey && !(event.ctrlKey || event.metaKey))
-+            // 但 Alt+Shift 组合应该被视为快捷键而不是特殊字符输入 &&
++            // Allow Alt+Shift combinations to be treated as shortcuts rather than special character input
++            !(browser.mac && event.altKey && !event.shiftKey && !(event.ctrlKey || event.metaKey)) &&
              (baseName = base[event.keyCode]) && baseName != name) {
              if (runFor(scopeObj[prefix + modifiers(baseName, event, true)])) {
                  handled = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   yauzl: ^3.3.0
 
 patchedDependencies:
-  '@codemirror/view@6.43.0': 09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f
+  '@codemirror/view@6.43.0': 57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f
   juice@11.1.1: 64286af9d3913b3ffbee649d634de8ec5a603857ce1185030d8bb6e4a384c92c
 
 importers:
@@ -55,7 +55,7 @@ importers:
         version: 6.6.0
       '@codemirror/view':
         specifier: 6.43.0
-        version: 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+        version: 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 9.0.0
@@ -431,13 +431,13 @@ importers:
         version: 6.7.0
       '@fsegurai/codemirror-theme-vscode-dark':
         specifier: ^6.2.6
-        version: 6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f))(@lezer/highlight@1.2.3)
+        version: 6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))(@lezer/highlight@1.2.3)
       '@fsegurai/codemirror-theme-vscode-light':
         specifier: ^6.2.6
-        version: 6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f))(@lezer/highlight@1.2.3)
+        version: 6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))(@lezer/highlight@1.2.3)
       '@replit/codemirror-indentation-markers':
         specifier: ^6.5.3
-        version: 6.5.3(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f))
+        version: 6.5.3(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -8359,14 +8359,14 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
 
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
 
   '@codemirror/lang-angular@0.1.4':
@@ -8406,7 +8406,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
@@ -8422,7 +8422,7 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.6
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
 
@@ -8432,7 +8432,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -8456,7 +8456,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -8467,7 +8467,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
 
@@ -8530,7 +8530,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
 
@@ -8573,7 +8573,7 @@ snapshots:
   '@codemirror/language@6.12.3':
     dependencies:
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -8586,20 +8586,20 @@ snapshots:
   '@codemirror/lint@6.9.6':
     dependencies:
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       crelt: 1.0.6
 
   '@codemirror/search@6.7.0':
     dependencies:
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       crelt: 1.0.6
 
   '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)':
+  '@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)':
     dependencies:
       '@codemirror/state': 6.6.0
       crelt: 1.0.6
@@ -9027,18 +9027,18 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@fsegurai/codemirror-theme-vscode-dark@6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f))(@lezer/highlight@1.2.3)':
+  '@fsegurai/codemirror-theme-vscode-dark@6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))(@lezer/highlight@1.2.3)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/highlight': 1.2.3
 
-  '@fsegurai/codemirror-theme-vscode-light@6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f))(@lezer/highlight@1.2.3)':
+  '@fsegurai/codemirror-theme-vscode-light@6.2.6(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))(@lezer/highlight@1.2.3)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
       '@lezer/highlight': 1.2.3
 
   '@hono/node-server@1.19.14(hono@4.12.21)':
@@ -9437,11 +9437,11 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@replit/codemirror-indentation-markers@6.5.3(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f))':
+  '@replit/codemirror-indentation-markers@6.5.3(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
 
   '@rolldown/binding-android-arm64@1.0.2':
     optional: true
@@ -11078,7 +11078,7 @@ snapshots:
       '@codemirror/lint': 6.9.6
       '@codemirror/search': 6.7.0
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.0(patch_hash=09f7b84fce74b6f9b4f2bb0fe2cece0a2815284f7dcbee34b095ed13bc802e5f)
+      '@codemirror/view': 6.43.0(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f)
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
## Problem

The existing patch for @codemirror/view incorrectly placed the && logical operator inside a comment, causing a runtime TypeError:

`
TypeError: (browser.mac && event.altKey && (!event.shiftKey) && (!(event.ctrlKey || event.metaKey))) is not a function
`

JavaScript interpreted the negation expression as a function call, with (baseName = base[event.keyCode]) treated as its argument.

## Fix

Move the connecting && out of the comment so it remains a proper logical operator:

`diff
-!(browser.mac && event.altKey && !event.shiftKey && !(event.ctrlKey || event.metaKey))
-// 但 Alt+Shift 组合应该被视为快捷键而不是特殊字符输入 &&
+// Allow Alt+Shift combinations to be treated as shortcuts rather than special character input
+!(browser.mac && event.altKey && !event.shiftKey && !(event.ctrlKey || event.metaKey)) &&
 (baseName = base[event.keyCode]) && baseName != name) {
`

This restores correct behavior where Alt+Shift key combinations are treated as shortcuts rather than special character input on macOS.