### PR TITLE
feat: add custom component system for Markdown editor

### DIFF
--- a/apps/web/src/assets/index.css
+++ b/apps/web/src/assets/index.css
@@ -92,5 +92,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+      'Noto Sans CJK SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
   }
 }

--- a/apps/web/src/components/editor/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/CustomComponentDialog.vue
@@ -189,9 +189,14 @@ const copiedId = ref<string | null>(null)
 
 async function copySnippet(def: CustomComponentDef) {
   const text = def.example || componentStore.buildSnippet(def)
-  await navigator.clipboard.writeText(text)
-  copiedId.value = def.id
-  setTimeout(() => { copiedId.value = null }, 1500)
+  try {
+    await navigator.clipboard.writeText(text)
+    copiedId.value = def.id
+    setTimeout(() => { copiedId.value = null }, 1500)
+  }
+  catch {
+    toast.error(`复制失败，请手动复制`)
+  }
 }
 
 // 类型颜色标签

--- a/apps/web/src/components/editor/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/CustomComponentDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ComponentPropDef, CustomComponentDef } from '@md/shared'
-import { Blocks, Lock, Pencil, Plus, Trash2, Zap } from 'lucide-vue-next'
+import { Blocks, Check, ChevronDown, Copy, Lock, Pencil, Plus, Trash2, Zap } from 'lucide-vue-next'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCustomComponentStore } from '@/stores/customComponent'
 import { useEditorStore } from '@/stores/editor'
@@ -172,32 +172,66 @@ function onUpdate(val: boolean) {
     isShowForm.value = false
   }
 }
+
+// ──────────────────────────────────────────────
+// 展开/折叠详情
+// ──────────────────────────────────────────────
+const expandedId = ref<string | null>(null)
+
+function toggleExpand(id: string) {
+  expandedId.value = expandedId.value === id ? null : id
+}
+
+// ──────────────────────────────────────────────
+// 复制代码片段
+// ──────────────────────────────────────────────
+const copiedId = ref<string | null>(null)
+
+async function copySnippet(def: CustomComponentDef) {
+  const text = def.example || componentStore.buildSnippet(def)
+  await navigator.clipboard.writeText(text)
+  copiedId.value = def.id
+  setTimeout(() => { copiedId.value = null }, 1500)
+}
+
+// 类型颜色标签
+function propTypeBadge(prop: ComponentPropDef) {
+  if (prop.required)
+    return { label: '必填', class: 'bg-red-50 text-red-600 border-red-200' }
+  if (prop.default !== undefined && prop.default !== '')
+    return { label: '可选', class: 'bg-blue-50 text-blue-600 border-blue-200' }
+  return { label: '可选', class: 'bg-muted text-muted-foreground border-border' }
+}
 </script>
 
 <template>
   <Dialog :open="uiStore.isShowComponentDialog" @update:open="onUpdate">
-    <DialogContent class="max-w-4xl max-h-[90vh] flex flex-col p-0">
-      <DialogHeader class="px-6 pt-6 pb-4 border-b">
-        <DialogTitle class="flex items-center gap-2">
-          <Blocks class="size-5" />
+    <DialogContent class="sm:max-w-4xl max-h-[92vh] flex flex-col p-0 gap-0">
+      <DialogHeader class="px-4 sm:px-6 pt-5 pb-4 border-b shrink-0">
+        <DialogTitle class="flex items-center gap-2 text-base">
+          <Blocks class="size-4.5" />
           自定义组件
         </DialogTitle>
-        <DialogDescription>
-          在 Markdown 中使用 JSX 风格的组件，如
-          <code class="text-xs bg-muted px-1 py-0.5 rounded">&lt;QRCodeBlock url="https://example.com" /&gt;</code>
+        <DialogDescription class="text-xs leading-relaxed mt-1">
+          在 Markdown 中插入 JSX 风格组件，如
+          <code class="bg-muted px-1 py-0.5 rounded font-mono">&lt;QRCodeBlock url="…" /&gt;</code>
         </DialogDescription>
       </DialogHeader>
 
-      <div class="flex-1 overflow-auto px-6 py-4">
+      <div class="flex-1 overflow-y-auto px-4 sm:px-6 py-4 space-y-6">
         <!-- ─── 新建/编辑表单 ─── -->
-        <div v-if="isShowForm" class="space-y-5 p-5 border rounded-lg bg-muted/30">
-          <h3 class="text-base font-semibold">
+        <div v-if="isShowForm" class="space-y-5 p-4 sm:p-5 border rounded-xl bg-muted/30">
+          <h3 class="text-sm font-semibold">
             {{ formMode === 'create' ? '新建组件' : '编辑组件' }}
           </h3>
 
           <!-- 组件名称 -->
           <div class="space-y-1.5">
-            <Label for="comp-name">组件名称 * <span class="text-muted-foreground text-xs font-normal">（PascalCase，如 QRCodeBlock）</span></Label>
+            <Label for="comp-name">
+              组件名称
+              <span class="text-red-500 ml-0.5">*</span>
+              <span class="text-muted-foreground text-xs font-normal ml-1">（PascalCase，如 QRCodeBlock）</span>
+            </Label>
             <Input
               id="comp-name"
               v-model="formData.name"
