### PR TITLE
feat: add slash command support for quick content insertion

### DIFF
--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -6,8 +6,10 @@ import { EditorView } from '@codemirror/view'
 import { markdownSetup, theme } from '@md/shared/editor'
 import imageCompression from 'browser-image-compression'
 import { SidebarAIToolbar } from '@/components/ai'
+import SlashCommandMenu from '@/components/editor/SlashCommandMenu.vue'
 import { SearchTab } from '@/components/ui/search-tab'
 import { useImageUploader } from '@/composables/useImageUploader'
+import { useSlashCommand } from '@/composables/useSlashCommand'
 import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
@@ -23,6 +25,8 @@ const renderStore = useRenderStore()
 const themeStore = useThemeStore()
 const uiStore = useUIStore()
 const { upload } = useImageUploader()
+
+const slashCommand = useSlashCommand()
 
 const { editor } = storeToRefs(editorStore)
 const { isDark } = storeToRefs(uiStore)
@@ -455,6 +459,7 @@ function createFormTextArea(dom: HTMLDivElement) {
       EditorView.domEventHandlers({
         paste: createPasteHandler(),
       }),
+      ...slashCommand.createExtension(() => codeMirrorView.value),
     ],
   })
 
@@ -564,6 +569,17 @@ defineExpose({
     class="codeMirror-wrapper relative h-full"
   >
     <SearchTab v-if="codeMirrorView" ref="searchTabRef" :editor-view="codeMirrorView as any" />
+    <SlashCommandMenu
+      :visible="slashCommand.visible.value"
+      :position="slashCommand.position.value"
+      :active-index="slashCommand.activeIndex.value"
+      :basic-commands="slashCommand.basicCommands.value"
+      :common-commands="slashCommand.commonCommands.value"
+      :filtered-commands="slashCommand.filteredCommands.value"
+      :editor-view="codeMirrorView"
+      @execute="(cmd) => codeMirrorView && slashCommand.executeCommand(codeMirrorView, cmd)"
+      @close="slashCommand.closeMenu()"
+    />
     <SidebarAIToolbar
       :is-mobile="isMobile"
       :show-editor="showEditor"

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -576,7 +576,6 @@ defineExpose({
       :basic-commands="slashCommand.basicCommands.value"
       :common-commands="slashCommand.commonCommands.value"
       :filtered-commands="slashCommand.filteredCommands.value"
-      :editor-view="codeMirrorView"
       @execute="(cmd) => codeMirrorView && slashCommand.executeCommand(codeMirrorView, cmd)"
       @close="slashCommand.closeMenu()"
     />

--- a/apps/web/src/components/editor/SlashCommandMenu.vue
+++ b/apps/web/src/components/editor/SlashCommandMenu.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { EditorView } from '@codemirror/view'
 import type { SlashCommandItem } from '@/composables/useSlashCommand'
 import {
   Braces,
@@ -26,7 +25,6 @@ const props = defineProps<{
   basicCommands: SlashCommandItem[]
   commonCommands: SlashCommandItem[]
   filteredCommands: SlashCommandItem[]
-  editorView: EditorView | null
 }>()
 
 const emit = defineEmits<{
@@ -194,19 +192,10 @@ function getGlobalIndex(command: SlashCommandItem): number {
             @mousedown.prevent="emit('execute', cmd)"
           >
             <span class="slash-common-icon">
-              <!-- Special icons for markdown and callout -->
+              <!-- Special icon for markdown -->
               <template v-if="cmd.id === 'markdown'">
                 <svg viewBox="0 0 24 24" class="w-4 h-4" fill="currentColor" aria-hidden="true">
                   <path d="M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12C21.35 6 22 6.63 22 7.41v9.18c0 .78-.65 1.41-1.44 1.41zM7 15V9l2 2 2-2v6h2V9l2 2 2-2v6h1V9h-1l-2 2-2-2H9L7 9v6H6V9H5v6h2z" />
-                </svg>
-              </template>
-              <template v-else-if="cmd.id === 'callout'">
-                <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                  <line x1="16" y1="13" x2="8" y2="13" />
-                  <line x1="16" y1="17" x2="8" y2="17" />
-                  <polyline points="10 9 9 9 8 9" />
                 </svg>
               </template>
               <component :is="iconMap[cmd.icon]" v-else-if="iconMap[cmd.icon]" class="w-4 h-4" />

--- a/apps/web/src/components/editor/SlashCommandMenu.vue
+++ b/apps/web/src/components/editor/SlashCommandMenu.vue
@@ -1,0 +1,408 @@
+<script setup lang="ts">
+import type { EditorView } from '@codemirror/view'
+import type { SlashCommandItem } from '@/composables/useSlashCommand'
+import {
+  Braces,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  Image,
+  Link,
+  List,
+  ListOrdered,
+  Minus,
+  Quote,
+  Sigma,
+  Table,
+} from 'lucide-vue-next'
+
+const props = defineProps<{
+  visible: boolean
+  position: { x: number, y: number }
+  activeIndex: number
+  basicCommands: SlashCommandItem[]
+  commonCommands: SlashCommandItem[]
+  filteredCommands: SlashCommandItem[]
+  editorView: EditorView | null
+}>()
+
+const emit = defineEmits<{
+  execute: [command: SlashCommandItem]
+  close: []
+}>()
+
+// Map icon names to lucide components
+const iconMap: Record<string, any> = {
+  'H1': Heading1,
+  'H2': Heading2,
+  'H3': Heading3,
+  'H4': Heading4,
+  'H5': Heading5,
+  'H6': Heading6,
+  'ordered-list': ListOrdered,
+  'unordered-list': List,
+  'blockquote': Quote,
+  'divider': Minus,
+  'link': Link,
+  'code': Braces,
+  'formula': Sigma,
+  'image': Image,
+  'table': Table,
+}
+
+// Heading items use text labels in the grid; others use icon + label in list
+const headingIds = [`h1`, `h2`, `h3`, `h4`, `h5`, `h6`]
+
+const menuRef = useTemplateRef<HTMLDivElement>(`menuRef`)
+
+// Calculate adjusted position so the menu stays in viewport
+const adjustedPosition = computed(() => {
+  const MENU_HEIGHT = 320
+  const MENU_WIDTH = 240
+  const PADDING = 8
+
+  let { x, y } = props.position
+
+  // Adjust horizontal
+  if (x + MENU_WIDTH > window.innerWidth - PADDING) {
+    x = window.innerWidth - MENU_WIDTH - PADDING
+  }
+  if (x < PADDING) {
+    x = PADDING
+  }
+
+  // Adjust vertical — prefer below cursor, flip above if insufficient space
+  if (y + MENU_HEIGHT > window.innerHeight - PADDING) {
+    // Position above cursor (need cursor top, approximate with -24px offset)
+    y = y - MENU_HEIGHT - 28
+  }
+
+  return { x, y }
+})
+
+// Close on outside click
+function handleOutsideClick(e: MouseEvent) {
+  if (menuRef.value && !menuRef.value.contains(e.target as Node)) {
+    emit(`close`)
+  }
+}
+
+watch(
+  () => props.visible,
+  (val) => {
+    if (val) {
+      nextTick(() => {
+        document.addEventListener(`mousedown`, handleOutsideClick)
+        scrollActiveIntoView()
+      })
+    }
+    else {
+      document.removeEventListener(`mousedown`, handleOutsideClick)
+    }
+  },
+)
+
+onUnmounted(() => {
+  document.removeEventListener(`mousedown`, handleOutsideClick)
+})
+
+// Scroll active item into view when navigating
+watch(
+  () => props.activeIndex,
+  () => {
+    scrollActiveIntoView()
+  },
+)
+
+function scrollActiveIntoView() {
+  nextTick(() => {
+    const el = menuRef.value?.querySelector(`[data-active="true"]`)
+    el?.scrollIntoView({ block: `nearest` })
+  })
+}
+
+function getGlobalIndex(command: SlashCommandItem): number {
+  return props.filteredCommands.indexOf(command)
+}
+</script>
+
+<template>
+  <Transition name="slash-menu">
+    <div
+      v-if="visible"
+      ref="menuRef"
+      class="slash-command-menu"
+      :style="{
+        left: `${adjustedPosition.x}px`,
+        top: `${adjustedPosition.y}px`,
+      }"
+    >
+      <!-- Basic group -->
+      <template v-if="basicCommands.length > 0">
+        <div class="slash-group-label">
+          基础
+          <span class="slash-group-count">{{ basicCommands.length }}</span>
+        </div>
+        <!-- Heading grid row -->
+        <div v-if="basicCommands.some(c => headingIds.includes(c.id))" class="slash-heading-grid">
+          <button
+            v-for="cmd in basicCommands.filter(c => headingIds.includes(c.id))"
+            :key="cmd.id"
+            class="slash-heading-btn"
+            :class="{ active: getGlobalIndex(cmd) === activeIndex }"
+            :data-active="getGlobalIndex(cmd) === activeIndex"
+            @mousedown.prevent="emit('execute', cmd)"
+          >
+            {{ cmd.label }}
+          </button>
+        </div>
+        <!-- Non-heading basic items grid -->
+        <div class="slash-misc-grid">
+          <button
+            v-for="cmd in basicCommands.filter(c => !headingIds.includes(c.id))"
+            :key="cmd.id"
+            class="slash-misc-btn"
+            :class="{ active: getGlobalIndex(cmd) === activeIndex }"
+            :data-active="getGlobalIndex(cmd) === activeIndex"
+            @mousedown.prevent="emit('execute', cmd)"
+          >
+            <span class="slash-misc-icon">
+              <component :is="iconMap[cmd.icon]" v-if="iconMap[cmd.icon]" class="w-4 h-4" />
+            </span>
+            <span class="slash-misc-label">{{ cmd.label }}</span>
+          </button>
+        </div>
+        <div v-if="commonCommands.length > 0" class="slash-separator" />
+      </template>
+
+      <!-- Common group -->
+      <template v-if="commonCommands.length > 0">
+        <div class="slash-group-label">
+          常用
+          <span class="slash-group-count">{{ commonCommands.length }}</span>
+        </div>
+        <div class="slash-common-list">
+          <button
+            v-for="cmd in commonCommands"
+            :key="cmd.id"
+            class="slash-common-item"
+            :class="{ active: getGlobalIndex(cmd) === activeIndex }"
+            :data-active="getGlobalIndex(cmd) === activeIndex"
+            @mousedown.prevent="emit('execute', cmd)"
+          >
+            <span class="slash-common-icon">
+              <!-- Special icons for markdown and callout -->
+              <template v-if="cmd.id === 'markdown'">
+                <svg viewBox="0 0 24 24" class="w-4 h-4" fill="currentColor" aria-hidden="true">
+                  <path d="M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12C21.35 6 22 6.63 22 7.41v9.18c0 .78-.65 1.41-1.44 1.41zM7 15V9l2 2 2-2v6h2V9l2 2 2-2v6h1V9h-1l-2 2-2-2H9L7 9v6H6V9H5v6h2z" />
+                </svg>
+              </template>
+              <template v-else-if="cmd.id === 'callout'">
+                <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="16" y1="13" x2="8" y2="13" />
+                  <line x1="16" y1="17" x2="8" y2="17" />
+                  <polyline points="10 9 9 9 8 9" />
+                </svg>
+              </template>
+              <component :is="iconMap[cmd.icon]" v-else-if="iconMap[cmd.icon]" class="w-4 h-4" />
+            </span>
+            <span class="slash-common-label">{{ cmd.label }}</span>
+          </button>
+        </div>
+      </template>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.slash-command-menu {
+  position: fixed;
+  z-index: 9999;
+  width: 240px;
+  border-radius: 10px;
+  border: 1px solid hsl(var(--border));
+  background-color: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 6px;
+  font-size: 13px;
+}
+
+.slash-group-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.slash-group-count {
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  border-radius: 10px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+/* ── Heading grid ── */
+.slash-heading-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 3px;
+  padding: 2px 2px 4px;
+}
+
+.slash-heading-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  border-radius: 6px;
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: hsl(var(--foreground));
+  transition: background 0.12s;
+  outline: none;
+}
+
+.slash-heading-btn:hover,
+.slash-heading-btn.active {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+/* ── Misc grid (ordered/unordered list, quote, divider) ── */
+.slash-misc-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 3px;
+  padding: 2px 2px 4px;
+}
+
+.slash-misc-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  height: 52px;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: hsl(var(--foreground));
+  transition: background 0.12s;
+  outline: none;
+}
+
+.slash-misc-btn:hover,
+.slash-misc-btn.active {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.slash-misc-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--foreground));
+}
+
+.slash-misc-label {
+  font-size: 10px;
+  color: hsl(var(--muted-foreground));
+  white-space: nowrap;
+}
+
+.slash-misc-btn:hover .slash-misc-label,
+.slash-misc-btn.active .slash-misc-label {
+  color: hsl(var(--accent-foreground));
+}
+
+.slash-separator {
+  height: 1px;
+  background: hsl(var(--border));
+  margin: 4px 4px;
+}
+
+/* ── Common list ── */
+.slash-common-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px;
+}
+
+.slash-common-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: hsl(var(--foreground));
+  text-align: left;
+  width: 100%;
+  transition: background 0.12s;
+  outline: none;
+}
+
+.slash-common-item:hover,
+.slash-common-item.active {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.slash-common-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s;
+}
+
+.slash-common-item:hover .slash-common-icon,
+.slash-common-item.active .slash-common-icon {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+.slash-common-label {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* ── Transition ── */
+.slash-menu-enter-active,
+.slash-menu-leave-active {
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.slash-menu-enter-from,
+.slash-menu-leave-to {
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+}
+</style>

--- a/apps/web/src/composables/useSlashCommand.ts
+++ b/apps/web/src/composables/useSlashCommand.ts
@@ -172,7 +172,7 @@ export function useSlashCommand() {
         const cursor = view.state.selection.main.head
         view.dispatch({
           changes: { from: cursor, to: cursor, insert: text },
-          selection: { anchor: cursor + 11 },
+          selection: { anchor: cursor + 12 },
         })
         view.focus()
       },

--- a/apps/web/src/composables/useSlashCommand.ts
+++ b/apps/web/src/composables/useSlashCommand.ts
@@ -1,0 +1,382 @@
+import type { EditorView as EditorViewType } from '@codemirror/view'
+import { Prec } from '@codemirror/state'
+import { EditorView, keymap } from '@codemirror/view'
+import { useUIStore } from '@/stores/ui'
+
+export interface SlashCommandItem {
+  id: string
+  label: string
+  group: 'basic' | 'common'
+  groupLabel: string
+  keywords: string[]
+  icon: string
+  action: (view: EditorViewType) => void
+}
+
+function insertText(view: EditorViewType, text: string, cursorOffset?: number) {
+  const cursor = view.state.selection.main.head
+  const offset = cursorOffset !== undefined ? cursorOffset : text.length
+  view.dispatch({
+    changes: { from: cursor, to: cursor, insert: text },
+    selection: { anchor: cursor + offset },
+  })
+  view.focus()
+}
+
+export function useSlashCommand() {
+  const uiStore = useUIStore()
+
+  const visible = ref(false)
+  const position = ref({ x: 0, y: 0 })
+  const filter = ref(``)
+  const activeIndex = ref(0)
+  const slashFrom = ref(-1)
+
+  const allCommands: SlashCommandItem[] = [
+    // ────── 基础 ──────
+    {
+      id: `h1`,
+      label: `H1`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`h1`, `heading1`, `一级`, `标题`],
+      icon: `H1`,
+      action: view => insertText(view, `# `),
+    },
+    {
+      id: `h2`,
+      label: `H2`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`h2`, `heading2`, `二级`, `标题`],
+      icon: `H2`,
+      action: view => insertText(view, `## `),
+    },
+    {
+      id: `h3`,
+      label: `H3`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`h3`, `heading3`, `三级`, `标题`],
+      icon: `H3`,
+      action: view => insertText(view, `### `),
+    },
+    {
+      id: `h4`,
+      label: `H4`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`h4`, `heading4`, `四级`, `标题`],
+      icon: `H4`,
+      action: view => insertText(view, `#### `),
+    },
+    {
+      id: `h5`,
+      label: `H5`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`h5`, `heading5`, `五级`, `标题`],
+      icon: `H5`,
+      action: view => insertText(view, `##### `),
+    },
+    {
+      id: `h6`,
+      label: `H6`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`h6`, `heading6`, `六级`, `标题`],
+      icon: `H6`,
+      action: view => insertText(view, `###### `),
+    },
+    {
+      id: `ordered-list`,
+      label: `有序列表`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`ol`, `ordered`, `有序`, `列表`, `numbered`],
+      icon: `ordered-list`,
+      action: view => insertText(view, `1. `),
+    },
+    {
+      id: `unordered-list`,
+      label: `无序列表`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`ul`, `unordered`, `无序`, `列表`, `bullet`],
+      icon: `unordered-list`,
+      action: view => insertText(view, `- `),
+    },
+    {
+      id: `blockquote`,
+      label: `引用`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`quote`, `引用`, `blockquote`],
+      icon: `blockquote`,
+      action: view => insertText(view, `> `),
+    },
+    {
+      id: `divider`,
+      label: `分割线`,
+      group: `basic`,
+      groupLabel: `基础`,
+      keywords: [`hr`, `divider`, `分割线`, `---`, `横线`],
+      icon: `divider`,
+      action: view => insertText(view, `\n---\n`),
+    },
+    // ────── 常用 ──────
+    {
+      id: `link`,
+      label: `链接`,
+      group: `common`,
+      groupLabel: `常用`,
+      keywords: [`link`, `链接`, `url`, `href`, `a`],
+      icon: `link`,
+      action: (view) => {
+        // Insert [文字](链接) with cursor selecting "文字"
+        const text = `[链接文字](https://)`
+        const cursor = view.state.selection.main.head
+        view.dispatch({
+          changes: { from: cursor, to: cursor, insert: text },
+          selection: { anchor: cursor + 1, head: cursor + 5 },
+        })
+        view.focus()
+      },
+    },
+    {
+      id: `code-block`,
+      label: `代码块`,
+      group: `common`,
+      groupLabel: `常用`,
+      keywords: [`code`, `代码块`, `\`\`\``, `codeblock`, `fence`],
+      icon: `code`,
+      action: (view) => {
+        const text = `\`\`\`\n\n\`\`\``
+        const cursor = view.state.selection.main.head
+        view.dispatch({
+          changes: { from: cursor, to: cursor, insert: text },
+          selection: { anchor: cursor + 4 },
+        })
+        view.focus()
+      },
+    },
+    {
+      id: `markdown`,
+      label: `Markdown`,
+      group: `common`,
+      groupLabel: `常用`,
+      keywords: [`markdown`, `md`, `raw`],
+      icon: `markdown`,
+      action: (view) => {
+        const text = `\`\`\`markdown\n\n\`\`\``
+        const cursor = view.state.selection.main.head
+        view.dispatch({
+          changes: { from: cursor, to: cursor, insert: text },
+          selection: { anchor: cursor + 11 },
+        })
+        view.focus()
+      },
+    },
+    {
+      id: `formula`,
+      label: `公式块`,
+      group: `common`,
+      groupLabel: `常用`,
+      keywords: [`formula`, `公式`, `math`, `latex`, `$$`, `katex`],
+      icon: `formula`,
+      action: () => {
+        uiStore.openFormulaEditor({ value: ``, displayMode: true })
+      },
+    },
+    {
+      id: `image`,
+      label: `图片`,
+      group: `common`,
+      groupLabel: `常用`,
+      keywords: [`image`, `图片`, `img`, `photo`, `picture`],
+      icon: `image`,
+      action: () => {
+        uiStore.toggleShowUploadImgDialog()
+      },
+    },
+    {
+      id: `table`,
+      label: `表格`,
+      group: `common`,
+      groupLabel: `常用`,
+      keywords: [`table`, `表格`, `grid`],
+      icon: `table`,
+      action: () => {
+        uiStore.toggleShowInsertFormDialog()
+      },
+    },
+  ]
+
+  const filteredCommands = computed(() => {
+    const f = filter.value.toLowerCase().trim()
+    if (!f)
+      return allCommands
+    return allCommands.filter(
+      cmd =>
+        cmd.label.toLowerCase().includes(f)
+        || cmd.id.toLowerCase().includes(f)
+        || cmd.keywords.some(k => k.toLowerCase().includes(f)),
+    )
+  })
+
+  const basicCommands = computed(() => filteredCommands.value.filter(c => c.group === `basic`))
+  const commonCommands = computed(() => filteredCommands.value.filter(c => c.group === `common`))
+
+  function openMenu(view: EditorViewType, from: number) {
+    const coords = view.coordsAtPos(from)
+    if (!coords)
+      return
+    slashFrom.value = from
+    filter.value = ``
+    activeIndex.value = 0
+    position.value = { x: coords.left, y: coords.bottom }
+    visible.value = true
+  }
+
+  function closeMenu() {
+    visible.value = false
+    filter.value = ``
+    slashFrom.value = -1
+  }
+
+  function executeCommand(view: EditorViewType, command: SlashCommandItem) {
+    const from = slashFrom.value
+    if (from < 0)
+      return
+    const cursor = view.state.selection.main.head
+    // Remove the "/" + filter text before executing
+    view.dispatch({
+      changes: { from, to: cursor, insert: `` },
+    })
+    closeMenu()
+    command.action(view)
+  }
+
+  function selectNext() {
+    const total = filteredCommands.value.length
+    if (total === 0)
+      return
+    activeIndex.value = (activeIndex.value + 1) % total
+  }
+
+  function selectPrev() {
+    const total = filteredCommands.value.length
+    if (total === 0)
+      return
+    activeIndex.value = (activeIndex.value - 1 + total) % total
+  }
+
+  function createExtension(getView: () => EditorViewType | null) {
+    return [
+      EditorView.updateListener.of((update) => {
+        if (!update.docChanged)
+          return
+
+        const state = update.state
+        const cursor = state.selection.main.head
+
+        if (!visible.value) {
+          // Check if "/" was just typed at the cursor position
+          update.changes.iterChanges((_fromA, _toA, fromB, _toB, inserted) => {
+            if (inserted.length === 1 && inserted.toString() === `/`) {
+              // Only trigger slash command when:
+              // - at start of line, or
+              // - preceded by whitespace/newline
+              const line = state.doc.lineAt(fromB)
+              const charBefore = fromB > line.from ? state.doc.sliceString(fromB - 1, fromB) : ``
+              const isAtLineStart = fromB === line.from
+              const isPrecededBySpace = charBefore === ` ` || charBefore === ``
+              if (isAtLineStart || isPrecededBySpace) {
+                const view = getView()
+                if (view)
+                  openMenu(view, fromB)
+              }
+            }
+          })
+        }
+        else {
+          // Menu is visible — update filter based on text between slashFrom and cursor
+          const from = slashFrom.value
+          if (from < 0 || cursor < from) {
+            closeMenu()
+            return
+          }
+          const text = state.doc.sliceString(from, cursor)
+          if (!text.startsWith(`/`)) {
+            closeMenu()
+            return
+          }
+          filter.value = text.slice(1)
+          activeIndex.value = 0
+          if (filteredCommands.value.length === 0)
+            closeMenu()
+        }
+      }),
+
+      // High-priority keymap to intercept navigation when menu is visible
+      Prec.highest(
+        keymap.of([
+          {
+            key: `ArrowDown`,
+            run: () => {
+              if (!visible.value)
+                return false
+              selectNext()
+              return true
+            },
+          },
+          {
+            key: `ArrowUp`,
+            run: () => {
+              if (!visible.value)
+                return false
+              selectPrev()
+              return true
+            },
+          },
+          {
+            key: `Enter`,
+            run: (view) => {
+              if (!visible.value)
+                return false
+              const cmd = filteredCommands.value[activeIndex.value]
+              if (cmd)
+                executeCommand(view, cmd)
+              else
+                closeMenu()
+              return true
+            },
+          },
+          {
+            key: `Escape`,
+            run: () => {
+              if (!visible.value)
+                return false
+              closeMenu()
+              return true
+            },
+          },
+        ]),
+      ),
+    ]
+  }
+
+  return {
+    visible,
+    position,
+    filter,
+    activeIndex,
+    filteredCommands,
+    basicCommands,
+    commonCommands,
+    allCommands,
+    closeMenu,
+    executeCommand,
+    createExtension,
+  }
+}

