### PR TITLE
feat: add .codespan inline code styling & refactor hardcoded colors to CSS variables

### DIFF
--- a/packages/shared/src/assets/default-custom-theme.txt
+++ b/packages/shared/src/assets/default-custom-theme.txt
@@ -54,7 +54,7 @@ blockquote > p {
 
 /* 代码 */
 /* 行内代码 */
-code {
+.codespan {
 }
 
 /* 代码块容器 */

--- a/packages/shared/src/configs/theme-css/default.css
+++ b/packages/shared/src/configs/theme-css/default.css
@@ -316,7 +316,7 @@ figure {
 figcaption,
 .md-figcaption {
   text-align: center;
-  color: #888;
+  color: color-mix(in srgb, hsl(var(--foreground)) 50%, transparent);
   font-size: 0.8em;
 }
 
@@ -386,15 +386,15 @@ thead {
 }
 
 th {
-  border: 1px solid #dfdfdf;
+  border: 1px solid color-mix(in srgb, hsl(var(--foreground)) 15%, transparent);
   padding: 0.25em 0.5em;
   color: hsl(var(--foreground));
   word-break: keep-all;
-  background: rgba(0, 0, 0, 0.05);
+  background: color-mix(in srgb, hsl(var(--foreground)) 5%, transparent);
 }
 
 td {
-  border: 1px solid #dfdfdf;
+  border: 1px solid color-mix(in srgb, hsl(var(--foreground)) 15%, transparent);
   padding: 0.25em 0.5em;
   color: hsl(var(--foreground));
   word-break: keep-all;

--- a/packages/shared/src/configs/theme-css/default.css
+++ b/packages/shared/src/configs/theme-css/default.css
@@ -334,12 +334,13 @@ hr {
 }
 
 /* ==================== 行内代码 ==================== */
-code {
+.codespan {
   font-size: 90%;
-  color: #d14;
-  background: rgba(27, 31, 35, 0.05);
+  color: var(--md-primary-color);
+  background: color-mix(in srgb, var(--md-primary-color) 8%, transparent);
   padding: 3px 5px;
   border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--md-primary-color) 20%, transparent);
 }
 
 /* 代码块内的 code 标签需要特殊处理（覆盖行内 code 样式） */

--- a/packages/shared/src/configs/theme-css/grace.css
+++ b/packages/shared/src/configs/theme-css/grace.css
@@ -52,6 +52,12 @@ blockquote {
   font-style: italic;
 }
 
+/* ==================== 行内代码 ==================== */
+.codespan {
+  font-family: 'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
 /* ==================== 代码块 ==================== */
 pre.code__pre,
 .hljs.code__pre {

--- a/packages/shared/src/configs/theme-css/simple.css
+++ b/packages/shared/src/configs/theme-css/simple.css
@@ -64,6 +64,13 @@ blockquote {
   font-style: italic;
 }
 
+/* ==================== 行内代码 ==================== */
+.codespan {
+  font-family: 'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--md-primary-color) 15%, transparent);
+}
+
 /* ==================== 代码块 ==================== */
 pre.code__pre,
 .hljs.code__pre {


### PR DESCRIPTION
## Summary

This PR adds consistent `.codespan` inline code styling across all themes and refactors hardcoded colors to CSS variables.

## Changes

### 1. Inline code (.codespan) styling

| Theme | Details |
|-------|---------|
| **default.css** | Refactored `code` selector to `.codespan`, uses `--md-primary-color` for color, background (8% mix), and border (20% mix) |
| **grace.css** | Added `.codespan` with Fira Code font-family and subtle box-shadow |
| **simple.css** | Added `.codespan` with Fira Code font-family, rounded corners, and primary-colored border |
| **default-custom-theme.txt** | Aligned `code` selector to `.codespan` |

### 2. Hardcoded color → CSS variable refactoring (default.css)

| Element | Before | After |
|---------|--------|-------|
| figcaption color | `#888` | `color-mix(in srgb, hsl(var(--foreground)) 50%, transparent)` |
| table th/td border | `#dfdfdf` | `color-mix(in srgb, hsl(var(--foreground)) 15%, transparent)` |
| table th background | `rgba(0,0,0,0.05)` | `color-mix(in srgb, hsl(var(--foreground)) 5%, transparent)` |

## Commits

- feat: add .codespan inline code styling across all themes
- refactor: replace hardcoded colors with CSS variables in default theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)