@@ -228,27 +262,45 @@ function onUpdate(val: boolean) {
                 添加 Prop
               </Button>
             </div>
+            <!-- 桌面端：网格表头 -->
+            <div class="hidden sm:grid grid-cols-12 gap-2 px-1">
+              <span class="col-span-3 text-xs text-muted-foreground">名称</span>
+              <span class="col-span-4 text-xs text-muted-foreground">描述</span>
+              <span class="col-span-3 text-xs text-muted-foreground">默认值</span>
+              <span class="col-span-2" />
+            </div>
             <div class="space-y-2">
               <div
                 v-for="(row, idx) in propRows"
                 :key="idx"
-                class="grid grid-cols-12 gap-2 items-center"
+                class="flex flex-col sm:grid sm:grid-cols-12 gap-2 items-start sm:items-center p-3 sm:p-0 border sm:border-0 rounded-lg sm:rounded-none bg-muted/20 sm:bg-transparent"
               >
-                <Input v-model="row.name" placeholder="名称" class="col-span-3 h-8 text-sm" />
-                <Input v-model="row.description" placeholder="描述" class="col-span-4 h-8 text-sm" />
-                <Input v-model="row.default" placeholder="默认值" class="col-span-3 h-8 text-sm" />
-                <label class="col-span-1 flex items-center justify-center gap-1 text-xs cursor-pointer">
-                  <input v-model="row.required" type="checkbox" class="cursor-pointer">
-                  必填
-                </label>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="col-span-1 size-7 text-muted-foreground hover:text-red-500"
-                  @click="removePropRow(idx)"
-                >
-                  <Trash2 class="size-3.5" />
-                </Button>
+                <div class="w-full sm:col-span-3 flex gap-1 items-center">
+                  <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">名称</span>
+                  <Input v-model="row.name" placeholder="propName" class="h-8 text-sm flex-1" />
+                </div>
+                <div class="w-full sm:col-span-4 flex gap-1 items-center">
+                  <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">描述</span>
+                  <Input v-model="row.description" placeholder="描述" class="h-8 text-sm flex-1" />
+                </div>
+                <div class="w-full sm:col-span-3 flex gap-1 items-center">
+                  <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">默认值</span>
+                  <Input v-model="row.default" placeholder="默认值" class="h-8 text-sm flex-1" />
+                </div>
+                <div class="flex items-center gap-2 sm:col-span-2 sm:justify-center">
+                  <label class="flex items-center gap-1 text-xs cursor-pointer select-none">
+                    <input v-model="row.required" type="checkbox" class="cursor-pointer">
+                    必填
+                  </label>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="size-7 text-muted-foreground hover:text-red-500"
+                    @click="removePropRow(idx)"
+                  >
+                    <Trash2 class="size-3.5" />
+                  </Button>
+                </div>
               </div>
             </div>
             <p class="text-xs text-muted-foreground">
@@ -258,12 +310,15 @@ function onUpdate(val: boolean) {
 
           <!-- HTML 模板 -->
           <div class="space-y-1.5">
-            <Label for="comp-template">HTML 模板 *</Label>
+            <Label for="comp-template">
+              HTML 模板
+              <span class="text-red-500 ml-0.5">*</span>
+            </Label>
             <Textarea
               id="comp-template"
               v-model="formData.template"
               :placeholder="TEMPLATE_PLACEHOLDER"
-              class="font-mono text-sm resize-none h-48"
+              class="font-mono text-sm resize-none h-44"
               :class="{ 'border-red-500': formErrors.template }"
             />
             <p v-if="formErrors.template" class="text-sm text-red-500">
@@ -287,116 +342,388 @@ function onUpdate(val: boolean) {
 
         <!-- ─── 组件列表 ─── -->
         <div v-if="!isShowForm">
-          <div class="flex justify-end mb-4">
-            <Button @click="openCreateForm">
-              <Plus class="mr-2 size-4" />
+          <div class="flex items-center justify-between mb-4">
+            <p class="text-xs text-muted-foreground">
+              共 {{ componentStore.allComponents.length }} 个组件
+            </p>
+            <Button size="sm" @click="openCreateForm">
+              <Plus class="mr-1.5 size-3.5" />
               新建组件
             </Button>
           </div>
 
           <!-- 空状态 -->
-          <div v-if="componentStore.allComponents.length === 0" class="text-center py-12">
-            <Blocks class="mx-auto size-12 text-muted-foreground mb-4" />
-            <p class="text-muted-foreground">
-              暂无组件
+          <div v-if="componentStore.allComponents.length === 0" class="text-center py-16">
+            <Blocks class="mx-auto size-12 text-muted-foreground/40 mb-3" />
+            <p class="text-sm text-muted-foreground">
+              暂无组件，点击右上角新建
             </p>
           </div>
 
-          <!-- 内置组件 -->
-          <div class="mb-6">
-            <h4 class="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-1.5">
-              <Lock class="size-3.5" />
-              内置组件
-            </h4>
+          <!-- ── 内置组件 ── -->
+          <section class="mb-6">
+            <div class="flex items-center gap-1.5 mb-3">
+              <Lock class="size-3.5 text-muted-foreground" />
+              <h4 class="text-sm font-medium text-muted-foreground">
+                内置组件
+              </h4>
+              <span class="text-xs text-muted-foreground/60">（只读，不可删除）</span>
+            </div>
             <div class="space-y-2">
               <div
                 v-for="def in componentStore.builtInComponents"
                 :key="def.id"
-                class="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
+                class="border rounded-xl overflow-hidden transition-all"
+                :class="expandedId === def.id ? 'border-primary/30 bg-primary/[0.02]' : 'hover:border-border/80 bg-card'"
               >
-                <div class="flex items-start justify-between gap-4">
+                <!-- 卡片头部：始终可见 -->
+                <div
+                  class="flex items-start sm:items-center gap-3 p-3 sm:p-4 cursor-pointer select-none"
+                  @click="toggleExpand(def.id)"
+                >
+                  <!-- 图标区 -->
+                  <div class="size-8 sm:size-9 shrink-0 rounded-lg bg-primary/10 flex items-center justify-center">
+                    <Blocks class="size-4 text-primary" />
+                  </div>
+                  <!-- 名称 & 描述 -->
                   <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-1">
+                    <div class="flex flex-wrap items-center gap-1.5 mb-0.5">
                       <code class="text-sm font-semibold text-primary">{{ def.name }}</code>
-                      <span class="text-xs bg-muted px-1.5 py-0.5 rounded text-muted-foreground">内置</span>
+                      <span class="text-[10px] border px-1.5 py-px rounded-full bg-muted text-muted-foreground">内置</span>
+                      <span class="text-[10px] border px-1.5 py-px rounded-full bg-muted text-muted-foreground">
+                        {{ def.props.length }} 个属性
+                      </span>
                     </div>
-                    <p v-if="def.description" class="text-sm text-muted-foreground mb-2">
+                    <p v-if="def.description" class="text-xs text-muted-foreground leading-relaxed line-clamp-1">
                       {{ def.description }}
                     </p>
-                    <p class="text-xs text-muted-foreground font-mono">
-                      {{ componentStore.buildSnippet(def) }}
-                    </p>
                   </div>
-                  <div class="flex gap-1 shrink-0">
+                  <!-- 操作按钮 -->
+                  <div class="flex items-center gap-1 shrink-0" @click.stop>
                     <Button
-                      variant="outline"
+                      variant="default"
                       size="sm"
-                      class="gap-1"
+                      class="h-7 px-2.5 text-xs gap-1"
                       @click="insertSnippet(def)"
                     >
-                      <Zap class="size-3.5" />
+                      <Zap class="size-3" />
                       插入
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      class="size-7 text-muted-foreground"
+                      @click="toggleExpand(def.id)"
+                    >
+                      <ChevronDown
+                        class="size-3.5 transition-transform duration-200"
+                        :class="{ 'rotate-180': expandedId === def.id }"
+                      />
                     </Button>
                   </div>
                 </div>
+
+                <!-- 展开详情 -->
+                <Transition
+                  enter-active-class="transition-all duration-200 ease-out"
+                  enter-from-class="opacity-0 -translate-y-1"
+                  enter-to-class="opacity-100 translate-y-0"
+                  leave-active-class="transition-all duration-150 ease-in"
+                  leave-from-class="opacity-100 translate-y-0"
+                  leave-to-class="opacity-0 -translate-y-1"
+                >
+                  <div v-if="expandedId === def.id" class="border-t px-3 sm:px-4 py-3 space-y-3 bg-muted/20">
+                    <!-- Props 表格 -->
+                    <div v-if="def.props.length > 0">
+                      <p class="text-xs font-medium text-muted-foreground mb-2">
+                        属性说明
+                      </p>
+                      <!-- 桌面端表格 -->
+                      <div class="hidden sm:block rounded-lg border overflow-hidden">
+                        <table class="w-full text-xs">
+                          <thead class="bg-muted/50">
+                            <tr>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-28">
+                                属性名
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
+                                状态
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground">
+                                描述
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-24">
+                                默认值
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              v-for="prop in def.props"
+                              :key="prop.name"
+                              class="border-t border-border/50"
+                            >
+                              <td class="px-3 py-2">
+                                <code class="font-mono text-primary font-medium">{{ prop.name }}</code>
+                              </td>
+                              <td class="px-3 py-2">
+                                <span
+                                  class="inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-medium"
+                                  :class="propTypeBadge(prop).class"
+                                >{{ propTypeBadge(prop).label }}</span>
+                              </td>
+                              <td class="px-3 py-2 text-muted-foreground">
+                                {{ prop.description || '—' }}
+                              </td>
+                              <td class="px-3 py-2">
+                                <code v-if="prop.default" class="text-[11px] bg-muted px-1.5 py-0.5 rounded text-foreground">{{ prop.default }}</code>
+                                <span v-else class="text-muted-foreground/50">—</span>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <!-- 移动端卡片列表 -->
+                      <div class="sm:hidden space-y-2">
+                        <div
+                          v-for="prop in def.props"
+                          :key="prop.name"
+                          class="rounded-lg border bg-card p-3 space-y-1"
+                        >
+                          <div class="flex items-center gap-2">
+                            <code class="font-mono text-sm font-semibold text-primary">{{ prop.name }}</code>
+                            <span
+                              class="inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-medium"
+                              :class="propTypeBadge(prop).class"
+                            >{{ propTypeBadge(prop).label }}</span>
+                          </div>
+                          <p v-if="prop.description" class="text-xs text-muted-foreground">
+                            {{ prop.description }}
+                          </p>
+                          <div v-if="prop.default" class="flex items-center gap-1 text-xs text-muted-foreground">
+                            <span>默认：</span>
+                            <code class="bg-muted px-1.5 py-0.5 rounded text-foreground">{{ prop.default }}</code>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 使用示例 -->
+                    <div>
+                      <p class="text-xs font-medium text-muted-foreground mb-1.5">
+                        使用示例
+                      </p>
+                      <div class="relative group">
+                        <pre class="text-xs font-mono bg-muted rounded-lg px-3 py-2.5 overflow-x-auto text-foreground/80 pr-10 leading-relaxed"><code>{{ def.example || componentStore.buildSnippet(def) }}</code></pre>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          class="absolute right-1.5 top-1.5 size-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                          @click="copySnippet(def)"
+                        >
+                          <Check v-if="copiedId === def.id" class="size-3 text-green-500" />
+                          <Copy v-else class="size-3 text-muted-foreground" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </Transition>
               </div>
             </div>
-          </div>
+          </section>
 
-          <!-- 用户自定义组件 -->
-          <div v-if="componentStore.userComponents.length > 0">
-            <h4 class="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-1.5">
-              <Blocks class="size-3.5" />
-              自定义组件
-            </h4>
+          <!-- ── 自定义组件 ── -->
+          <section v-if="componentStore.userComponents.length > 0">
+            <div class="flex items-center gap-1.5 mb-3">
+              <Blocks class="size-3.5 text-muted-foreground" />
+              <h4 class="text-sm font-medium text-muted-foreground">
+                自定义组件
+              </h4>
+            </div>
             <div class="space-y-2">
               <div
                 v-for="def in componentStore.userComponents"
                 :key="def.id"
-                class="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
+                class="border rounded-xl overflow-hidden transition-all"
+                :class="expandedId === def.id ? 'border-primary/30 bg-primary/[0.02]' : 'hover:border-border/80 bg-card'"
               >
-                <div class="flex items-start justify-between gap-4">
+                <!-- 卡片头部 -->
+                <div
+                  class="flex items-start sm:items-center gap-3 p-3 sm:p-4 cursor-pointer select-none"
+                  @click="toggleExpand(def.id)"
+                >
+                  <div class="size-8 sm:size-9 shrink-0 rounded-lg bg-primary/10 flex items-center justify-center">
+                    <Blocks class="size-4 text-primary" />
+                  </div>
                   <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-1">
-                      <code class="text-sm font-semibold text-primary">{{ def.name }}</code>
+                    <div class="flex flex-wrap items-center gap-1.5 mb-0.5">
+                      <code class="text-sm font-semibold text-foreground">{{ def.name }}</code>
+                      <span class="text-[10px] border px-1.5 py-px rounded-full bg-muted text-muted-foreground">
+                        {{ def.props.length }} 个属性
+                      </span>
                     </div>
-                    <p v-if="def.description" class="text-sm text-muted-foreground mb-2">
+                    <p v-if="def.description" class="text-xs text-muted-foreground leading-relaxed line-clamp-1">
                       {{ def.description }}
                     </p>
-                    <p class="text-xs text-muted-foreground font-mono">
-                      {{ componentStore.buildSnippet(def) }}
-                    </p>
                   </div>
-                  <div class="flex gap-1 shrink-0">
+                  <div class="flex items-center gap-1 shrink-0" @click.stop>
                     <Button
-                      variant="outline"
+                      variant="default"
                       size="sm"
-                      class="gap-1"
+                      class="h-7 px-2.5 text-xs gap-1"
                       @click="insertSnippet(def)"
                     >
-                      <Zap class="size-3.5" />
+                      <Zap class="size-3" />
                       插入
                     </Button>
                     <Button
-                      variant="outline"
-                      size="sm"
-                      @click="openEditForm(def)"
+                      variant="ghost"
+                      size="icon"
+                      class="size-7 text-muted-foreground"
+                      @click="toggleExpand(def.id)"
                     >
-                      <Pencil class="size-3.5" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      class="text-red-500 hover:text-red-600"
-                      @click="openDeleteConfirm(def)"
-                    >
-                      <Trash2 class="size-3.5" />
+                      <ChevronDown
+                        class="size-3.5 transition-transform duration-200"
+                        :class="{ 'rotate-180': expandedId === def.id }"
+                      />
                     </Button>
                   </div>
                 </div>
+
+                <!-- 展开详情 -->
+                <Transition
+                  enter-active-class="transition-all duration-200 ease-out"
+                  enter-from-class="opacity-0 -translate-y-1"
+                  enter-to-class="opacity-100 translate-y-0"
+                  leave-active-class="transition-all duration-150 ease-in"
+                  leave-from-class="opacity-100 translate-y-0"
+                  leave-to-class="opacity-0 -translate-y-1"
+                >
+                  <div v-if="expandedId === def.id" class="border-t px-3 sm:px-4 py-3 space-y-3 bg-muted/20">
+                    <!-- Props 表格 -->
+                    <div v-if="def.props.length > 0">
+                      <p class="text-xs font-medium text-muted-foreground mb-2">
+                        属性说明
+                      </p>
+                      <!-- 桌面端表格 -->
+                      <div class="hidden sm:block rounded-lg border overflow-hidden">
+                        <table class="w-full text-xs">
+                          <thead class="bg-muted/50">
+                            <tr>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-28">
+                                属性名
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
+                                状态
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground">
+                                描述
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-24">
+                                默认值
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              v-for="prop in def.props"
+                              :key="prop.name"
+                              class="border-t border-border/50"
+                            >
+                              <td class="px-3 py-2">
+                                <code class="font-mono text-primary font-medium">{{ prop.name }}</code>
+                              </td>
+                              <td class="px-3 py-2">
+                                <span
+                                  class="inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-medium"
+                                  :class="propTypeBadge(prop).class"
+                                >{{ propTypeBadge(prop).label }}</span>
+                              </td>
+                              <td class="px-3 py-2 text-muted-foreground">
+                                {{ prop.description || '—' }}
+                              </td>
+                              <td class="px-3 py-2">
+                                <code v-if="prop.default" class="text-[11px] bg-muted px-1.5 py-0.5 rounded text-foreground">{{ prop.default }}</code>
+                                <span v-else class="text-muted-foreground/50">—</span>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <!-- 移动端卡片列表 -->
+                      <div class="sm:hidden space-y-2">
+                        <div
+                          v-for="prop in def.props"
+                          :key="prop.name"
+                          class="rounded-lg border bg-card p-3 space-y-1"
+                        >
+                          <div class="flex items-center gap-2">
+                            <code class="font-mono text-sm font-semibold text-primary">{{ prop.name }}</code>
+                            <span
+                              class="inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-medium"
+                              :class="propTypeBadge(prop).class"
+                            >{{ propTypeBadge(prop).label }}</span>
+                          </div>
+                          <p v-if="prop.description" class="text-xs text-muted-foreground">
+                            {{ prop.description }}
+                          </p>
+                          <div v-if="prop.default" class="flex items-center gap-1 text-xs text-muted-foreground">
+                            <span>默认：</span>
+                            <code class="bg-muted px-1.5 py-0.5 rounded text-foreground">{{ prop.default }}</code>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div v-else>
+                      <p class="text-xs text-muted-foreground italic">
+                        该组件无属性定义
+                      </p>
+                    </div>
+
+                    <!-- 使用示例 -->
+                    <div>
+                      <p class="text-xs font-medium text-muted-foreground mb-1.5">
+                        使用示例
+                      </p>
+                      <div class="relative group">
+                        <pre class="text-xs font-mono bg-muted rounded-lg px-3 py-2.5 overflow-x-auto text-foreground/80 pr-10 leading-relaxed"><code>{{ def.example || componentStore.buildSnippet(def) }}</code></pre>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          class="absolute right-1.5 top-1.5 size-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                          @click="copySnippet(def)"
+                        >
+                          <Check v-if="copiedId === def.id" class="size-3 text-green-500" />
+                          <Copy v-else class="size-3 text-muted-foreground" />
+                        </Button>
+                      </div>
+                    </div>
+                    <!-- 编辑 / 删除 -->
+                    <div class="flex items-center gap-2 pt-1 border-t">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-7 px-2.5 text-xs gap-1"
+                        @click="openEditForm(def)"
+                      >
+                        <Pencil class="size-3" />
+                        编辑
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-7 px-2.5 text-xs gap-1 text-red-500 hover:text-red-600 hover:border-red-300"
+                        @click="openDeleteConfirm(def)"
+                      >
+                        <Trash2 class="size-3" />
+                        删除
+                      </Button>
+                    </div>
+                  </div>
+                </Transition>
               </div>
             </div>
-          </div>
+          </section>
         </div>
       </div>
     </DialogContent>

--- a/apps/web/src/components/editor/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/CustomComponentDialog.vue
@@ -1,0 +1,404 @@
+<script setup lang="ts">
+import type { ComponentPropDef, CustomComponentDef } from '@md/shared'
+import { Blocks, Lock, Pencil, Plus, Trash2, Zap } from 'lucide-vue-next'
+import { useConfirmStore } from '@/stores/confirm'
+import { useCustomComponentStore } from '@/stores/customComponent'
+import { useEditorStore } from '@/stores/editor'
+import { useUIStore } from '@/stores/ui'
+
+const confirmStore = useConfirmStore()
+const editorStore = useEditorStore()
+const componentStore = useCustomComponentStore()
+const uiStore = useUIStore()
+
+const { toggleShowComponentDialog } = uiStore
+
+// ──────────────────────────────────────────────
+// 表单状态
+// ──────────────────────────────────────────────
+const isShowForm = ref(false)
+const formMode = ref<'create' | 'edit'>('create')
+const editingId = ref('')
+
+interface PropRow {
+  name: string
+  description: string
+  default: string
+  required: boolean
+}
+
+const formData = reactive({
+  name: '',
+  description: '',
+  template: '',
+})
+
+const propRows = ref<PropRow[]>([{ name: '', description: '', default: '', required: false }])
+
+const formErrors = reactive({
+  name: '',
+  template: '',
+})
+
+// ──────────────────────────────────────────────
+// 表单操作
+// ──────────────────────────────────────────────
+function openCreateForm() {
+  formMode.value = 'create'
+  formData.name = ''
+  formData.description = ''
+  formData.template = ''
+  propRows.value = [{ name: '', description: '', default: '', required: false }]
+  formErrors.name = ''
+  formErrors.template = ''
+  isShowForm.value = true
+}
+
+function openEditForm(def: CustomComponentDef) {
+  formMode.value = 'edit'
+  editingId.value = def.id
+  formData.name = def.name
+  formData.description = def.description || ''
+  formData.template = def.template
+  propRows.value = def.props.length
+    ? def.props.map(p => ({
+        name: p.name,
+        description: p.description || '',
+        default: p.default || '',
+        required: !!p.required,
+      }))
+    : [{ name: '', description: '', default: '', required: false }]
+  formErrors.name = ''
+  formErrors.template = ''
+  isShowForm.value = true
+}
+
+function addPropRow() {
+  propRows.value.push({ name: '', description: '', default: '', required: false })
+}
+
+function removePropRow(idx: number) {
+  propRows.value.splice(idx, 1)
+  if (propRows.value.length === 0) {
+    propRows.value.push({ name: '', description: '', default: '', required: false })
+  }
+}
+
+function validate(): boolean {
+  formErrors.name = ''
+  formErrors.template = ''
+
+  if (!formData.name.trim()) {
+    formErrors.name = '组件名称不能为空'
+    return false
+  }
+  if (!/^[A-Z][a-zA-Z0-9]*$/.test(formData.name.trim())) {
+    formErrors.name = '组件名称必须以大写字母开头，只含字母和数字（PascalCase）'
+    return false
+  }
+  if (!formData.template.trim()) {
+    formErrors.template = '组件模板不能为空'
+    return false
+  }
+  return true
+}
+
+function buildProps(): ComponentPropDef[] {
+  return propRows.value
+    .filter(r => r.name.trim())
+    .map(r => ({
+      name: r.name.trim(),
+      description: r.description.trim() || undefined,
+      default: r.default || undefined,
+      required: r.required || undefined,
+    }))
+}
+
+function saveComponent() {
+  if (!validate())
+    return
+
+  const props = buildProps()
+
+  if (formMode.value === 'create') {
+    componentStore.createComponent({
+      name: formData.name.trim(),
+      description: formData.description.trim() || undefined,
+      template: formData.template,
+      props,
+    })
+  }
+  else {
+    componentStore.updateComponent(editingId.value, {
+      name: formData.name.trim(),
+      description: formData.description.trim() || undefined,
+      template: formData.template,
+      props,
+    })
+  }
+  isShowForm.value = false
+}
+
+function cancelForm() {
+  isShowForm.value = false
+}
+
+const TEMPLATE_PLACEHOLDER = `<section style="text-align:center;">
+  <img src="https://api.qrserver.com/v1/create-qr-code/?data={{url}}" />
+  <p>{{text}}</p>
+</section>`
+
+// ──────────────────────────────────────────────
+// 列表操作
+// ──────────────────────────────────────────────
+function insertSnippet(def: CustomComponentDef) {
+  const snippet = componentStore.buildSnippet(def)
+  editorStore.insertAtCursor(snippet)
+  toast.success(`已插入组件「${def.name}」`)
+  toggleShowComponentDialog(false)
+}
+
+function openDeleteConfirm(def: CustomComponentDef) {
+  confirmStore.confirm({
+    title: '确认删除',
+    description: `确定要删除组件「${def.name}」吗？`,
+    onConfirm: () => { componentStore.deleteComponent(def.id) },
+  })
+}
+
+function onUpdate(val: boolean) {
+  if (!val) {
+    toggleShowComponentDialog(false)
+    isShowForm.value = false
+  }
+}
+</script>
+
+<template>
+  <Dialog :open="uiStore.isShowComponentDialog" @update:open="onUpdate">
+    <DialogContent class="max-w-4xl max-h-[90vh] flex flex-col p-0">
+      <DialogHeader class="px-6 pt-6 pb-4 border-b">
+        <DialogTitle class="flex items-center gap-2">
+          <Blocks class="size-5" />
+          自定义组件
+        </DialogTitle>
+        <DialogDescription>
+          在 Markdown 中使用 JSX 风格的组件，如
+          <code class="text-xs bg-muted px-1 py-0.5 rounded">&lt;QRCodeBlock url="https://example.com" /&gt;</code>
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="flex-1 overflow-auto px-6 py-4">
+        <!-- ─── 新建/编辑表单 ─── -->
+        <div v-if="isShowForm" class="space-y-5 p-5 border rounded-lg bg-muted/30">
+          <h3 class="text-base font-semibold">
+            {{ formMode === 'create' ? '新建组件' : '编辑组件' }}
+          </h3>
+
+          <!-- 组件名称 -->
+          <div class="space-y-1.5">
+            <Label for="comp-name">组件名称 * <span class="text-muted-foreground text-xs font-normal">（PascalCase，如 QRCodeBlock）</span></Label>
+            <Input
+              id="comp-name"
+              v-model="formData.name"
+              placeholder="QRCodeBlock"
+              :class="{ 'border-red-500': formErrors.name }"
+            />
+            <p v-if="formErrors.name" class="text-sm text-red-500">
+              {{ formErrors.name }}
+            </p>
+          </div>
+
+          <!-- 组件描述 -->
+          <div class="space-y-1.5">
+            <Label for="comp-desc">组件描述</Label>
+            <Input
+              id="comp-desc"
+              v-model="formData.description"
+              placeholder="简短描述该组件的用途"
+            />
+          </div>
+
+          <!-- Props 定义 -->
+          <div class="space-y-2">
+            <div class="flex items-center justify-between">
+              <Label>Props 定义</Label>
+              <Button variant="outline" size="sm" @click="addPropRow">
+                <Plus class="size-3 mr-1" />
+                添加 Prop
+              </Button>
+            </div>
+            <div class="space-y-2">
+              <div
+                v-for="(row, idx) in propRows"
+                :key="idx"
+                class="grid grid-cols-12 gap-2 items-center"
+              >
+                <Input v-model="row.name" placeholder="名称" class="col-span-3 h-8 text-sm" />
+                <Input v-model="row.description" placeholder="描述" class="col-span-4 h-8 text-sm" />
+                <Input v-model="row.default" placeholder="默认值" class="col-span-3 h-8 text-sm" />
+                <label class="col-span-1 flex items-center justify-center gap-1 text-xs cursor-pointer">
+                  <input v-model="row.required" type="checkbox" class="cursor-pointer">
+                  必填
+                </label>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="col-span-1 size-7 text-muted-foreground hover:text-red-500"
+                  @click="removePropRow(idx)"
+                >
+                  <Trash2 class="size-3.5" />
+                </Button>
+              </div>
+            </div>
+            <p class="text-xs text-muted-foreground">
+              在模板中使用 <code class="bg-muted px-1 rounded">&#123;&#123;propName&#125;&#125;</code> 引用 prop 值
+            </p>
+          </div>
+
+          <!-- HTML 模板 -->
+          <div class="space-y-1.5">
+            <Label for="comp-template">HTML 模板 *</Label>
+            <Textarea
+              id="comp-template"
+              v-model="formData.template"
+              :placeholder="TEMPLATE_PLACEHOLDER"
+              class="font-mono text-sm resize-none h-48"
+              :class="{ 'border-red-500': formErrors.template }"
+            />
+            <p v-if="formErrors.template" class="text-sm text-red-500">
+              {{ formErrors.template }}
+            </p>
+            <div class="text-xs text-muted-foreground space-y-0.5">
+              <p><code class="bg-muted px-1 rounded">&#123;&#123;propName&#125;&#125;</code> — 替换为 prop 值（自动 HTML 转义）</p>
+              <p><code class="bg-muted px-1 rounded">&#123;&#123;#if propName&#125;&#125;...&#123;&#123;/if&#125;&#125;</code> — prop 非空时显示该块</p>
+            </div>
+          </div>
+
+          <div class="flex gap-2 justify-end">
+            <Button variant="outline" @click="cancelForm">
+              取消
+            </Button>
+            <Button @click="saveComponent">
+              {{ formMode === 'create' ? '创建' : '保存' }}
+            </Button>
+          </div>
+        </div>
+
+        <!-- ─── 组件列表 ─── -->
+        <div v-if="!isShowForm">
+          <div class="flex justify-end mb-4">
+            <Button @click="openCreateForm">
+              <Plus class="mr-2 size-4" />
+              新建组件
+            </Button>
+          </div>
+
+          <!-- 空状态 -->
+          <div v-if="componentStore.allComponents.length === 0" class="text-center py-12">
+            <Blocks class="mx-auto size-12 text-muted-foreground mb-4" />
+            <p class="text-muted-foreground">
+              暂无组件
+            </p>
+          </div>
+
+          <!-- 内置组件 -->
+          <div class="mb-6">
+            <h4 class="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-1.5">
+              <Lock class="size-3.5" />
+              内置组件
+            </h4>
+            <div class="space-y-2">
+              <div
+                v-for="def in componentStore.builtInComponents"
+                :key="def.id"
+                class="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 mb-1">
+                      <code class="text-sm font-semibold text-primary">{{ def.name }}</code>
+                      <span class="text-xs bg-muted px-1.5 py-0.5 rounded text-muted-foreground">内置</span>
+                    </div>
+                    <p v-if="def.description" class="text-sm text-muted-foreground mb-2">
+                      {{ def.description }}
+                    </p>
+                    <p class="text-xs text-muted-foreground font-mono">
+                      {{ componentStore.buildSnippet(def) }}
+                    </p>
+                  </div>
+                  <div class="flex gap-1 shrink-0">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="gap-1"
+                      @click="insertSnippet(def)"
+                    >
+                      <Zap class="size-3.5" />
+                      插入
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 用户自定义组件 -->
+          <div v-if="componentStore.userComponents.length > 0">
+            <h4 class="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-1.5">
+              <Blocks class="size-3.5" />
+              自定义组件
+            </h4>
+            <div class="space-y-2">
+              <div
+                v-for="def in componentStore.userComponents"
+                :key="def.id"
+                class="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 mb-1">
+                      <code class="text-sm font-semibold text-primary">{{ def.name }}</code>
+                    </div>
+                    <p v-if="def.description" class="text-sm text-muted-foreground mb-2">
+                      {{ def.description }}
+                    </p>
+                    <p class="text-xs text-muted-foreground font-mono">
+                      {{ componentStore.buildSnippet(def) }}
+                    </p>
+                  </div>
+                  <div class="flex gap-1 shrink-0">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="gap-1"
+                      @click="insertSnippet(def)"
+                    >
+                      <Zap class="size-3.5" />
+                      插入
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      @click="openEditForm(def)"
+                    >
+                      <Pencil class="size-3.5" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="text-red-500 hover:text-red-600"
+                      @click="openDeleteConfirm(def)"
+                    >
+                      <Trash2 class="size-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/web/src/components/editor/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/CustomComponentDialog.vue
@@ -342,22 +342,16 @@ function propTypeBadge(prop: ComponentPropDef) {
 
         <!-- ─── 组件列表 ─── -->
         <div v-if="!isShowForm">
-          <div class="flex items-center justify-between mb-4">
-            <p class="text-xs text-muted-foreground">
-              共 {{ componentStore.allComponents.length }} 个组件
-            </p>
-            <Button size="sm" @click="openCreateForm">
-              <Plus class="mr-1.5 size-3.5" />
-              新建组件
-            </Button>
-          </div>
-
           <!-- 空状态 -->
           <div v-if="componentStore.allComponents.length === 0" class="text-center py-16">
             <Blocks class="mx-auto size-12 text-muted-foreground/40 mb-3" />
-            <p class="text-sm text-muted-foreground">
-              暂无组件，点击右上角新建
+            <p class="text-sm text-muted-foreground mb-4">
+              暂无组件，点击新建
             </p>
+            <Button variant="outline" size="sm" @click="openCreateForm">
+              <Plus class="mr-1.5 size-3.5" />
+              新建组件
+            </Button>
           </div>
 
           <!-- ── 内置组件 ── -->
@@ -533,14 +527,28 @@ function propTypeBadge(prop: ComponentPropDef) {
           </section>
 
           <!-- ── 自定义组件 ── -->
-          <section v-if="componentStore.userComponents.length > 0">
-            <div class="flex items-center gap-1.5 mb-3">
-              <Blocks class="size-3.5 text-muted-foreground" />
-              <h4 class="text-sm font-medium text-muted-foreground">
-                自定义组件
-              </h4>
+          <section>
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-1.5">
+                <Blocks class="size-3.5 text-muted-foreground" />
+                <h4 class="text-sm font-medium text-muted-foreground">
+                  自定义组件
+                </h4>
+                <span class="text-xs text-muted-foreground/60">
+                  {{ componentStore.userComponents.length }} 个
+                </span>
+              </div>
+              <Button variant="outline" size="sm" class="h-6 px-2 text-xs" @click="openCreateForm">
+                <Plus class="mr-1 size-3" />
+                新建
+              </Button>
             </div>
-            <div class="space-y-2">
+            <div v-if="componentStore.userComponents.length === 0" class="text-center py-8">
+              <p class="text-xs text-muted-foreground">
+                暂无自定义组件，点击上方"新建"按钮创建
+              </p>
+            </div>
+            <div v-else class="space-y-2">
               <div
                 v-for="def in componentStore.userComponents"
                 :key="def.id"

--- a/apps/web/src/components/editor/editor-header/InsertDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/InsertDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Contact, Image, Table } from 'lucide-vue-next'
+import { Blocks, Contact, Image, Table } from 'lucide-vue-next'
 import { useEditorStore } from '@/stores/editor'
 import { useUIStore } from '@/stores/ui'
 import { normalizeFormulaInput } from '@/utils/formula'
@@ -14,7 +14,7 @@ const { asSub } = toRefs(props)
 const uiStore = useUIStore()
 const editorStore = useEditorStore()
 
-const { toggleShowInsertFormDialog, toggleShowUploadImgDialog, toggleShowInsertMpCardDialog } = uiStore
+const { toggleShowInsertFormDialog, toggleShowUploadImgDialog, toggleShowInsertMpCardDialog, toggleShowComponentDialog } = uiStore
 
 function openFormulaEditor() {
   const selection = normalizeFormulaInput(editorStore.getSelection())
@@ -48,6 +48,11 @@ function openFormulaEditor() {
         <Contact class="mr-2 h-4 w-4" />
         公众号名片
       </MenubarItem>
+      <MenubarSeparator />
+      <MenubarItem @click="toggleShowComponentDialog()">
+        <Blocks class="mr-2 h-4 w-4" />
+        自定义组件
+      </MenubarItem>
     </MenubarSubContent>
   </MenubarSub>
 
@@ -72,6 +77,11 @@ function openFormulaEditor() {
       <MenubarItem @click="toggleShowInsertMpCardDialog()">
         <Contact class="mr-2 h-4 w-4" />
         公众号名片
+      </MenubarItem>
+      <MenubarSeparator />
+      <MenubarItem @click="toggleShowComponentDialog()">
+        <Blocks class="mr-2 h-4 w-4" />
+        自定义组件
       </MenubarItem>
     </MenubarContent>
   </MenubarMenu>

--- a/apps/web/src/stores/customComponent.ts
+++ b/apps/web/src/stores/customComponent.ts
@@ -1,0 +1,132 @@
+import type { ComponentRegistry, CreateComponentParams, CustomComponentDef, UpdateComponentParams } from '@md/shared'
+import { BUILT_IN_COMPONENTS, getBuiltInRegistry } from '@md/core'
+import { v4 as uuidv4 } from 'uuid'
+import { addPrefix } from '@/utils'
+import { store } from '@/utils/storage'
+
+/**
+ * 自定义组件管理 Store
+ *
+ * 用户可定义 JSX 风格的组件，在 Markdown 中使用：
+ *   <QRCodeBlock url="https://example.com" text="扫码访问" />
+ *
+ * 内置组件随系统提供，用户组件持久化到 localStorage。
+ * 合并后的注册表传递给渲染器使用。
+ */
+export const useCustomComponentStore = defineStore(`customComponent`, () => {
+  // ==================== 状态 ====================
+
+  /** 用户自定义组件列表（持久化） */
+  const userComponents = store.reactive<CustomComponentDef[]>(addPrefix(`custom_components`), [])
+
+  // ==================== 计算属性 ====================
+
+  /** 内置组件列表（只读） */
+  const builtInComponents = computed(() => BUILT_IN_COMPONENTS)
+
+  /** 所有组件（内置 + 用户，用户组件可覆盖内置组件名） */
+  const allComponents = computed<CustomComponentDef[]>(() => {
+    const builtInMap = new Map(BUILT_IN_COMPONENTS.map(c => [c.name, c]))
+    // 用户组件覆盖同名内置组件
+    for (const c of userComponents.value) {
+      builtInMap.set(c.name, c)
+    }
+    return [...builtInMap.values()]
+  })
+
+  /** 渲染器使用的注册表 */
+  const registry = computed<ComponentRegistry>(() => {
+    const base = getBuiltInRegistry()
+    for (const c of userComponents.value) {
+      base[c.name] = c
+    }
+    return base
+  })
+
+  // ==================== 方法 ====================
+
+  /**
+   * 创建新的用户组件
+   */
+  function createComponent(params: CreateComponentParams): CustomComponentDef {
+    const now = Date.now()
+    const def: CustomComponentDef = {
+      id: uuidv4(),
+      name: params.name,
+      description: params.description,
+      template: params.template,
+      props: params.props,
+      createdAt: now,
+      updatedAt: now,
+    }
+    userComponents.value.push(def)
+    toast.success(`组件「${params.name}」创建成功`)
+    return def
+  }
+
+  /**
+   * 更新用户组件
+   */
+  function updateComponent(id: string, params: UpdateComponentParams): boolean {
+    const idx = userComponents.value.findIndex(c => c.id === id)
+    if (idx === -1) {
+      toast.error(`组件不存在`)
+      return false
+    }
+    userComponents.value[idx] = {
+      ...userComponents.value[idx],
+      ...params,
+      updatedAt: Date.now(),
+    }
+    toast.success(`组件已更新`)
+    return true
+  }
+
+  /**
+   * 删除用户组件（不能删除内置组件）
+   */
+  function deleteComponent(id: string): boolean {
+    const idx = userComponents.value.findIndex(c => c.id === id)
+    if (idx === -1) {
+      toast.error(`组件不存在`)
+      return false
+    }
+    const name = userComponents.value[idx].name
+    userComponents.value.splice(idx, 1)
+    toast.success(`组件「${name}」已删除`)
+    return true
+  }
+
+  /**
+   * 根据 ID 查找用户组件
+   */
+  function getComponentById(id: string): CustomComponentDef | undefined {
+    return userComponents.value.find(c => c.id === id)
+  }
+
+  /**
+   * 生成该组件的 Markdown 使用示例字符串
+   */
+  function buildSnippet(def: CustomComponentDef): string {
+    const propsStr = def.props
+      .filter(p => p.required || p.default !== undefined)
+      .map(p => `${p.name}="${p.default || ``}"`)
+      .join(` `)
+    return `<${def.name}${propsStr ? ` ${propsStr}` : ``} />`
+  }
+
+  return {
+    // State
+    userComponents,
+    // Computed
+    builtInComponents,
+    allComponents,
+    registry,
+    // Actions
+    createComponent,
+    updateComponent,
+    deleteComponent,
+    getComponentById,
+    buildSnippet,
+  }
+})

--- a/apps/web/src/stores/customComponent.ts
+++ b/apps/web/src/stores/customComponent.ts
@@ -105,12 +105,11 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
   }
 
   /**
-   * 生成该组件的 Markdown 使用示例字符串
+   * 生成该组件的 Markdown 使用示例字符串（包含所有 props）
    */
   function buildSnippet(def: CustomComponentDef): string {
     const propsStr = def.props
-      .filter(p => p.required || p.default !== undefined)
-      .map(p => `${p.name}="${p.default || ``}"`)
+      .map(p => `${p.name}="${p.default ?? ``}"`)
       .join(` `)
     return `<${def.name}${propsStr ? ` ${propsStr}` : ``} />`
   }

--- a/apps/web/src/stores/render.ts
+++ b/apps/web/src/stores/render.ts
@@ -1,5 +1,6 @@
 import { initRenderer } from '@md/core'
 import { postProcessHtml, renderMarkdown } from '@/utils'
+import { useCustomComponentStore } from './customComponent'
 import { useThemeStore } from './theme'
 import { useUIStore } from './ui'
 
@@ -71,6 +72,7 @@ export const useRenderStore = defineStore(`render`, () => {
 
     const themeStore = useThemeStore()
     const uiStore = useUIStore()
+    const componentStore = useCustomComponentStore()
 
     // 重置渲染器配置
     // 注意：isUseIndent 和 isUseJustify 通过 CSS 变量处理，不需要传递给渲染器
@@ -81,6 +83,7 @@ export const useRenderStore = defineStore(`render`, () => {
       isMacCodeBlock: themeStore.isMacCodeBlock,
       isShowLineNumber: themeStore.isShowLineNumber,
       themeMode: uiStore.isDark ? 'dark' : 'light',
+      components: componentStore.registry,
     })
 
     // 渲染 Markdown

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -124,6 +124,10 @@ export const useUIStore = defineStore(`ui`, () => {
   const isShowTemplateDialog = ref(false)
   const toggleShowTemplateDialog = useToggle(isShowTemplateDialog)
 
+  // 是否展示自定义组件对话框
+  const isShowComponentDialog = ref(false)
+  const toggleShowComponentDialog = useToggle(isShowComponentDialog)
+
   // AI 对话框
   const aiDialogVisible = ref(false)
   const aiImageDialogVisible = ref(false)
@@ -214,6 +218,8 @@ export const useUIStore = defineStore(`ui`, () => {
     localImageUploadData,
     isShowTemplateDialog,
     toggleShowTemplateDialog,
+    isShowComponentDialog,
+    toggleShowComponentDialog,
     aiDialogVisible,
     toggleAIDialog,
     aiImageDialogVisible,

--- a/apps/web/src/views/CodemirrorEditor.vue
+++ b/apps/web/src/views/CodemirrorEditor.vue
@@ -260,6 +260,8 @@ onUnmounted(() => {
       <FormulaEditorDialog />
 
       <TemplateDialog />
+
+      <CustomComponentDialog />
     </main>
 
     <Footer />

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -154,12 +154,15 @@ function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string
   let html = def.template
 
   // 3. 处理 {{#if prop}}...{{/if}} 条件块
-  html = html.replace(/\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, content) => {
+  html = html.replace(/\{\{#if\s+([\w-]+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, content) => {
     return finalProps[key] ? content : ``
   })
 
-  // 4. 替换 {{propName}} 占位符（转义值）
-  html = html.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+  // 4. 替换 {{propName}} 占位符（转义值）；{{children}} 保留原始 HTML 不转义
+  html = html.replace(/\{\{([\w-]+)\}\}/g, (_, key) => {
+    if (key === `children`) {
+      return finalProps[key] ?? ``
+    }
     return finalProps[key] !== undefined ? escapeAttr(finalProps[key]) : ``
   })
 
@@ -199,7 +202,10 @@ export function getBuiltInRegistry(): ComponentRegistry {
  *
  * 组件名必须以大写字母开头（PascalCase）以与普通 HTML 标签区分。
  */
-export function markedComponent(): MarkedExtension {
+export function markedComponent(getRegistry?: () => ComponentRegistry): MarkedExtension {
+  function resolveRegistry(): ComponentRegistry {
+    return getRegistry ? getRegistry() : _registry
+  }
   /**
    * 简单的非正则标签解析器，避免复杂 regex 的回溯问题。
    * 返回 raw（完整原始文本）、name（组件名）、propsStr（属性串）。
@@ -272,13 +278,17 @@ export function markedComponent(): MarkedExtension {
         },
 
         renderer(token) {
-          const { name, propsStr } = token as unknown as { name: string, propsStr: string }
-          const def = _registry[name]
+          const { name, propsStr, children } = token as unknown as { name: string, propsStr: string, children: string }
+          const def = resolveRegistry()[name]
           if (!def) {
             // 未知组件，保留原始文本并给出提示
             return `<p style="color:#f00;font-size:12px;">[未知组件: ${name}]</p>\n`
           }
           const props = parseProps(propsStr)
+          // 将内部子内容作为保留的 children prop 传入（原始 HTML，不转义）
+          if (children && props.children === undefined) {
+            props.children = children
+          }
           return `${renderTemplate(def, props)}\n`
         },
       },

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -1,0 +1,283 @@
+import type { ComponentRegistry, CustomComponentDef } from '@md/shared/types'
+import type { MarkedExtension } from 'marked'
+
+// ────────────────────────────────────────────────────────────────────────────
+// 内置组件定义
+// ────────────────────────────────────────────────────────────────────────────
+
+export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
+  {
+    id: `builtin-qrcode`,
+    name: `QRCodeBlock`,
+    description: `二维码组件，将 URL 渲染为可扫描的二维码图片`,
+    builtIn: true,
+    props: [
+      { name: `url`, description: `二维码内容（URL）`, required: true },
+      { name: `text`, description: `二维码下方提示文字`, default: `扫码访问` },
+      { name: `size`, description: `二维码尺寸（px）`, default: `150` },
+    ],
+    template: `<section style="text-align: center; margin: 20px auto; padding: 16px 0;">
+  <img
+    src="https://api.qrserver.com/v1/create-qr-code/?size={{size}}x{{size}}&data={{url}}"
+    alt="QR Code"
+    style="width: {{size}}px; height: {{size}}px; display: block; margin: 0 auto; border-radius: 4px;"
+  />
+  <p style="text-align: center; font-size: 14px; color: #888; margin-top: 8px; margin-bottom: 0;">{{text}}</p>
+</section>`,
+  },
+  {
+    id: `builtin-card`,
+    name: `CardBlock`,
+    description: `卡片组件，展示带标题和描述的卡片`,
+    builtIn: true,
+    props: [
+      { name: `title`, description: `卡片标题`, required: true },
+      { name: `description`, description: `卡片描述文字` },
+      { name: `url`, description: `跳转链接（可选）` },
+      { name: `cover`, description: `封面图片 URL（可选）` },
+    ],
+    template: `<section style="border: 1px solid #e8e8e8; border-radius: 8px; overflow: hidden; margin: 16px 0; background: #fff;">
+  {{#if cover}}<img src="{{cover}}" alt="{{title}}" style="width: 100%; height: 160px; object-fit: cover; display: block;" />{{/if}}
+  <section style="padding: 16px;">
+    <p style="margin: 0 0 8px; font-size: 16px; font-weight: bold; color: #333;">{{title}}</p>
+    {{#if description}}<p style="margin: 0; font-size: 14px; color: #666; line-height: 1.6;">{{description}}</p>{{/if}}
+    {{#if url}}<a href="{{url}}" style="display: inline-block; margin-top: 12px; font-size: 13px; color: #07c160; text-decoration: none;">阅读全文 →</a>{{/if}}
+  </section>
+</section>`,
+  },
+  {
+    id: `builtin-author`,
+    name: `AuthorBlock`,
+    description: `作者信息组件，展示作者头像、名称和简介`,
+    builtIn: true,
+    props: [
+      { name: `name`, description: `作者名称`, required: true },
+      { name: `avatar`, description: `头像图片 URL` },
+      { name: `bio`, description: `作者简介` },
+    ],
+    template: `<section style="display: table; width: 100%; border-top: 1px solid #f0f0f0; padding: 16px 0; margin: 16px 0; box-sizing: border-box;">
+  <section style="display: table-cell; vertical-align: middle; width: 64px;">
+    <img src="{{avatar}}" alt="{{name}}" style="width: 56px; height: 56px; border-radius: 50%; display: block;" />
+  </section>
+  <section style="display: table-cell; vertical-align: middle; padding-left: 12px;">
+    <p style="margin: 0 0 4px; font-size: 15px; font-weight: bold; color: #333;">{{name}}</p>
+    <p style="margin: 0; font-size: 13px; color: #888; line-height: 1.5;">{{bio}}</p>
+  </section>
+</section>`,
+  },
+  {
+    id: `builtin-tip`,
+    name: `TipBlock`,
+    description: `提示框组件，高亮展示小贴士或注意事项`,
+    builtIn: true,
+    props: [
+      { name: `type`, description: `类型：info | success | warning | danger`, default: `info` },
+      { name: `title`, description: `标题（可选）` },
+      { name: `content`, description: `提示内容`, required: true },
+    ],
+    template: `<section style="border-left: 4px solid {{borderColor}}; background: {{bgColor}}; padding: 12px 16px; margin: 16px 0; border-radius: 0 6px 6px 0;">
+  {{#if title}}<p style="margin: 0 0 6px; font-size: 14px; font-weight: bold; color: {{textColor}};">{{title}}</p>{{/if}}
+  <p style="margin: 0; font-size: 14px; color: {{textColor}}; line-height: 1.6;">{{content}}</p>
+</section>`,
+  },
+]
+
+// ────────────────────────────────────────────────────────────────────────────
+// 属性解析
+// ────────────────────────────────────────────────────────────────────────────
+
+/** 将 prop 字符串解析为 key->value 映射 */
+function parseProps(propsStr: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  // 支持 key="value" 和 key='value'
+  for (const m of propsStr.matchAll(/(\w[\w-]*)=(?:"([^"]*)"|'([^']*)')/g)) {
+    result[m[1]] = m[2] !== undefined ? m[2] : (m[3] ?? ``)
+  }
+  return result
+}
+
+/** HTML 属性值转义（防 XSS） */
+function escapeAttr(val: string): string {
+  return val
+    .replace(/&/g, `&amp;`)
+    .replace(/"/g, `&quot;`)
+    .replace(/'/g, `&#39;`)
+    .replace(/</g, `&lt;`)
+    .replace(/>/g, `&gt;`)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// TipBlock 类型颜色映射
+// ────────────────────────────────────────────────────────────────────────────
+
+const TIP_COLORS: Record<string, { borderColor: string, bgColor: string, textColor: string }> = {
+  info: { borderColor: `#1890ff`, bgColor: `#e6f7ff`, textColor: `#0050b3` },
+  success: { borderColor: `#52c41a`, bgColor: `#f6ffed`, textColor: `#135200` },
+  warning: { borderColor: `#faad14`, bgColor: `#fffbe6`, textColor: `#874d00` },
+  danger: { borderColor: `#ff4d4f`, bgColor: `#fff2f0`, textColor: `#a8071a` },
+}
+
+/** 为 TipBlock 注入颜色变量 */
+function injectTipColors(props: Record<string, string>): Record<string, string> {
+  const type = props.type || `info`
+  const colors = TIP_COLORS[type] || TIP_COLORS.info
+  return { ...colors, ...props }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 模板渲染
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 将组件定义和 props 渲染为 HTML 字符串。
+ * 支持：
+ *   - `{{propName}}` 基础占位符替换（值自动转义）
+ *   - `{{#if propName}}...{{/if}}` 条件块（prop 存在且非空时显示）
+ */
+function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string>): string {
+  // 1. 合并默认值
+  const props: Record<string, string> = {}
+  for (const propDef of def.props) {
+    if (propDef.default !== undefined) {
+      props[propDef.name] = propDef.default
+    }
+  }
+  Object.assign(props, rawProps)
+
+  // 2. TipBlock 特殊处理：注入颜色变量
+  const finalProps = def.name === `TipBlock` ? injectTipColors(props) : props
+
+  let html = def.template
+
+  // 3. 处理 {{#if prop}}...{{/if}} 条件块
+  html = html.replace(/\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, content) => {
+    return finalProps[key] ? content : ``
+  })
+
+  // 4. 替换 {{propName}} 占位符（转义值）
+  html = html.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+    return finalProps[key] !== undefined ? escapeAttr(finalProps[key]) : ``
+  })
+
+  return html
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 可变注册表（通过 setComponentRegistry 在渲染时更新）
+// ────────────────────────────────────────────────────────────────────────────
+
+let _registry: ComponentRegistry = {}
+
+/** 更新当前渲染使用的组件注册表 */
+export function setComponentRegistry(registry: ComponentRegistry): void {
+  _registry = registry
+}
+
+/** 获取内置组件注册表 */
+export function getBuiltInRegistry(): ComponentRegistry {
+  const reg: ComponentRegistry = {}
+  for (const c of BUILT_IN_COMPONENTS) {
+    reg[c.name] = c
+  }
+  return reg
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Marked 扩展
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * marked 扩展：解析 JSX 风格的自定义组件语法
+ *
+ * 支持：
+ *   自闭合：  <ComponentName prop="value" />
+ *   开闭合：  <ComponentName prop="value">children</ComponentName>
+ *
+ * 组件名必须以大写字母开头（PascalCase）以与普通 HTML 标签区分。
+ */
+export function markedComponent(): MarkedExtension {
+  /**
+   * 简单的非正则标签解析器，避免复杂 regex 的回溯问题。
+   * 返回 raw（完整原始文本）、name（组件名）、propsStr（属性串）。
+   */
+  function parseTag(src: string) {
+    // 必须以 <UppercaseLetter 开头
+    if (src[0] !== `<` || src[1] < `A` || src[1] > `Z`)
+      return null
+
+    // 提取组件名
+    let i = 1
+    while (i < src.length && /\w/.test(src[i])) i++
+    const name = src.slice(1, i)
+    if (!name)
+      return null
+
+    // 扫描开始标签内容，正确处理引号内的 > 字符
+    let inQuote = ``
+    let j = i
+    while (j < src.length) {
+      const ch = src[j]
+      if (inQuote) {
+        if (ch === inQuote)
+          inQuote = ``
+      }
+      else if (ch === `"` || ch === `'`) {
+        inQuote = ch
+      }
+      else if (ch === `/` && src[j + 1] === `>`) {
+        // 自闭合标签结束
+        return { raw: src.slice(0, j + 2), name, propsStr: src.slice(i, j).trim(), children: `` }
+      }
+      else if (ch === `>`) {
+        // 开放标签结束，找对应的关闭标签
+        const closeTag = `</${name}>`
+        const closeIdx = src.indexOf(closeTag, j + 1)
+        if (closeIdx < 0)
+          return null
+        const children = src.slice(j + 1, closeIdx)
+        return { raw: src.slice(0, closeIdx + closeTag.length), name, propsStr: src.slice(i, j).trim(), children }
+      }
+      j++
+    }
+    return null
+  }
+
+  return {
+    extensions: [
+      {
+        name: `mdComponent`,
+        level: `block`,
+
+        start(src: string) {
+          // 快速定位到第一个大写字母开头的 '<'
+          const idx = src.search(/<[A-Z]/)
+          return idx >= 0 ? idx : undefined
+        },
+
+        tokenizer(src: string) {
+          const tag = parseTag(src)
+          if (!tag)
+            return undefined
+          return {
+            type: `mdComponent`,
+            raw: tag.raw,
+            name: tag.name,
+            propsStr: tag.propsStr,
+            children: tag.children,
+          }
+        },
+
+        renderer(token) {
+          const { name, propsStr } = token as unknown as { name: string, propsStr: string }
+          const def = _registry[name]
+          if (!def) {
+            // 未知组件，保留原始文本并给出提示
+            return `<p style="color:#f00;font-size:12px;">[未知组件: ${name}]</p>\n`
+          }
+          const props = parseProps(propsStr)
+          return `${renderTemplate(def, props)}\n`
+        },
+      },
+    ],
+  }
+}

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -24,6 +24,7 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
   />
   <p style="text-align: center; font-size: 14px; color: #888; margin-top: 8px; margin-bottom: 0;">{{text}}</p>
 </section>`,
+    example: `<QRCodeBlock url="https://md.doocs.org" text="扫码访问" size="150" />`,
   },
   {
     id: `builtin-card`,
@@ -44,6 +45,7 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
     {{#if url}}<a href="{{url}}" style="display: inline-block; margin-top: 12px; font-size: 13px; color: #07c160; text-decoration: none;">阅读全文 →</a>{{/if}}
   </section>
 </section>`,
+    example: `<CardBlock title="Doocs 开源社区" description="低门槛、高质量的互联网技术社区" url="https://doocs.github.io" />`,
   },
   {
     id: `builtin-author`,
@@ -55,7 +57,7 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
       { name: `avatar`, description: `头像图片 URL` },
       { name: `bio`, description: `作者简介` },
     ],
-    template: `<section style="display: table; width: 100%; border-top: 1px solid #f0f0f0; padding: 16px 0; margin: 16px 0; box-sizing: border-box;">
+    template: `<section style="display: table; width: 100%; padding: 16px 0; margin: 16px 0; box-sizing: border-box;">
   <section style="display: table-cell; vertical-align: middle; width: 64px;">
     <img src="{{avatar}}" alt="{{name}}" style="width: 56px; height: 56px; border-radius: 50%; display: block;" />
   </section>
@@ -64,6 +66,7 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
     <p style="margin: 0; font-size: 13px; color: #888; line-height: 1.5;">{{bio}}</p>
   </section>
 </section>`,
+    example: `<AuthorBlock name="yanglbme" avatar="https://avatars.githubusercontent.com/u/21008209?v=4" bio="Creator of Doocs" />`,
   },
   {
     id: `builtin-tip`,
@@ -79,6 +82,7 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
   {{#if title}}<p style="margin: 0 0 6px; font-size: 14px; font-weight: bold; color: {{textColor}};">{{title}}</p>{{/if}}
   <p style="margin: 0; font-size: 14px; color: {{textColor}}; line-height: 1.6;">{{content}}</p>
 </section>`,
+    example: `<TipBlock type="info" title="提示" content="这是一条提示信息" />`,
   },
 ]
 

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -1,5 +1,6 @@
 // Markdown 扩展导出
 export * from './alert'
+export * from './component'
 export * from './footnotes'
 export * from './infographic'
 export * from './katex'

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -7,6 +7,7 @@ import hljs from 'highlight.js/lib/core'
 import { marked } from 'marked'
 import {
   markedAlert,
+  markedComponent,
   markedFootnotes,
   markedInfographic,
   markedMarkup,
@@ -16,6 +17,7 @@ import {
   markedSlider,
   markedToc,
   MDKatex,
+  setComponentRegistry,
 } from '../extensions'
 import { COMMON_LANGUAGES, highlightAndFormatCode } from '../utils/languages'
 
@@ -121,6 +123,54 @@ const macCodeSvg = `
   </svg>
 `.trim()
 
+/**
+ * 渲染 diff-{lang} 代码块。
+ * 以 `+` 开头的行显示绿色底色（新增），`-` 开头的行显示红色底色（删除），
+ * 其余行正常高亮显示。
+ */
+function renderDiffCode(text: string, baseLang: string): string {
+  const isLangRegistered = hljs.getLanguage(baseLang)
+  const lang = isLangRegistered ? baseLang : `plaintext`
+
+  const lines = text.split(`\n`)
+  const rendered = lines
+    .map((line) => {
+      const prefix = line[0]
+      const rest = line.slice(1)
+      let highlighted: string
+      let bg: string
+      let sign: string
+
+      if (prefix === `+`) {
+        highlighted = isLangRegistered
+          ? hljs.highlight(rest, { language: lang }).value
+          : escapeHtml(rest)
+        bg = `background:rgba(80,200,80,.18);`
+        sign = `<span style="color:#52c41a;user-select:none;">+</span>`
+      }
+      else if (prefix === `-`) {
+        highlighted = isLangRegistered
+          ? hljs.highlight(rest, { language: lang }).value
+          : escapeHtml(rest)
+        bg = `background:rgba(255,80,80,.18);`
+        sign = `<span style="color:#ff4d4f;user-select:none;">-</span>`
+      }
+      else {
+        highlighted = isLangRegistered
+          ? hljs.highlight(line, { language: lang }).value
+          : escapeHtml(line)
+        bg = ``
+        sign = `<span style="user-select:none;"> </span>`
+      }
+
+      return `<span style="display:block;${bg}">${sign}${highlighted}</span>`
+    })
+    .join(``)
+
+  const span = `<span class="mac-sign" style="padding: 10px 14px 0;">${macCodeSvg}</span>`
+  return `<pre class="hljs code__pre">${span}<code class="language-diff-${baseLang}">${rendered}</code></pre>`
+}
+
 interface ParseResult {
   yamlData: Record<string, any>
   markdownContent: string
@@ -191,6 +241,9 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   function reset(newOpts: Partial<IOpts>): void {
     footnotes.length = 0
     footnoteIndex = 0
+    if (newOpts.components !== undefined) {
+      setComponentRegistry(newOpts.components)
+    }
     setOptions(newOpts)
   }
 
@@ -249,6 +302,12 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
     code({ text, lang = `` }: Tokens.Code): string {
       const langText = lang.split(` `)[0]
+
+      // diff-{lang} 语法：将代码渲染为 diff 对比视图（+/- 行着色）
+      if (langText.startsWith(`diff-`)) {
+        return renderDiffCode(text, langText.slice(5))
+      }
+
       const isLanguageRegistered = hljs.getLanguage(langText)
       const language = isLanguageRegistered ? langText : `plaintext`
 
@@ -404,6 +463,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
   marked.use({ renderer })
   // 新主题系统：扩展不再需要 styles 参数
+  marked.use(markedComponent())
   marked.use(markedMarkup())
   marked.use(markedToc())
   marked.use(markedSlider())

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -6,6 +6,7 @@ import frontMatter from 'front-matter'
 import hljs from 'highlight.js/lib/core'
 import { marked } from 'marked'
 import {
+  getBuiltInRegistry,
   markedAlert,
   markedComponent,
   markedFootnotes,
@@ -17,7 +18,6 @@ import {
   markedSlider,
   markedToc,
   MDKatex,
-  setComponentRegistry,
 } from '../extensions'
 import { COMMON_LANGUAGES, highlightAndFormatCode } from '../utils/languages'
 
@@ -133,32 +133,32 @@ function renderDiffCode(text: string, baseLang: string): string {
   const lang = isLangRegistered ? baseLang : `plaintext`
 
   const lines = text.split(`\n`)
+  const prefixes = lines.map(line => line[0])
+  // 将每行去掉前缀（+/-/ ）后拼接，整体高亮一次以避免逐行调用 hljs
+  const strippedLines = lines.map((line, i) => {
+    const p = prefixes[i]
+    return (p === `+` || p === `-`) ? line.slice(1) : line
+  })
+  const highlightedLines = isLangRegistered
+    ? hljs.highlight(strippedLines.join(`\n`), { language: lang }).value.split(`\n`)
+    : strippedLines.map(escapeHtml)
+
   const rendered = lines
-    .map((line) => {
-      const prefix = line[0]
-      const rest = line.slice(1)
-      let highlighted: string
+    .map((_, i) => {
+      const prefix = prefixes[i]
+      const highlighted = highlightedLines[i] ?? ``
       let bg: string
       let sign: string
 
       if (prefix === `+`) {
-        highlighted = isLangRegistered
-          ? hljs.highlight(rest, { language: lang }).value
-          : escapeHtml(rest)
         bg = `background:rgba(80,200,80,.18);`
         sign = `<span style="color:#52c41a;user-select:none;">+</span>`
       }
       else if (prefix === `-`) {
-        highlighted = isLangRegistered
-          ? hljs.highlight(rest, { language: lang }).value
-          : escapeHtml(rest)
         bg = `background:rgba(255,80,80,.18);`
         sign = `<span style="color:#ff4d4f;user-select:none;">-</span>`
       }
       else {
-        highlighted = isLangRegistered
-          ? hljs.highlight(line, { language: lang }).value
-          : escapeHtml(line)
         bg = ``
         sign = `<span style="user-select:none;"> </span>`
       }
@@ -241,9 +241,6 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   function reset(newOpts: Partial<IOpts>): void {
     footnotes.length = 0
     footnoteIndex = 0
-    if (newOpts.components !== undefined) {
-      setComponentRegistry(newOpts.components)
-    }
     setOptions(newOpts)
   }
 
@@ -463,7 +460,8 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
   marked.use({ renderer })
   // 新主题系统：扩展不再需要 styles 参数
-  marked.use(markedComponent())
+  // 通过闭包传入注册表 getter，避免直接依赖全局状态
+  marked.use(markedComponent(() => opts.components ?? getBuiltInRegistry()))
   marked.use(markedMarkup())
   marked.use(markedToc())
   marked.use(markedSlider())

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1,4 +1,5 @@
 import type { Token } from 'marked'
+import type { ComponentRegistry } from './component'
 
 /**
  * 渲染器选项（新主题系统）
@@ -12,6 +13,8 @@ export interface IOpts {
   isMacCodeBlock?: boolean
   isShowLineNumber?: boolean
   themeMode?: 'light' | 'dark'
+  /** 自定义组件注册表 */
+  components?: ComponentRegistry
 }
 
 export interface IConfigOption<VT = string> {

--- a/packages/shared/src/types/component.ts
+++ b/packages/shared/src/types/component.ts
@@ -34,6 +34,8 @@ export interface CustomComponentDef {
   props: ComponentPropDef[]
   /** 是否为内置组件（内置组件不可删除，但可覆盖） */
   builtIn?: boolean
+  /** 使用示例（用于 UI 展示，优先于自动生成的 snippet） */
+  example?: string
   /** 创建时间戳 */
   createdAt?: number
   /** 最后更新时间戳 */

--- a/packages/shared/src/types/component.ts
+++ b/packages/shared/src/types/component.ts
@@ -1,0 +1,60 @@
+/**
+ * 自定义组件系统类型定义
+ *
+ * 允许用户在 Markdown 中使用 JSX 风格的自定义组件：
+ *   <QRCodeBlock url="https://example.com" text="扫码访问" />
+ */
+
+/** 组件 Prop 定义 */
+export interface ComponentPropDef {
+  /** Prop 名称 */
+  name: string
+  /** Prop 描述（用于编辑器提示） */
+  description?: string
+  /** 默认值 */
+  default?: string
+  /** 是否必填 */
+  required?: boolean
+}
+
+/** 组件定义 */
+export interface CustomComponentDef {
+  /** 唯一 ID */
+  id: string
+  /** 组件名称，必须为 PascalCase，如 QRCodeBlock */
+  name: string
+  /** 组件描述 */
+  description?: string
+  /**
+   * HTML 模板，使用 {{propName}} 作为 prop 占位符
+   * @example `<img src="https://api.qrserver.com/v1/create-qr-code/?data={{url}}" />`
+   */
+  template: string
+  /** Prop 列表 */
+  props: ComponentPropDef[]
+  /** 是否为内置组件（内置组件不可删除，但可覆盖） */
+  builtIn?: boolean
+  /** 创建时间戳 */
+  createdAt?: number
+  /** 最后更新时间戳 */
+  updatedAt?: number
+}
+
+/** 组件注册表：组件名 -> 组件定义 */
+export type ComponentRegistry = Record<string, CustomComponentDef>
+
+/** 创建组件的参数 */
+export interface CreateComponentParams {
+  name: string
+  description?: string
+  template: string
+  props: ComponentPropDef[]
+}
+
+/** 更新组件的参数 */
+export interface UpdateComponentParams {
+  name?: string
+  description?: string
+  template?: string
+  props?: ComponentPropDef[]
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './ai-services-types'
 export * from './common'
+export * from './component'
 export * from './renderer-types'
 export * from './template'


### PR DESCRIPTION
## 概述

实现 #552 提出的自定义组件功能，允许用户在 Markdown 中使用 JSX 风格的组件语法，预览区按组件预定义的样式进行渲染。

## 语法

**自闭合：**
```
<QRCodeBlock url="https://baidu.com" text="长按二维码识别" />
```

**带内容：**
```
<CardBlock title="文章标题" description="摘要内容" url="https://example.com" />
```

**diff 代码块：**
````
```diff-js
- console.log('hello world');
+ console.log('hello mdx');
```
````

## 内置组件

| 组件 | 说明 |
|------|------|
| `QRCodeBlock` | 二维码（url, text, size） |
| `CardBlock` | 文章卡片（title, description, url, cover） |
| `AuthorBlock` | 作者信息（name, avatar, bio） |
| `TipBlock` | 提示框（type: info/success/warning/danger, title, content） |

## 用户自定义组件

用户可在「插入 → 自定义组件」对话框中新建组件，模板语法：
- `{{propName}}` — prop 值（自动 HTML 转义）
- `{{#if propName}}...{{/if}}` — 条件块

## 变更文件

- `packages/shared/src/types/component.ts` — 类型定义
- `packages/core/src/extensions/component.ts` — marked 扩展 + 内置组件
- `packages/core/src/renderer/renderer-impl.ts` — 注册扩展，支持 diff-{lang}
- `apps/web/src/stores/customComponent.ts` — Pinia Store（localStorage 持久化）
- `apps/web/src/stores/render.ts` — 传入组件注册表
- `apps/web/src/stores/ui.ts` — 对话框状态
- `apps/web/src/components/editor/CustomComponentDialog.vue` — 管理 UI
- `apps/web/src/components/editor/editor-header/InsertDropdown.vue` — 菜单入口

Closes #552
