### PR TITLE
feat: auto-detect and upload local images on markdown import

### DIFF
--- a/apps/web/src/components/editor/ImportMarkdownDialog.vue
+++ b/apps/web/src/components/editor/ImportMarkdownDialog.vue
@@ -11,6 +11,73 @@ const { isShowImportMdDialog } = storeToRefs(uiStore)
 // 当前选中的 tab
 const activeTab = ref<'url' | 'file'>(`file`)
 
+// ==================== 检测本地图片路径 ====================
+/**
+ * 从 Markdown 内容中检测本地图片路径
+ * 排除 http/https URL、data URI 和空路径
+ */
+function detectLocalImagePaths(content: string): string[] {
+  const regex = /!\[[^\]]*\]\((?!https?:\/\/|data:)([^)]+)\)/g
+  const paths = new Set<string>()
+  let match = regex.exec(content)
+  while (match != null) {
+    const path = match[1]!.trim()
+    if (path) {
+      paths.add(path)
+    }
+    match = regex.exec(content)
+  }
+  return Array.from(paths)
+}
+
+/**
+ * 导入内容，如果包含本地图片则弹出上传对话框
+ */
+async function importContent(title: string, content: string) {
+  const localPaths = detectLocalImagePaths(content)
+  if (localPaths.length === 0) {
+    // 没有本地图片，直接导入
+    postStore.addPost(title)
+    postStore.updatePostContent(postStore.currentPostId, content)
+    closeDialog()
+    return
+  }
+
+  // 有本地图片，弹出上传对话框
+  uiStore.localImageUploadData = {
+    markdownContent: content,
+    detectedPaths: localPaths,
+  }
+  uiStore.isShowLocalImageUpload = true
+
+  // 等待上传对话框处理完成
+  await new Promise<void>((resolve) => {
+    const unwatch = watch(
+      () => uiStore.localImageUploadData,
+      (data) => {
+        if (data && data.processed) {
+          unwatch()
+          if (data.skipUpload) {
+            // 用户选择跳过，按原样导入
+            postStore.addPost(title)
+            postStore.updatePostContent(postStore.currentPostId, content)
+          }
+          else {
+            // 用户已上传并应用，使用替换后的内容
+            postStore.addPost(title)
+            postStore.updatePostContent(postStore.currentPostId, data!.markdownContent)
+          }
+          closeDialog()
+          resolve()
+        }
+      },
+    )
+  })
+
+  // 清理
+  uiStore.localImageUploadData = null
+}
+
 // ==================== 网络链接导入 ====================
 const url = ref(``)
 const isUrlLoading = ref(false)
@@ -105,9 +172,7 @@ async function importFromUrl() {
         return `untitled`
       }
     })()
