### PR TITLE
feat: add Star History section to README files

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -141,6 +141,16 @@ docker run -d -p 8080:80 doocs/md:latest
 
 Then open http://localhost:8080 in your browser. For more details on the Docker image, see https://github.com/doocs/docker-md.
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=doocs%2Fmd&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## Who's Using It
 
 See [USERS.md](USERS.md) for a list of WeChat Official Accounts using this project.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ docker run -d -p 8080:80 doocs/md:latest
 
 启动后访问 http://localhost:8080 即可。Docker 镜像的更多信息，请参考 https://github.com/doocs/docker-md
 
+## Star 趋势
+
+<a href="https://www.star-history.com/?repos=doocs%2Fmd&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## 谁在使用
 
 请查看 [USERS.md](USERS.md)，了解使用本项目的公众号列表。


### PR DESCRIPTION
## Summary

- Add Star History badge/chart section to both `README.md` (Chinese) and `README-EN.md` (English)
- Uses star-history.com with date-type chart and dark/light theme support via `<picture>` element
- Placed before the "Who's Using It" / "谁在使用" section in both files

## Test plan

- [x] Verify `README.md` renders correctly with dark/light theme Star History chart
- [x] Verify `README-EN.md` renders correctly with dark/light theme Star History chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)