### PR TITLE
fix: stabilize renderer state and copy preview behavior

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -8,6 +8,8 @@ import { css } from './css'
 import { MarkdownTreeDataProvider } from './treeDataProvider'
 
 let activePanel: vscode.WebviewPanel | undefined
+let activePreviewEditor: vscode.TextEditor | undefined
+let refreshActivePanel: (() => void) | undefined
 
 export function activate(context: vscode.ExtensionContext) {
   // Register TreeDataProvider
@@ -44,6 +46,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     // 如果已有面板且未关闭，则直接显示
     if (activePanel) {
+      activePreviewEditor = editor
+      activePanel.title = `Markdown Preview - ${editor.document.fileName}`
+      refreshActivePanel?.()
       activePanel.reveal(vscode.ViewColumn.Two)
       return
     }
@@ -60,15 +65,26 @@ export function activate(context: vscode.ExtensionContext) {
     )
 
     activePanel = panel
+    activePreviewEditor = editor
 
     panel.onDidDispose(() => {
-      activePanel = undefined
+      if (activePanel === panel) {
+        activePanel = undefined
+        activePreviewEditor = undefined
+        refreshActivePanel = undefined
+      }
     })
 
-    treeDataProvider.onDidChangeTreeData(updateWebview)
+    const treeDataSubscription = treeDataProvider.onDidChangeTreeData(() => {
+      refreshActivePanel?.()
+    })
+
     function updateWebview() {
-      if (!editor)
+      const previewEditor = activePreviewEditor
+      if (!previewEditor || previewEditor.document.languageId !== `markdown`)
         return
+
+      panel.title = `Markdown Preview - ${previewEditor.document.fileName}`
 
       // 使用新主题系统
       const renderer = initRenderer({
@@ -77,7 +93,7 @@ export function activate(context: vscode.ExtensionContext) {
         legend: `none`,
       })
 
-      const markdownContent = editor.document.getText()
+      const markdownContent = previewEditor.document.getText()
       const html = modifyHtmlContent(markdownContent, renderer)
 
       // 生成主题 CSS
@@ -95,12 +111,14 @@ export function activate(context: vscode.ExtensionContext) {
       panel.webview.html = wrapHtmlTag(html, completeCss)
     }
 
+    refreshActivePanel = updateWebview
+
     // render first webview
     updateWebview()
 
     // Monitor the changes of documents
     const changeSubscription = vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
-      if (e.document === editor.document) {
+      if (activePreviewEditor && e.document === activePreviewEditor.document) {
         updateWebview()
       }
     })
@@ -108,6 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Cancel the subscription when the panel is closed
     panel.onDidDispose(() => {
       changeSubscription.dispose()
+      treeDataSubscription.dispose()
     })
   })
 

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -95,16 +95,9 @@ function fallbackCopyUsingExecCommand(htmlContent: string) {
   tempContainer.style.setProperty(`color`, `#000000`, `important`)
 
   document.body.appendChild(tempContainer)
-
-  const htmlElement = document.documentElement
-  const wasDark = htmlElement.classList.contains(`dark`)
   let successful = false
 
   try {
-    if (wasDark) {
-      htmlElement.classList.remove(`dark`)
-    }
-
     const range = document.createRange()
     range.selectNodeContents(tempContainer)
     selection.removeAllRanges()
@@ -118,10 +111,6 @@ function fallbackCopyUsingExecCommand(htmlContent: string) {
   finally {
     selection.removeAllRanges()
     tempContainer.remove()
-
-    if (wasDark) {
-      htmlElement.classList.add(`dark`)
-    }
   }
 
   return successful

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -131,8 +131,13 @@ async function copy() {
 
   setTimeout(() => {
     nextTick(async () => {
+      let processedClipboardContent: {
+        html: string
+        plainText: string
+      }
+
       try {
-        await processClipboardContent(primaryColor.value)
+        processedClipboardContent = await processClipboardContent(primaryColor.value)
       }
       catch (error) {
         toast.error(`处理 HTML 失败，请联系开发者。${normalizeErrorMessage(error)}`)
@@ -153,7 +158,7 @@ async function copy() {
       clipboardDiv.focus()
       window.getSelection()?.removeAllRanges()
 
-      const temp = clipboardDiv.innerHTML
+      const temp = processedClipboardContent.html
 
       if (copyMode.value === `txt`) {
         try {
@@ -161,10 +166,9 @@ async function copy() {
             throw new TypeError(`ClipboardItem is not supported in this browser.`)
           }
 
-          const plainText = clipboardDiv.textContent || ``
           const clipboardItem = new ClipboardItem({
             'text/html': new Blob([temp], { type: `text/html` }),
-            'text/plain': new Blob([plainText], { type: `text/plain` }),
+            'text/plain': new Blob([processedClipboardContent.plainText], { type: `text/plain` }),
           })
 
           await writeClipboardItems([clipboardItem])
@@ -172,7 +176,6 @@ async function copy() {
         catch (error) {
           const fallbackSucceeded = fallbackCopyUsingExecCommand(temp)
           if (!fallbackSucceeded) {
-            clipboardDiv.innerHTML = output.value
             window.getSelection()?.removeAllRanges()
             editorRefresh()
             toast.error(`复制失败，请联系开发者。${normalizeErrorMessage(error)}`)
@@ -181,8 +184,6 @@ async function copy() {
           }
         }
       }
-
-      clipboardDiv.innerHTML = output.value
 
       if (copyMode.value === `html`) {
         await copyContent(temp)

--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -209,8 +209,8 @@ export async function exportPDF(title: string = `untitled`) {
   }
 }
 
-export function solveWeChatImage() {
-  const clipboardDiv = document.getElementById(`output`)
+export function solveWeChatImage(container?: HTMLElement) {
+  const clipboardDiv = container ?? document.getElementById(`output`)
   if (!clipboardDiv)
     return
   const images = clipboardDiv.getElementsByTagName(`img`)
@@ -316,9 +316,15 @@ async function getStylesToAdd(): Promise<string> {
 }
 
 export async function processClipboardContent(primaryColor: string) {
-  const clipboardDiv = document.getElementById(`output`)
-  if (!clipboardDiv)
-    return
+  const outputElement = document.getElementById(`output`)
+  if (!outputElement) {
+    return {
+      html: ``,
+      plainText: ``,
+    }
+  }
+
+  const clipboardDiv = outputElement.cloneNode(true) as HTMLElement
 
   const stylesToAdd = await getStylesToAdd()
 
@@ -351,7 +357,7 @@ export async function processClipboardContent(primaryColor: string) {
     )
 
   // 处理图片大小
-  solveWeChatImage()
+  solveWeChatImage(clipboardDiv)
 
   // 添加空白节点用于兼容 SVG 复制
   const beforeNode = createEmptyNode()
@@ -412,4 +418,9 @@ export async function processClipboardContent(primaryColor: string) {
       }
     })
   })
+
+  return {
+    html: clipboardDiv.innerHTML,
+    plainText: clipboardDiv.textContent || ``,
+  }
 }

--- a/packages/core/src/extensions/footnotes.ts
+++ b/packages/core/src/extensions/footnotes.ts
@@ -12,16 +12,22 @@ interface MapContent {
   index: number
   text: string
 }
-const fnMap = new Map<string, MapContent>()
 
 export function markedFootnotes(): MarkedExtension {
+  const fnMap = new Map<string, MapContent>()
+
   return {
+    hooks: {
+      preprocess(markdown) {
+        fnMap.clear()
+        return markdown
+      },
+    },
     extensions: [
       {
         name: `footnoteDef`,
         level: `block`,
         start(src: string) {
-          fnMap.clear()
           return src.match(/^\[\^/)?.index
         },
         tokenizer(src: string) {
@@ -67,18 +73,21 @@ export function markedFootnotes(): MarkedExtension {
           const match = src.match(/^\[\^(.*?)\]/)
           if (match) {
             const [raw, fnId] = match
-            if (fnMap.has(fnId)) {
-              return {
-                type: `footnoteRef`,
-                raw,
-                fnId,
-              }
+            return {
+              type: `footnoteRef`,
+              raw,
+              fnId,
             }
           }
         },
         renderer(token: Tokens.Generic) {
           const { fnId } = token
-          const { index } = fnMap.get(fnId) as MapContent
+          const reference = fnMap.get(fnId)
+          if (!reference) {
+            return token.raw
+          }
+
+          const { index } = reference
           return `<sup style="color: var(--md-primary-color);">
                     <a href="#fnDef-${fnId}" id="fnRef-${fnId}">\[${index}\]</a>
                 </sup>`

--- a/packages/core/src/extensions/infographic.ts
+++ b/packages/core/src/extensions/infographic.ts
@@ -5,10 +5,10 @@ interface InfographicOptions {
   themeMode?: 'dark' | 'light'
 }
 
+type InfographicOptionsSource = InfographicOptions | (() => InfographicOptions | undefined)
+
 // key -> svg
 const svgCache = new Map<string, string>()
-// 上一次渲染的结果（用于在新渲染完成前显示旧图片）
-let lastRenderedSvg: string | null = null
 
 const RE_INFOGRAPHIC_START = /^```infographic/m
 const RE_INFOGRAPHIC_BLOCK = /^```infographic\r?\n([\s\S]*?)\r?\n```/
@@ -65,7 +65,6 @@ async function renderInfographic(containerId: string, code: string, cacheKey: st
           exportToSVG(node, { removeIds: true }).then((svg) => {
             container.replaceChildren(svg)
             svgCache.set(cacheKey, container.innerHTML)
-            lastRenderedSvg = container.innerHTML
           })
         })
 
@@ -90,7 +89,11 @@ async function renderInfographic(containerId: string, code: string, cacheKey: st
   }
 }
 
-export function markedInfographic(options?: InfographicOptions): MarkedExtension {
+function resolveOptions(options?: InfographicOptionsSource): InfographicOptions | undefined {
+  return typeof options === 'function' ? options() : options
+}
+
+export function markedInfographic(options?: InfographicOptionsSource): MarkedExtension {
   const className = 'infographic-diagram'
 
   return {
@@ -113,7 +116,8 @@ export function markedInfographic(options?: InfographicOptions): MarkedExtension
         },
         renderer(token: any) {
           const code = token.text
-          const cacheKey = simpleHash(`${code}-${options?.themeMode || 'light'}`)
+          const currentOptions = resolveOptions(options)
+          const cacheKey = simpleHash(`${code}-${currentOptions?.themeMode || 'light'}`)
 
           // 有缓存直接返回
           const cached = svgCache.get(cacheKey)
@@ -123,12 +127,7 @@ export function markedInfographic(options?: InfographicOptions): MarkedExtension
 
           // 没有缓存，触发渲染
           const id = `infographic-${cacheKey}`
-          renderInfographic(id, code, cacheKey, options)
-
-          // 如果有上一次渲染的结果，显示旧图片；否则显示占位符
-          if (lastRenderedSvg) {
-            return `<!--infographic-start--><div id="${id}" class="${className}" style="width: 100%;">${lastRenderedSvg}</div><!--infographic-end-->`
-          }
+          renderInfographic(id, code, cacheKey, currentOptions)
 
           return `<!--infographic-start--><div id="${id}" class="${className}" style="width: 100%;">正在加载 Infographic...</div><!--infographic-end-->`
         },

--- a/packages/core/src/extensions/mermaid.ts
+++ b/packages/core/src/extensions/mermaid.ts
@@ -19,8 +19,6 @@ function getMermaid() {
 
 // key -> svg
 const svgCache = new Map<string, string>()
-// 上一次渲染的结果（用于在新渲染完成前显示旧图片）
-let lastRenderedSvg: string | null = null
 
 function renderMermaid(id: string, code: string, cacheKey: string) {
   if (typeof window === 'undefined')
@@ -28,7 +26,6 @@ function renderMermaid(id: string, code: string, cacheKey: string) {
 
   const handleResult = (svg: string) => {
     svgCache.set(cacheKey, svg)
-    lastRenderedSvg = svg
 
     const el = document.getElementById(id)
     if (el) {
@@ -84,11 +81,6 @@ export function markedMermaid(): MarkedExtension {
           // 没有缓存，触发渲染
           const id = `mermaid-${cacheKey}`
           renderMermaid(id, code, cacheKey)
-
-          // 如果有上一次渲染的结果，显示旧图片；否则显示占位符
-          if (lastRenderedSvg) {
-            return `<!--mermaid-start--><div id="${id}" class="${className}">${lastRenderedSvg}</div><!--mermaid-end-->`
-          }
 
           return `<!--mermaid-start--><div id="${id}" class="${className}">正在加载 Mermaid...</div><!--mermaid-end-->`
         },

--- a/packages/core/src/extensions/plantuml.ts
+++ b/packages/core/src/extensions/plantuml.ts
@@ -4,8 +4,6 @@ import { simpleHash } from '../utils/basicHelpers'
 
 // key -> svg
 const svgCache = new Map<string, string>()
-// 上一次渲染的结果（用于在新渲染完成前显示旧图片）
-let lastRenderedSvg: string | null = null
 
 export interface PlantUMLOptions {
   /**
@@ -175,7 +173,6 @@ function renderPlantUMLDiagram(token: Tokens.Code, options: Required<PlantUMLOpt
         const html = createPlantUMLHTML(imageUrl, options, svgContent)
         placeholderElement.outerHTML = html
         svgCache.set(cacheKey, html)
-        lastRenderedSvg = svgContent
       }
     })
 
@@ -184,11 +181,6 @@ function renderPlantUMLDiagram(token: Tokens.Code, options: Required<PlantUMLOpt
           .map(([key, value]) => `${key.replace(/([A-Z])/g, `-$1`).toLowerCase()}: ${value}`)
           .join(`; `)
       : ``
-
-    // 如果有上一次渲染的结果，显示旧图片；否则显示占位符
-    if (lastRenderedSvg) {
-      return `<div class="${options.className}" style="${containerStyles}" data-placeholder="${placeholder}">${lastRenderedSvg}</div>`
-    }
 
     return `<div class="${options.className}" style="${containerStyles}" data-placeholder="${placeholder}">
       <div style="color: #666; font-style: italic;">正在加载PlantUML图表...</div>

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -4,7 +4,7 @@ import type { RendererObject, Tokens } from 'marked'
 import readingTime from '@md/shared/utils/readingTime'
 import frontMatter from 'front-matter'
 import hljs from 'highlight.js/lib/core'
-import { marked } from 'marked'
+import { Marked } from 'marked'
 import {
   getBuiltInRegistry,
   markedAlert,
@@ -27,10 +27,6 @@ Object.entries(COMMON_LANGUAGES).forEach(([name, lang]) => {
 })
 
 export { hljs }
-
-marked.setOptions({
-  breaks: true,
-})
 
 const DOUBLE_QUOTE_REGEX = /"/g
 const UNDERSCORE_REGEX = /_/g
@@ -192,6 +188,11 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   let footnoteIndex: number = 0
   const listOrderedStack: boolean[] = []
   const listCounters: number[] = []
+  const markdownParser = new Marked()
+
+  markdownParser.setOptions({
+    breaks: true,
+  })
 
   function getOpts(): IOpts {
     return opts
@@ -227,12 +228,13 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   function reset(newOpts: Partial<IOpts>): void {
     footnotes.length = 0
     footnoteIndex = 0
+    listOrderedStack.length = 0
+    listCounters.length = 0
     setOptions(newOpts)
   }
 
   function setOptions(newOpts: Partial<IOpts>): void {
     opts = { ...opts, ...newOpts }
-    marked.use(markedInfographic({ themeMode: newOpts.themeMode }))
   }
 
   function buildReadingTime(readingTime: ReadTimeResults): string {
@@ -444,22 +446,22 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     },
   }
 
-  marked.use({ renderer })
+  markdownParser.use({ renderer })
   // 新主题系统：扩展不再需要 styles 参数
   // 通过闭包传入注册表 getter，避免直接依赖全局状态
-  marked.use(markedComponent(() => opts.components ?? getBuiltInRegistry()))
-  marked.use(markedMarkup())
-  marked.use(markedToc())
-  marked.use(markedSlider())
-  marked.use(markedAlert({}))
-  marked.use(MDKatex({ nonStandard: true }, true))
-  marked.use(markedFootnotes())
-  marked.use(markedMermaid())
-  marked.use(markedPlantUML({
+  markdownParser.use(markedComponent(() => opts.components ?? getBuiltInRegistry()))
+  markdownParser.use(markedMarkup())
+  markdownParser.use(markedToc())
+  markdownParser.use(markedSlider())
+  markdownParser.use(markedAlert({}))
+  markdownParser.use(MDKatex({ nonStandard: true }, true))
+  markdownParser.use(markedFootnotes())
+  markdownParser.use(markedMermaid())
+  markdownParser.use(markedPlantUML({
     inlineSvg: true, // 启用SVG内嵌，适用于微信公众号
   }))
-  marked.use(markedInfographic({ themeMode: opts.themeMode }))
-  marked.use(markedRuby())
+  markdownParser.use(markedInfographic(() => ({ themeMode: opts.themeMode })))
+  markdownParser.use(markedRuby())
 
   return {
     buildAddition,
@@ -467,6 +469,9 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     setOptions,
     reset,
     parseFrontMatterAndContent,
+    renderMarkdownToHtml(markdown: string) {
+      return markdownParser.parse(markdown) as string
+    },
     buildReadingTime,
     createContainer(content: string) {
       return styledContent(`container mx-auto`, content, `section`)

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -109,7 +109,7 @@ export async function loadAndRegisterLanguage(language: string, hljs: any): Prom
   // 开始加载
   const loadPromise = (async () => {
     try {
-      const module = await import(/* @vite-ignore */ grammarUrlFor(language))
+      const module = await import(/* webpackIgnore: true */ /* @vite-ignore */ grammarUrlFor(language))
       hljs.registerLanguage(language, module.default)
     }
     catch (error) {

--- a/packages/core/src/utils/markdownHelpers.ts
+++ b/packages/core/src/utils/markdownHelpers.ts
@@ -1,7 +1,6 @@
 import type { RendererAPI } from '@md/shared/types'
 import type { ReadTimeResults } from '@md/shared/utils/readingTime'
 import DOMPurify from 'isomorphic-dompurify'
-import { marked } from 'marked'
 
 const INFOGRAPHIC_PLACEHOLDER_REGEX = /<!--infographic-start-->[\s\S]*?<!--infographic-end-->/g
 const MERMAID_PLACEHOLDER_REGEX = /<!--mermaid-start-->[\s\S]*?<!--mermaid-end-->/g
@@ -59,7 +58,7 @@ export function renderMarkdown(raw: string, renderer: RendererAPI) {
     = renderer.parseFrontMatterAndContent(raw)
 
   // marked -> html
-  let html = marked.parse(markdownContent) as string
+  let html = renderer.renderMarkdownToHtml(markdownContent)
   html = sanitizeHtml(html)
   return { html, readingTime }
 }
@@ -111,7 +110,7 @@ export function modifyHtmlContent(content: string, renderer: RendererAPI): strin
     readingTime: readingTimeResult,
   } = renderer.parseFrontMatterAndContent(content)
 
-  let html = marked.parse(markdownContent) as string
+  let html = renderer.renderMarkdownToHtml(markdownContent)
   html = sanitizeHtml(html)
   return postProcessHtml(html, readingTimeResult, renderer)
 }

--- a/packages/shared/src/types/renderer-types.ts
+++ b/packages/shared/src/types/renderer-types.ts
@@ -13,6 +13,7 @@ export interface RendererAPI {
     markdownContent: string
     readingTime: ReadTimeResults
   }
+  renderMarkdownToHtml: (markdown: string) => string
 
   /* —— HTML 拼装 —— */
   buildReadingTime: (reading: ReadTimeResults) => string


### PR DESCRIPTION
## Summary
- isolate renderer state per Marked instance to avoid shared parser side effects
- fix VSCode preview reuse and copy fallback behavior
- avoid mutating the live preview DOM during copy so the right slider styles do not flash

## Validation
- pnpm run type-check
- pnpm run compile --filter apps/vscode