-    postStore.addPost(urlTitle)
-    postStore.updatePostContent(postStore.currentPostId, content)
-    closeDialog()
+    await importContent(urlTitle, content)
   }
   catch (err) {
     if ((err as Error).name === `AbortError`)
@@ -175,11 +240,11 @@ async function readAndImportFiles(files: File[]) {
     return
   for (const { file, content } of validResults) {
     const title = file.name.replace(/\.(md|markdown|txt)$/i, ``)
-    postStore.addPost(title)
-    postStore.updatePostContent(postStore.currentPostId, content)
+    await importContent(title, content)
   }
-  toast.success(validResults.length === 1 ? `已导入 1 篇文章` : `已批量导入 ${validResults.length} 篇文章`)
-  closeDialog()
+  if (validResults.length > 0) {
+    toast.success(validResults.length === 1 ? `已导入 1 篇文章` : `已批量导入 ${validResults.length} 篇文章`)
+  }
 }
 
 // ==================== 对话框控制 ====================

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -43,6 +43,12 @@ const matchedCount = computed(() => {
   return count
 })
 
+// 是否全部上传成功（选中的图片都有结果且无报错）
+const isAllUploaded = computed(() => {
+  const paths = Array.from(selectedPaths.value)
+  return paths.length > 0 && paths.every(p => uploadResults.value[p] && !uploadErrors.value[p])
+})
+
 watch(() => uiStore.localImageUploadData, (data) => {
   if (data) {
     selectedPaths.value = new Set(data.detectedPaths)
@@ -247,7 +253,12 @@ function onOpenChange(val: boolean) {
         </label>
 
         <!-- 底部操作区 -->
-        <div class="flex items-center justify-between gap-2 pt-2">
+        <div v-if="isAllUploaded" class="flex justify-end pt-2">
+          <Button @click="handleApply">
+            完成
+          </Button>
+        </div>
+        <div v-else class="flex items-center justify-between gap-2 pt-2">
           <Button variant="link" class="px-2 text-muted-foreground" @click="handleSkip">
             跳过
           </Button>

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -13,7 +13,10 @@ import { useImageUploader } from '@/composables/useImageUploader'
 import { useUIStore } from '@/stores/ui'
 
 const uiStore = useUIStore()
-const { upload, isUploading } = useImageUploader()
+const { upload } = useImageUploader()
+
+// 批次上传状态（覆盖整个上传循环）
+const isUploading = ref(false)
 
 const isDialogOpen = computed({
   get: () => uiStore.isShowLocalImageUpload,
@@ -127,6 +130,7 @@ async function handleUpload() {
   progressValue.value = 0
   uploadResults.value = {}
   uploadErrors.value = {}
+  isUploading.value = true
 
   for (let i = 0; i < pathsToUpload.length; i++) {
     const path = pathsToUpload[i]!
@@ -140,6 +144,7 @@ async function handleUpload() {
     }
     progressValue.value = Math.round(((i + 1) / total) * 100)
   }
+  isUploading.value = false
 }
 
 // 关闭并应用

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -237,7 +237,7 @@ function onOpenChange(val: boolean) {
         <Progress v-if="isUploading || progressValue > 0" :model-value="progressValue" class="h-1.5" />
 
         <!-- 选择文件夹按钮 -->
-        <label class="block">
+        <label v-if="!isAllUploaded" class="block">
           <input
             type="file"
             webkitdirectory

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -164,13 +164,13 @@ function handleApply() {
   if (!uiStore.localImageUploadData)
     return
 
-  // 仅替换图片语法 `![alt](path)`，避免误改普通链接
+  // 仅替换图片语法 `![alt](path)` 中的路径为上传后的 URL
   let content = uiStore.localImageUploadData.markdownContent
   for (const [path, url] of Object.entries(uploadResults.value)) {
     const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     content = content
-      .replace(new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)`, 'g'), `!](${url})`)
-      .replace(new RegExp(`!\\[[^\\]]*\\]\\(\\.\\/${escaped}\\)`, 'g'), `!](${url})`)
+      .replace(new RegExp(`(!\\[[^\\]]*\\]\\()${escaped}\\)`, 'g'), `$1${url})`)
+      .replace(new RegExp(`(!\\[[^\\]]*\\]\\(\\.\\/)${escaped}\\)`, 'g'), `$1${url})`)
   }
 
   uiStore.localImageUploadData = {

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -46,6 +46,11 @@ const matchedCount = computed(() => {
   return count
 })
 
+// 是否已有上传结果（成功或失败）
+const hasUploadAttempt = computed(() =>
+  Object.keys(uploadResults.value).length > 0 || Object.keys(uploadErrors.value).length > 0,
+)
+
 // 是否全部上传成功（选中的图片都有结果且无报错）
 const isAllUploaded = computed(() => {
   const paths = Array.from(selectedPaths.value)
@@ -164,8 +169,8 @@ function handleApply() {
   for (const [path, url] of Object.entries(uploadResults.value)) {
     const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     content = content
-      .replace(new RegExp(`!\\]\\(${escaped}\\)`, 'g'), `!](${url})`)
-      .replace(new RegExp(`!\\]\\(\\.\\/${escaped}\\)`, 'g'), `!](${url})`)
+      .replace(new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)`, 'g'), `!](${url})`)
+      .replace(new RegExp(`!\\[[^\\]]*\\]\\(\\.\\/${escaped}\\)`, 'g'), `!](${url})`)
   }
 
   uiStore.localImageUploadData = {
@@ -271,7 +276,7 @@ function onOpenChange(val: boolean) {
             完成
           </Button>
         </div>
-        <div v-else class="flex items-center justify-between gap-2 pt-2">
+        <div v-else-if="hasUploadAttempt" class="flex items-center justify-between gap-2 pt-2">
           <Button variant="link" class="px-2 text-muted-foreground" @click="handleSkip">
             跳过
           </Button>
@@ -282,6 +287,16 @@ function onOpenChange(val: boolean) {
             >
               完成
             </Button>
+            <Button variant="outline" @click="handleUpload">
+              重新上传
+            </Button>
+          </div>
+        </div>
+        <div v-else class="flex items-center justify-between gap-2 pt-2">
+          <Button variant="link" class="px-2 text-muted-foreground" @click="handleSkip">
+            跳过
+          </Button>
+          <div class="flex gap-2">
             <Button
               :disabled="isUploading || selectedPaths.size === 0 || matchedCount === 0"
               @click="handleUpload"

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -232,43 +231,42 @@ function onOpenChange(val: boolean) {
         <Progress v-if="isUploading || progressValue > 0" :model-value="progressValue" class="h-1.5" />
 
         <!-- 选择文件夹按钮 -->
-        <div class="flex items-center gap-2">
-          <label class="flex-1">
-            <input
-              id="local-image-folder-input"
-              type="file"
-              webkitdirectory
-              multiple
-              accept="image/*"
-              class="hidden"
-              @change="handleFolderSelect"
-            >
-            <Button variant="outline" class="w-full" as="span">
-              <FolderOpen class="mr-2 h-4 w-4" />
-              {{ folderFiles.length > 0 ? `已选择文件夹 (${folderFiles.length} 个文件)` : '选择包含图片的文件夹' }}
-            </Button>
-          </label>
-        </div>
+        <label class="block">
+          <input
+            type="file"
+            webkitdirectory
+            multiple
+            accept="image/*"
+            class="hidden"
+            @change="handleFolderSelect"
+          >
+          <Button variant="outline" class="w-full" as="span">
+            <FolderOpen class="mr-2 h-4 w-4" />
+            {{ folderFiles.length > 0 ? `已选择文件夹 (${folderFiles.length} 个文件)` : '选择包含图片的文件夹' }}
+          </Button>
+        </label>
 
-        <!-- 操作按钮 -->
-        <DialogFooter class="gap-2 sm:gap-0">
-          <Button variant="outline" @click="handleSkip">
-            跳过，按原样导入
+        <!-- 底部操作区 -->
+        <div class="flex items-center justify-between gap-2 pt-2">
+          <Button variant="link" class="px-2 text-muted-foreground" @click="handleSkip">
+            跳过
           </Button>
-          <Button
-            :disabled="isUploading || selectedPaths.size === 0 || matchedCount === 0"
-            @click="handleUpload"
-          >
-            <Loader2 v-if="isUploading" class="mr-2 h-4 w-4 animate-spin" />
-            {{ isUploading ? '上传中...' : '上传选中的图片' }}
-          </Button>
-          <Button
-            v-if="Object.keys(uploadResults).length > 0"
-            @click="handleApply"
-          >
-            应用并导入
-          </Button>
-        </DialogFooter>
+          <div class="flex gap-2">
+            <Button
+              v-if="Object.keys(uploadResults).length > 0"
+              @click="handleApply"
+            >
+              完成
+            </Button>
+            <Button
+              :disabled="isUploading || selectedPaths.size === 0 || matchedCount === 0"
+              @click="handleUpload"
+            >
+              <Loader2 v-if="isUploading" class="mr-2 h-4 w-4 animate-spin" />
+              {{ isUploading ? '上传中...' : '上传图片' }}
+            </Button>
+          </div>
+        </div>
       </div>
     </DialogContent>
   </Dialog>

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Check, FileImage, Loader2, Upload, X } from 'lucide-vue-next'
+import { Check, FileImage, FolderOpen, Loader2, X } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -14,7 +14,7 @@ import { useImageUploader } from '@/composables/useImageUploader'
 import { useUIStore } from '@/stores/ui'
 
 const uiStore = useUIStore()
-const { upload } = useImageUploader()
+const { upload, isUploading } = useImageUploader()
 
 const isDialogOpen = computed({
   get: () => uiStore.isShowLocalImageUpload,
@@ -30,10 +30,19 @@ const selectedPaths = ref<Set<string>>(new Set())
 const progressValue = ref(0)
 const uploadResults = ref<Record<string, string>>({})
 const uploadErrors = ref<Record<string, string>>({})
-const isUploadingBatch = ref(false)
 
-// 用户选择的文件列表（按选择顺序，与勾选的路径一一对应）
-const selectedFiles = ref<File[]>([])
+// 用户选择的文件夹中的文件列表
+const folderFiles = ref<File[]>([])
+
+// 匹配状态
+const matchedCount = computed(() => {
+  let count = 0
+  for (const path of selectedPaths.value) {
+    if (findMatchedFile(path))
+      count++
+  }
+  return count
+})
 
 watch(() => uiStore.localImageUploadData, (data) => {
   if (data) {
@@ -41,80 +50,54 @@ watch(() => uiStore.localImageUploadData, (data) => {
     progressValue.value = 0
     uploadResults.value = {}
     uploadErrors.value = {}
-    isUploadingBatch.value = false
-    selectedFiles.value = []
+    folderFiles.value = []
   }
 }, { immediate: true })
 
-/**
- * 根据文件名自动匹配路径
- * 将匹配到的文件自动关联到对应的路径上
- */
-function autoMatchFiles() {
-  if (!uiStore.localImageUploadData || selectedFiles.value.length === 0)
-    return
-
-  const fileArray = selectedFiles.value
-  const paths = uiStore.localImageUploadData.detectedPaths
-  const pathIndexMap = new Map<string, number>()
-
-  // 第一轮：精确匹配（文件名相同）
-  const usedFileIndices = new Set<number>()
-  for (const path of paths) {
-    if (pathIndexMap.has(path))
-      continue
-    const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase()
-    for (let fi = 0; fi < fileArray.length; fi++) {
-      if (usedFileIndices.has(fi))
-        continue
-      if (fileArray[fi]!.name.toLowerCase() === pathFileName) {
-        pathIndexMap.set(path, fi)
-        usedFileIndices.add(fi)
-        break
-      }
-    }
-  }
-
-  // 第二轮：模糊匹配（文件名包含或去掉扩展名匹配）
-  for (const path of paths) {
-    if (pathIndexMap.has(path))
-      continue
-    const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase().replace(/\.[^.]+$/, '')
-    for (let fi = 0; fi < fileArray.length; fi++) {
-      if (usedFileIndices.has(fi))
-        continue
-      const fileBase = fileArray[fi]!.name.toLowerCase().replace(/\.[^.]+$/, '')
-      if (pathFileName === fileBase) {
-        pathIndexMap.set(path, fi)
-        usedFileIndices.add(fi)
-        break
-      }
-    }
-  }
-
-  // 将匹配到的路径自动选中
-  for (const path of pathIndexMap.keys()) {
-    selectedPaths.value.add(path)
-  }
-
-  // 重置 input
-  const input = document.getElementById('local-image-file-input') as HTMLInputElement
-  if (input)
-    input.value = ''
-}
-
-// 选择文件
-function handleFileSelect(event: Event) {
+// 选择包含图片的文件夹
+function handleFolderSelect(event: Event) {
   const files = (event.target as HTMLInputElement).files
   if (!files || files.length === 0)
     return
 
-  // 追加新选择的文件
-  const existing = Array.from(selectedFiles.value)
-  selectedFiles.value = [...existing, ...Array.from(files)]
+  folderFiles.value = Array.from(files)
 
-  // 自动匹配
-  autoMatchFiles()
+  // 自动选中已匹配的路径
+  for (const path of selectedPaths.value) {
+    if (!findMatchedFile(path)) {
+      selectedPaths.value.delete(path)
+    }
+  }
+  for (const path of uiStore.localImageUploadData?.detectedPaths || []) {
+    if (findMatchedFile(path)) {
+      selectedPaths.value.add(path)
+    }
+  }
+
+  // 重置 input
+  ;(event.target as HTMLInputElement).value = ''
+}
+
+/**
+ * 根据路径从文件夹文件中查找匹配的文件
+ */
+function findMatchedFile(path: string): File | undefined {
+  const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase()
+  const fileArray = folderFiles.value
+
+  // 第一轮：精确匹配文件名
+  for (const file of fileArray) {
+    if (file.name.toLowerCase() === pathFileName)
+      return file
+  }
+  // 第二轮：去扩展名匹配
+  const pathBase = pathFileName.replace(/\.[^.]+$/, '')
+  for (const file of fileArray) {
+    const fileBase = file.name.toLowerCase().replace(/\.[^.]+$/, '')
+    if (fileBase === pathBase)
+      return file
+  }
+  return undefined
 }
 
 // 开始上传
@@ -129,7 +112,13 @@ async function handleUpload() {
     return
   }
 
-  isUploadingBatch.value = true
+  // 检查未匹配的
+  const unmatched = pathsToUpload.filter(p => !findMatchedFile(p))
+  if (unmatched.length > 0) {
+    toast.error(`以下图片未在文件夹中找到：${unmatched.join(', ')}`)
+    return
+  }
+
   progressValue.value = 0
   uploadResults.value = {}
   uploadErrors.value = {}
@@ -137,19 +126,8 @@ async function handleUpload() {
   for (let i = 0; i < pathsToUpload.length; i++) {
     const path = pathsToUpload[i]!
     try {
-      let url: string
-      const matchedFile = findMatchedFile(path)
-      if (matchedFile) {
-        // 有匹配的文件，直接上传
-        url = await upload(matchedFile)
-      }
-      else {
-        // 没有匹配的文件，但用户勾选了，说明用户想自己上传
-        toast.error(`路径 "${path}" 未找到对应文件`)
-        uploadErrors.value[path] = '未选择对应文件'
-        progressValue.value = Math.round(((i + 1) / total) * 100)
-        continue
-      }
+      const file = findMatchedFile(path)!
+      const url = await upload(file)
       uploadResults.value[path] = url
     }
     catch (err: unknown) {
@@ -157,26 +135,6 @@ async function handleUpload() {
     }
     progressValue.value = Math.round(((i + 1) / total) * 100)
   }
-
-  isUploadingBatch.value = false
-}
-
-function findMatchedFile(path: string): File | undefined {
-  const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase()
-  const fileArray = selectedFiles.value
-  // 精确匹配
-  for (const file of fileArray) {
-    if (file.name.toLowerCase() === pathFileName)
-      return file
-  }
-  // 模糊匹配（去扩展名）
-  const pathBase = pathFileName.replace(/\.[^.]+$/, '')
-  for (const file of fileArray) {
-    const fileBase = file.name.toLowerCase().replace(/\.[^.]+$/, '')
-    if (fileBase === pathBase)
-      return file
-  }
-  return undefined
 }
 
 // 关闭并应用
@@ -187,14 +145,12 @@ function handleApply() {
   // 替换 Markdown 中的路径
   let content = uiStore.localImageUploadData.markdownContent
   for (const [path, url] of Object.entries(uploadResults.value)) {
-    // 替换 ](path) 和 ](./path) 两种形式
     const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     content = content
       .replace(new RegExp(`\\]\\(${escaped}\\)`, 'g'), `](${url})`)
       .replace(new RegExp(`\\]\\(\\.\\/${escaped}\\)`, 'g'), `](${url})`)
   }
 
-  // 触发后续处理（设置内容等）
   uiStore.localImageUploadData = {
     markdownContent: content,
     detectedPaths: [],
@@ -229,7 +185,7 @@ function onOpenChange(val: boolean) {
       <DialogHeader>
         <DialogTitle>检测到本地图片</DialogTitle>
         <DialogDescription>
-          文档中包含本地图片路径，请选择对应文件并上传到图床。
+          文档中包含本地图片路径，请选择包含这些图片的文件夹，系统将自动匹配并上传。
         </DialogDescription>
       </DialogHeader>
 
@@ -240,8 +196,8 @@ function onOpenChange(val: boolean) {
             <span class="text-sm font-medium">
               检测到 {{ uiStore.localImageUploadData.detectedPaths.length }} 张本地图片
             </span>
-            <span class="text-xs text-muted-foreground">
-              已选择 {{ selectedFiles.length }} 个文件
+            <span v-if="folderFiles.length > 0" class="text-xs text-muted-foreground">
+              已匹配 {{ matchedCount }} / {{ selectedPaths.size }}
             </span>
           </div>
           <div class="max-h-48 overflow-auto p-2">
@@ -273,32 +229,25 @@ function onOpenChange(val: boolean) {
         </div>
 
         <!-- 进度条 -->
-        <Progress v-if="isUploadingBatch || progressValue > 0" :model-value="progressValue" class="h-1.5" />
+        <Progress v-if="isUploading || progressValue > 0" :model-value="progressValue" class="h-1.5" />
 
-        <!-- 选择文件按钮 -->
+        <!-- 选择文件夹按钮 -->
         <div class="flex items-center gap-2">
           <label class="flex-1">
             <input
-              id="local-image-file-input"
+              id="local-image-folder-input"
               type="file"
+              webkitdirectory
               multiple
               accept="image/*"
               class="hidden"
-              @change="handleFileSelect"
+              @change="handleFolderSelect"
             >
             <Button variant="outline" class="w-full" as="span">
-              <Upload class="mr-2 h-4 w-4" />
-              选择图片文件{{ selectedFiles.length > 0 ? `（已选 ${selectedFiles.length} 个）` : '' }}
+              <FolderOpen class="mr-2 h-4 w-4" />
+              {{ folderFiles.length > 0 ? `已选择文件夹 (${folderFiles.length} 个文件)` : '选择包含图片的文件夹' }}
             </Button>
           </label>
-        </div>
-
-        <!-- 已选文件列表 -->
-        <div v-if="selectedFiles.length > 0" class="text-xs text-muted-foreground space-y-1">
-          <div v-for="(file, i) in selectedFiles" :key="i" class="flex items-center gap-1">
-            <span>{{ file.name }}</span>
-            <span class="text-muted-foreground/50">({{ (file.size / 1024).toFixed(1) }} KB)</span>
-          </div>
         </div>
 
         <!-- 操作按钮 -->
@@ -307,11 +256,11 @@ function onOpenChange(val: boolean) {
             跳过，按原样导入
           </Button>
           <Button
-            :disabled="isUploadingBatch || selectedPaths.size === 0"
+            :disabled="isUploading || selectedPaths.size === 0 || matchedCount === 0"
             @click="handleUpload"
           >
-            <Loader2 v-if="isUploadingBatch" class="mr-2 h-4 w-4 animate-spin" />
-            {{ isUploadingBatch ? '上传中...' : '上传选中的图片' }}
+            <Loader2 v-if="isUploading" class="mr-2 h-4 w-4 animate-spin" />
+            {{ isUploading ? '上传中...' : '上传选中的图片' }}
           </Button>
           <Button
             v-if="Object.keys(uploadResults).length > 0"

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -132,11 +132,18 @@ async function handleUpload() {
   uploadErrors.value = {}
   isUploading.value = true
 
+  // 文件 → URL 缓存，避免同文件重复上传
+  const fileUrlMap = new WeakMap<File, string>()
+
   for (let i = 0; i < pathsToUpload.length; i++) {
     const path = pathsToUpload[i]!
     try {
       const file = findMatchedFile(path)!
-      const url = await upload(file)
+      let url = fileUrlMap.get(file)
+      if (!url) {
+        url = await upload(file)
+        fileUrlMap.set(file, url)
+      }
       uploadResults.value[path] = url
     }
     catch (err: unknown) {
@@ -152,13 +159,13 @@ function handleApply() {
   if (!uiStore.localImageUploadData)
     return
 
-  // 替换 Markdown 中的路径
+  // 仅替换图片语法 `![alt](path)`，避免误改普通链接
   let content = uiStore.localImageUploadData.markdownContent
   for (const [path, url] of Object.entries(uploadResults.value)) {
     const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     content = content
-      .replace(new RegExp(`\\]\\(${escaped}\\)`, 'g'), `](${url})`)
-      .replace(new RegExp(`\\]\\(\\.\\/${escaped}\\)`, 'g'), `](${url})`)
+      .replace(new RegExp(`!\\]\\(${escaped}\\)`, 'g'), `!](${url})`)
+      .replace(new RegExp(`!\\]\\(\\.\\/${escaped}\\)`, 'g'), `!](${url})`)
   }
 
   uiStore.localImageUploadData = {
@@ -223,6 +230,7 @@ function onOpenChange(val: boolean) {
               <input
                 type="checkbox"
                 :checked="selectedPaths.has(path)"
+                :aria-label="path"
                 class="h-3.5 w-3.5 shrink-0 accent-primary"
                 @change="selectedPaths.has(path) ? selectedPaths.delete(path) : selectedPaths.add(path)"
               >

--- a/apps/web/src/components/editor/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/LocalImageUploadDialog.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import { Check, FileImage, Loader2, Upload, X } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { progress as Progress } from '@/components/ui/progress'
+import { useImageUploader } from '@/composables/useImageUploader'
+import { useUIStore } from '@/stores/ui'
+
+const uiStore = useUIStore()
+const { upload } = useImageUploader()
+
+const isDialogOpen = computed({
+  get: () => uiStore.isShowLocalImageUpload,
+  set: (val) => {
+    uiStore.isShowLocalImageUpload = val
+  },
+})
+
+// 用户勾选要上传的路径
+const selectedPaths = ref<Set<string>>(new Set())
+
+// 上传进度
+const progressValue = ref(0)
+const uploadResults = ref<Record<string, string>>({})
+const uploadErrors = ref<Record<string, string>>({})
+const isUploadingBatch = ref(false)
+
+// 用户选择的文件列表（按选择顺序，与勾选的路径一一对应）
+const selectedFiles = ref<File[]>([])
+
+watch(() => uiStore.localImageUploadData, (data) => {
+  if (data) {
+    selectedPaths.value = new Set(data.detectedPaths)
+    progressValue.value = 0
+    uploadResults.value = {}
+    uploadErrors.value = {}
+    isUploadingBatch.value = false
+    selectedFiles.value = []
+  }
+}, { immediate: true })
+
+/**
+ * 根据文件名自动匹配路径
+ * 将匹配到的文件自动关联到对应的路径上
+ */
+function autoMatchFiles() {
+  if (!uiStore.localImageUploadData || selectedFiles.value.length === 0)
+    return
+
+  const fileArray = selectedFiles.value
+  const paths = uiStore.localImageUploadData.detectedPaths
+  const pathIndexMap = new Map<string, number>()
+
+  // 第一轮：精确匹配（文件名相同）
+  const usedFileIndices = new Set<number>()
+  for (const path of paths) {
+    if (pathIndexMap.has(path))
+      continue
+    const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase()
+    for (let fi = 0; fi < fileArray.length; fi++) {
+      if (usedFileIndices.has(fi))
+        continue
+      if (fileArray[fi]!.name.toLowerCase() === pathFileName) {
+        pathIndexMap.set(path, fi)
+        usedFileIndices.add(fi)
+        break
+      }
+    }
+  }
+
+  // 第二轮：模糊匹配（文件名包含或去掉扩展名匹配）
+  for (const path of paths) {
+    if (pathIndexMap.has(path))
+      continue
+    const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase().replace(/\.[^.]+$/, '')
+    for (let fi = 0; fi < fileArray.length; fi++) {
+      if (usedFileIndices.has(fi))
+        continue
+      const fileBase = fileArray[fi]!.name.toLowerCase().replace(/\.[^.]+$/, '')
+      if (pathFileName === fileBase) {
+        pathIndexMap.set(path, fi)
+        usedFileIndices.add(fi)
+        break
+      }
+    }
+  }
+
+  // 将匹配到的路径自动选中
+  for (const path of pathIndexMap.keys()) {
+    selectedPaths.value.add(path)
+  }
+
+  // 重置 input
+  const input = document.getElementById('local-image-file-input') as HTMLInputElement
+  if (input)
+    input.value = ''
+}
+
+// 选择文件
+function handleFileSelect(event: Event) {
+  const files = (event.target as HTMLInputElement).files
+  if (!files || files.length === 0)
+    return
+
+  // 追加新选择的文件
+  const existing = Array.from(selectedFiles.value)
+  selectedFiles.value = [...existing, ...Array.from(files)]
+
+  // 自动匹配
+  autoMatchFiles()
+}
+
+// 开始上传
+async function handleUpload() {
+  if (!uiStore.localImageUploadData)
+    return
+
+  const pathsToUpload = Array.from(selectedPaths.value)
+  const total = pathsToUpload.length
+  if (total === 0) {
+    toast.warning('请至少勾选一项')
+    return
+  }
+
+  isUploadingBatch.value = true
+  progressValue.value = 0
+  uploadResults.value = {}
+  uploadErrors.value = {}
+
+  for (let i = 0; i < pathsToUpload.length; i++) {
+    const path = pathsToUpload[i]!
+    try {
+      let url: string
+      const matchedFile = findMatchedFile(path)
+      if (matchedFile) {
+        // 有匹配的文件，直接上传
+        url = await upload(matchedFile)
+      }
+      else {
+        // 没有匹配的文件，但用户勾选了，说明用户想自己上传
+        toast.error(`路径 "${path}" 未找到对应文件`)
+        uploadErrors.value[path] = '未选择对应文件'
+        progressValue.value = Math.round(((i + 1) / total) * 100)
+        continue
+      }
+      uploadResults.value[path] = url
+    }
+    catch (err: unknown) {
+      uploadErrors.value[path] = (err as Error).message || '上传失败'
+    }
+    progressValue.value = Math.round(((i + 1) / total) * 100)
+  }
+
+  isUploadingBatch.value = false
+}
+
+function findMatchedFile(path: string): File | undefined {
+  const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase()
+  const fileArray = selectedFiles.value
+  // 精确匹配
+  for (const file of fileArray) {
+    if (file.name.toLowerCase() === pathFileName)
+      return file
+  }
+  // 模糊匹配（去扩展名）
+  const pathBase = pathFileName.replace(/\.[^.]+$/, '')
+  for (const file of fileArray) {
+    const fileBase = file.name.toLowerCase().replace(/\.[^.]+$/, '')
+    if (fileBase === pathBase)
+      return file
+  }
+  return undefined
+}
+
+// 关闭并应用
+function handleApply() {
+  if (!uiStore.localImageUploadData)
+    return
+
+  // 替换 Markdown 中的路径
+  let content = uiStore.localImageUploadData.markdownContent
+  for (const [path, url] of Object.entries(uploadResults.value)) {
+    // 替换 ](path) 和 ](./path) 两种形式
+    const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    content = content
+      .replace(new RegExp(`\\]\\(${escaped}\\)`, 'g'), `](${url})`)
+      .replace(new RegExp(`\\]\\(\\.\\/${escaped}\\)`, 'g'), `](${url})`)
+  }
+
+  // 触发后续处理（设置内容等）
+  uiStore.localImageUploadData = {
+    markdownContent: content,
+    detectedPaths: [],
+    processed: true,
+  }
+  isDialogOpen.value = false
+}
+
+// 关闭并跳过上传
+function handleSkip() {
+  if (uiStore.localImageUploadData) {
+    uiStore.localImageUploadData = {
+      ...uiStore.localImageUploadData,
+      processed: true,
+      skipUpload: true,
+    }
+  }
+  isDialogOpen.value = false
+}
+
+function onOpenChange(val: boolean) {
+  if (!val) {
+    isDialogOpen.value = false
+    uiStore.localImageUploadData = null
+  }
+}
+</script>
+
+<template>
+  <Dialog :open="isDialogOpen" @update:open="onOpenChange">
+    <DialogContent class="sm:max-w-lg">
+      <DialogHeader>
+        <DialogTitle>检测到本地图片</DialogTitle>
+        <DialogDescription>
+          文档中包含本地图片路径，请选择对应文件并上传到图床。
+        </DialogDescription>
+      </DialogHeader>
+
+      <div v-if="uiStore.localImageUploadData" class="space-y-4">
+        <!-- 图片路径列表 -->
+        <div class="rounded-md border">
+          <div class="flex items-center justify-between border-b px-4 py-2">
+            <span class="text-sm font-medium">
+              检测到 {{ uiStore.localImageUploadData.detectedPaths.length }} 张本地图片
+            </span>
+            <span class="text-xs text-muted-foreground">
+              已选择 {{ selectedFiles.length }} 个文件
+            </span>
+          </div>
+          <div class="max-h-48 overflow-auto p-2">
+            <div
+              v-for="path in uiStore.localImageUploadData.detectedPaths"
+              :key="path"
+              class="flex items-center gap-2 rounded px-2 py-1.5 text-xs"
+              :class="{
+                'bg-primary/5': selectedPaths.has(path),
+                'text-muted-foreground': !selectedPaths.has(path),
+              }"
+            >
+              <input
+                type="checkbox"
+                :checked="selectedPaths.has(path)"
+                class="h-3.5 w-3.5 shrink-0 accent-primary"
+                @change="selectedPaths.has(path) ? selectedPaths.delete(path) : selectedPaths.add(path)"
+              >
+              <FileImage class="h-3.5 w-3.5 shrink-0" />
+              <span class="truncate" :title="path">{{ path }}</span>
+              <span v-if="uploadResults[path]" class="ml-auto shrink-0 text-green-600">
+                <Check class="h-3.5 w-3.5" />
+              </span>
+              <span v-else-if="uploadErrors[path]" class="ml-auto shrink-0 text-destructive" :title="uploadErrors[path]">
+                <X class="h-3.5 w-3.5" />
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 进度条 -->
+        <Progress v-if="isUploadingBatch || progressValue > 0" :model-value="progressValue" class="h-1.5" />
+
+        <!-- 选择文件按钮 -->
+        <div class="flex items-center gap-2">
+          <label class="flex-1">
+            <input
+              id="local-image-file-input"
+              type="file"
+              multiple
+              accept="image/*"
+              class="hidden"
+              @change="handleFileSelect"
+            >
+            <Button variant="outline" class="w-full" as="span">
+              <Upload class="mr-2 h-4 w-4" />
+              选择图片文件{{ selectedFiles.length > 0 ? `（已选 ${selectedFiles.length} 个）` : '' }}
+            </Button>
+          </label>
+        </div>
+
+        <!-- 已选文件列表 -->
+        <div v-if="selectedFiles.length > 0" class="text-xs text-muted-foreground space-y-1">
+          <div v-for="(file, i) in selectedFiles" :key="i" class="flex items-center gap-1">
+            <span>{{ file.name }}</span>
+            <span class="text-muted-foreground/50">({{ (file.size / 1024).toFixed(1) }} KB)</span>
+          </div>
+        </div>
+
+        <!-- 操作按钮 -->
+        <DialogFooter class="gap-2 sm:gap-0">
+          <Button variant="outline" @click="handleSkip">
+            跳过，按原样导入
+          </Button>
+          <Button
+            :disabled="isUploadingBatch || selectedPaths.size === 0"
+            @click="handleUpload"
+          >
+            <Loader2 v-if="isUploadingBatch" class="mr-2 h-4 w-4 animate-spin" />
+            {{ isUploadingBatch ? '上传中...' : '上传选中的图片' }}
+          </Button>
+          <Button
+            v-if="Object.keys(uploadResults).length > 0"
+            @click="handleApply"
+          >
+            应用并导入
+          </Button>
+        </DialogFooter>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -107,6 +107,19 @@ export const useUIStore = defineStore(`ui`, () => {
   /** 通过 URL 参数 open 打开时传入的待导入链接，对话框打开后会据此自动执行导入 */
   const importMdOpenUrl = ref<string | null>(null)
 
+  // 是否展示本地图片上传对话框
+  const isShowLocalImageUpload = ref(false)
+  const toggleShowLocalImageUpload = useToggle(isShowLocalImageUpload)
+  /** 待处理的本地图片上传数据 */
+  const localImageUploadData = ref<{
+    markdownContent: string
+    detectedPaths: string[]
+    processed?: boolean
+    skipUpload?: boolean
+    successCount?: number
+    failCount?: number
+  } | null>(null)
+
   // 是否展示模板管理对话框
   const isShowTemplateDialog = ref(false)
   const toggleShowTemplateDialog = useToggle(isShowTemplateDialog)
@@ -196,6 +209,9 @@ export const useUIStore = defineStore(`ui`, () => {
     isShowImportMdDialog,
     toggleShowImportMdDialog,
     importMdOpenUrl,
+    isShowLocalImageUpload,
+    toggleShowLocalImageUpload,
+    localImageUploadData,
     isShowTemplateDialog,
     toggleShowTemplateDialog,
     aiDialogVisible,

--- a/apps/web/src/views/CodemirrorEditor.vue
+++ b/apps/web/src/views/CodemirrorEditor.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import EditorPanel from '@/components/editor/EditorPanel.vue'
-import FormulaEditorDialog from '@/components/editor/FormulaEditorDialog.vue'
 import FolderSourcePanel from '@/components/editor/FolderSourcePanel.vue'
+import FormulaEditorDialog from '@/components/editor/FormulaEditorDialog.vue'
+import LocalImageUploadDialog from '@/components/editor/LocalImageUploadDialog.vue'
 import PreviewPanel from '@/components/editor/PreviewPanel.vue'
 import {
   ResizableHandle,
@@ -251,6 +252,8 @@ onUnmounted(() => {
       <InsertMpCardDialog />
 
       <ImportMarkdownDialog />
+
+      <LocalImageUploadDialog />
 
       <FormulaEditorDialog />
 


### PR DESCRIPTION
## Summary
Fix for #1576 — 导入 Markdown 时自动检测本地图片路径并提供上传功能

### Changes
- **New component**: `LocalImageUploadDialog.vue` — 检测到本地图片时弹出对话框，列出路径、自动匹配文件、支持批量上传
- **Modified**: `ImportMarkdownDialog.vue` — 导入后扫描 `![](path)` 语法，排除 http/https/data URI，发现本地路径后触发上传对话框
- **Modified**: `ui.ts` — 新增 `isShowLocalImageUpload` 和 `localImageUploadData` 状态
- **Modified**: `CodemirrorEditor.vue` — 注册新对话框组件

### How it works
1. 导入 Markdown（文件或 URL）后自动扫描本地图片路径
2. 弹出对话框列出所有检测到的路径（如 `images/Knight.gif`、`./images/how-to-contribute.png`）
3. 用户选择对应图片文件，系统自动按文件名匹配路径
4. 上传到已配置的图床，替换 Markdown 中的本地路径为远程 URL
5. 用户也可选择"跳过"，按原样导入

## Test plan
- [ ] 导入含本地图片的 Markdown，确认弹出对话框
- [ ] 选择对应图片文件，确认自动匹配并上传成功
- [ ] 确认导入后的 Markdown 中图片路径已替换
- [ ] 选择"跳过"确认按原样导入
- [ ] 导入不含本地图片的 Markdown，确认直接导入无弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)