### PR TITLE
fix: cap scroll sync targets and handle malformed internal links

### DIFF
--- a/apps/web/src/composables/useCursorSync.ts
+++ b/apps/web/src/composables/useCursorSync.ts
@@ -132,14 +132,18 @@ export function useCursorSync(
     if (linkEl) {
       const href = linkEl.getAttribute(`href`)
       if (href && href.startsWith(`#`)) {
-        const targetId = decodeURIComponent(href.slice(1))
+        let targetId = ``
+        try {
+          targetId = decodeURIComponent(href.slice(1))
+        }
+        catch {}
         if (targetId) {
           const targetEl = document.getElementById(targetId)
           if (targetEl) {
-            event.preventDefault()
-            event.stopPropagation()
             const container = target.closest(`.preview-wrapper`) || document.getElementById(`preview`)
-            if (container) {
+            if (container && container.contains(targetEl)) {
+              event.preventDefault()
+              event.stopPropagation()
               const containerRect = container.getBoundingClientRect()
               const elementRect = targetEl.getBoundingClientRect()
               const targetScrollTop = elementRect.top - containerRect.top + container.scrollTop

--- a/apps/web/src/composables/useScrollSync.ts
+++ b/apps/web/src/composables/useScrollSync.ts
@@ -220,8 +220,9 @@ export function useScrollSync(
       return
     }
     if (scroller.scrollTop >= scrollable) {
-      pendingPreviewScrollTop = preview.scrollHeight - preview.clientHeight
-      preview.scrollTop = preview.scrollHeight
+      const maxPreviewScrollTop = preview.scrollHeight - preview.clientHeight
+      pendingPreviewScrollTop = maxPreviewScrollTop
+      preview.scrollTop = maxPreviewScrollTop
       requestAnimationFrame(() => { isSyncingFromEditor = false })
       return
     }
@@ -247,8 +248,10 @@ export function useScrollSync(
 
     const previewIndex = mapBlockIndex(srcIndex, sourceBlocks.length, previewBlocks.length)
     const targetIndex = Math.min(previewIndex, previewBlocks.length - 1)
-    pendingPreviewScrollTop = previewOffsetTops[targetIndex]
-    preview.scrollTop = previewOffsetTops[targetIndex]
+    const maxPreviewScrollTop = preview.scrollHeight - preview.clientHeight
+    const targetScrollTop = Math.min(previewOffsetTops[targetIndex], maxPreviewScrollTop)
+    pendingPreviewScrollTop = targetScrollTop
+    preview.scrollTop = targetScrollTop
     requestAnimationFrame(() => { isSyncingFromEditor = false })
   }
 
@@ -285,8 +288,9 @@ export function useScrollSync(
       return
     }
     if (preview.scrollTop >= previewScrollable) {
-      pendingEditorScrollTop = view.scrollDOM.scrollHeight - view.scrollDOM.clientHeight
-      view.scrollDOM.scrollTop = view.scrollDOM.scrollHeight
+      const maxEditorScrollTop = view.scrollDOM.scrollHeight - view.scrollDOM.clientHeight
+      pendingEditorScrollTop = maxEditorScrollTop
+      view.scrollDOM.scrollTop = maxEditorScrollTop
       requestAnimationFrame(() => { isSyncingFromPreview = false })
       return
     }
@@ -322,8 +326,10 @@ export function useScrollSync(
 
     const blockInfo = view.lineBlockAt(line.from)
     if (blockInfo) {
-      pendingEditorScrollTop = blockInfo.top
-      view.scrollDOM.scrollTop = blockInfo.top
+      const maxEditorScrollTop = view.scrollDOM.scrollHeight - view.scrollDOM.clientHeight
+      const targetScrollTop = Math.min(blockInfo.top, maxEditorScrollTop)
+      pendingEditorScrollTop = targetScrollTop
+      view.scrollDOM.scrollTop = targetScrollTop
     }
     requestAnimationFrame(() => { isSyncingFromPreview = false })
   }


### PR DESCRIPTION
## Summary

Fix scroll sync overshooting and handle malformed internal anchor links.

## Changes

### useScrollSync.ts
- Cap editor-to-preview scroll targets at `scrollHeight - clientHeight` to prevent overshooting to the bottom
- Cap preview-to-editor scroll targets at `scrollHeight - clientHeight` to prevent overshooting
- Use `Math.min()` to ensure target scroll positions never exceed the maximum scrollable height
- Extract `maxScrollTop` into a constant to avoid duplicate calculations

### useCursorSync.ts
- Wrap `decodeURIComponent()` in try-catch to avoid errors on malformed href values
- Only `preventDefault` for internal anchor clicks when the target element is contained within the preview container — avoids intercepting links to elements outside the preview scope

## Related

Builds on recent scroll sync echo prevention work (#1598, #1599).

🤖 Generated with [Claude Code](https://claude.com/claude-code)