### PR TITLE
fix: replace :checked with v-model on CheckboxRoot in PostInfo

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -381,7 +381,7 @@ onBeforeMount(() => {
                   </div>
                   <div class="flex items-center gap-1 ml-2">
                     <CheckboxRoot
-                      :checked="isCategoryAllSelected(category.accounts) ? true : isCategoryIndeterminate(category.accounts) ? 'indeterminate' : false"
+                      :model-value="isCategoryAllSelected(category.accounts) ? true : isCategoryIndeterminate(category.accounts) ? 'indeterminate' : false"
                       class="bg-background hover:bg-muted h-[18px] w-[18px] flex shrink-0 appearance-none items-center justify-center border border-gray-300 rounded-[3px] outline-hidden"
                       @click.stop="toggleCategorySelectAll(category.accounts)"
                     >
@@ -400,7 +400,7 @@ onBeforeMount(() => {
                     class="flex items-center gap-2 whitespace-nowrap"
                   >
                     <CheckboxRoot
-                      v-model:checked="account.checked"
+                      v-model="account.checked"
                       :disabled="!account.loggedIn"
                       class="bg-background hover:bg-muted h-[18px] w-[18px] flex shrink-0 appearance-none items-center justify-center border border-gray-300 rounded-[3px] outline-hidden disabled:opacity-50 disabled:cursor-not-allowed"
                     >


### PR DESCRIPTION
## Summary
- Fixes checkbox two-way binding issue in the multi-platform post dialog
- Replaces `:checked` with `v-model` on category-level `CheckboxRoot` (one-way binding doesn't update internal state)
- Replaces `v-model:checked` with `v-model` on individual account checkboxes (reka-ui uses `modelValue` as default, not `checked`)

## Problem
Individual platform checkboxes couldn't be toggled — only clicking the "select all" checkbox worked. This was because `:checked` creates a one-way binding that doesn't trigger the component's internal state update, and `v-model:checked` binds to a non-existent prop on `CheckboxRoot` from reka-ui.

## Test plan
- [ ] Open the multi-platform post dialog
- [ ] Verify individual platform checkboxes can be toggled by clicking on them
- [ ] Verify "select all" checkbox still works correctly for each category
- [ ] Verify indeterminate state displays correctly when some checkboxes are selected

Closes #1590

🤖 Generated with [Claude Code](https://claude.com/claude-code)