--- a/packages/shared/src/editor/markdown.ts
+++ b/packages/shared/src/editor/markdown.ts
@@ -132,6 +132,6 @@ export function markdownSetup(options?: MarkdownKeymapOptions) {
     EditorView.lineWrapping,
     EditorState.allowMultipleSelections.of(true),
 
-    placeholder(`开始写作...`),
+    placeholder(`输入 "/" 快速添加内容`),
   ]
 }


### PR DESCRIPTION
## Summary
- Add a slash command menu triggered by typing `/` in the editor
- Support quick insertion of headings (H1–H6), lists, blockquote, divider, links, code blocks, formula blocks, images, and tables
- Update editor placeholder to hint at the `/` shortcut
- Keyboard navigation: ArrowUp/ArrowDown to select, Enter to confirm, Escape to dismiss

## Test plan
- [x] Type `/` in the editor and verify the command menu appears
- [x] Type `/h` and verify headings are filtered
- [x] Select H1 and verify `# ` is inserted at cursor with `/` removed
- [x] Select code block and verify triple-backtick block is inserted
- [x] Select formula block and verify the formula editor dialog opens
- [x] Navigate with ArrowUp/ArrowDown and confirm Enter executes the highlighted command
- [x] Press Escape and confirm the menu closes
- [x] Click outside the menu and confirm it closes

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)