### PR TITLE
fix: code quality optimizations across AI components and core renderer

### DIFF
--- a/apps/web/src/components/ai/SidebarAIToolbar.vue
+++ b/apps/web/src/components/ai/SidebarAIToolbar.vue
@@ -194,9 +194,11 @@ onMounted(() => {
 
 <template>
   <!-- 编辑区内侧AI工具栏 -->
+  <!-- @mousedown.prevent 防止点击工具栏时编辑器失去焦点，从而保持选区高亮 -->
   <div
     v-if="(!isMobile || (isMobile && showEditor))"
     class="editor-ai-toolbar absolute top-1/2 -translate-y-1/2 right-0 z-30 transition-all duration-300 ease-out"
+    @mousedown.prevent
   >
     <!-- 默认状态：贴边栏 -->
     <div

--- a/apps/web/src/components/ai/chat-box/AIAssistantPanel.vue
+++ b/apps/web/src/components/ai/chat-box/AIAssistantPanel.vue
@@ -88,18 +88,7 @@ const { apiKey, endpoint, model, temperature, maxToken, type } = storeToRefs(AIC
 const quickCmdStore = useQuickCommandsStore()
 
 function getSelectedText(): string {
-  try {
-    const cm: any = editor.value
-    if (!cm)
-      return ``
-    if (typeof cm.getSelection === `function`)
-      return cm.getSelection() || ``
-    return ``
-  }
-  catch {
-    console.warn(`获取选中文本失败`)
-    return ``
-  }
+  return editorStore.getSelection()
 }
 
 function applyQuickCommand(cmd: QuickCommandRuntime) {
@@ -118,17 +107,11 @@ function applyQuickCommand(cmd: QuickCommandRuntime) {
 }
 
 onMounted(async () => {
-  const savedList = await store.get(conversationListKey)
-  if (savedList) {
-    conversationList.value = JSON.parse(savedList)
-  }
+  conversationList.value = await store.getJSON(conversationListKey, [])
 
-  const saved = await store.get(memoryKey)
-  messages.value = saved
-    ? JSON.parse(saved).map((msg: ChatMessage) => ({
-        ...msg,
-        id: msg.id || uuidv4(),
-      }))
+  const saved = await store.getJSON<ChatMessage[]>(memoryKey, [])
+  messages.value = saved.length > 0
+    ? saved.map((msg: ChatMessage) => ({ ...msg, id: msg.id || uuidv4() }))
     : getDefaultMessages()
   await scrollToBottom(true)
 })

--- a/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
+++ b/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
@@ -28,11 +28,10 @@ import { copyPlain } from '@/utils/clipboard'
 import { store } from '@/utils/storage'
 import AIImageConfig from './AIImageConfig.vue'
 
-/* ---------- 组件属性 ---------- */
-const props = defineProps<{ open: boolean }>()
-const emit = defineEmits([`update:open`])
+// 图片链接有效期：1小时（毫秒）
 
-/* ---------- 编辑器引用 ---------- */
+/* ---------- 组件属性 ---------- */
+const props = defineProps<{ open: boolean }>(); const emit = defineEmits([`update:open`]); const EXPIRY_TIME = 60 * 60 * 1000/* ---------- 编辑器引用 ---------- */
 const editorStore = useEditorStore()
 const { editor } = storeToRefs(editorStore)
 const uiStore = useUIStore()
@@ -53,13 +52,13 @@ watch(dialogVisible, val => emit(`update:open`, val))
 const configVisible = ref(false)
 const loading = ref(false)
 const prompt = ref<string>(``)
-const lastUsedPrompt = ref<string>(``) // 存储最后一次使用的提示词，用于重新生成
 const generatedImages = ref<string[]>([])
 const imagePrompts = ref<string[]>([]) // 存储每张图片对应的prompt
 const imageTimestamps = ref<number[]>([]) // 存储每张图片的生成时间戳
 const abortController = ref<AbortController | null>(null)
 const currentImageIndex = ref(0)
-const timeUpdateInterval = ref<NodeJS.Timeout | null>(null)
+const currentTime = ref(Date.now()) // 用于实时显示图片剩余有效期
+let timerIntervalId: ReturnType<typeof setInterval> | null = null
 
 /* ---------- AI 配置 ---------- */
 const AIImageConfigStore = useAIImageConfigStore()
@@ -67,25 +66,22 @@ const { apiKey, endpoint, model, type, size, quality, style } = storeToRefs(AIIm
 
 /* ---------- 过期检查函数 ---------- */
 function isImageExpired(timestamp: number): boolean {
-  const EXPIRY_TIME = 60 * 60 * 1000 // 1小时，单位毫秒
-  const now = Date.now()
-  return now - timestamp > EXPIRY_TIME
+  return Date.now() - timestamp > EXPIRY_TIME
 }
 
 async function cleanExpiredImages() {
-  const savedImages = await store.get(`ai_generated_images`)
-  const savedTimestamps = await store.get(`ai_image_timestamps`)
+  const images = await store.getJSON<string[]>(`ai_generated_images`, [])
+  const timestamps = await store.getJSON<number[]>(`ai_image_timestamps`, [])
 
-  if (!savedImages) {
+  // 没有数据则无需清理
+  if (images.length === 0) {
     return
   }
 
-  const images = await store.getJSON(`ai_generated_images`, [])
-  const prompts = await store.getJSON(`ai_image_prompts`, [])
-  const timestamps = await store.getJSON(`ai_image_timestamps`, [])
+  const prompts = await store.getJSON<string[]>(`ai_image_prompts`, [])
 
   // 如果没有时间戳数据，说明是旧版本，默认清除所有数据
-  if (!savedTimestamps || timestamps.length === 0) {
+  if (timestamps.length === 0) {
     generatedImages.value = []
     imagePrompts.value = []
     imageTimestamps.value = []
@@ -127,7 +123,7 @@ async function cleanExpiredImages() {
   }
 }
 
-/* ---------- 初始数据 ---------- */
+/* ---------- 初始数据 & 定时器 ---------- */
 onMounted(async () => {
   // 先进行过期检查和清理
   await cleanExpiredImages()
@@ -158,20 +154,22 @@ onMounted(async () => {
     }
   }
 
-  // 启动定时器，每30秒检查一次过期图片并更新时间显示
-  timeUpdateInterval.value = setInterval(() => {
-    // 检查并清理过期图片
-    if (generatedImages.value.length > 0) {
+  // 每秒更新当前时间（用于实时显示剩余有效期）
+  // 每30秒顺带清理一次已过期的图片
+  let tick = 0
+  timerIntervalId = setInterval(() => {
+    currentTime.value = Date.now()
+    tick++
+    if (tick % 30 === 0 && generatedImages.value.length > 0) {
       cleanExpiredImages()
     }
-  }, 30000) // 30秒
+  }, 1000)
 })
 
 onBeforeUnmount(() => {
-  // 清除定时器
-  if (timeUpdateInterval.value) {
-    clearInterval(timeUpdateInterval.value)
-    timeUpdateInterval.value = null
+  if (timerIntervalId !== null) {
+    clearInterval(timerIntervalId)
+    timerIntervalId = null
   }
 })
 
@@ -291,8 +289,6 @@ async function generateImage() {
   if (!prompt.value.trim() || loading.value)
     return
 
-  // 保存当前提示词用于重新生成
-  lastUsedPrompt.value = prompt.value.trim()
   await doGenerateImage(prompt.value, true)
 }
 
@@ -350,14 +346,10 @@ async function downloadImage(imageUrl: string, index: number) {
 async function copyImageUrl(imageUrl: string) {
   try {
     await copyPlain(imageUrl)
-    if (typeof toast !== `undefined`) {
-      toast.success(`图片链接已复制到剪贴板`)
-    }
+    toast.success(`图片链接已复制到剪贴板`)
   }
   catch {
-    if (typeof toast !== `undefined`) {
-      toast.error(`复制失败，请重试`)
-    }
+    toast.error(`复制失败，请重试`)
   }
 }
 
@@ -452,29 +444,12 @@ function closePreview() {
 }
 
 /* ---------- 时间相关函数 ---------- */
-const currentTime = ref(Date.now())
-
-// 每秒更新当前时间，用于实时显示剩余时间
-onMounted(() => {
-  const updateTime = () => {
-    currentTime.value = Date.now()
-  }
-
-  // 启动定时器更新时间显示
-  const timeDisplayInterval = setInterval(updateTime, 1000)
-
-  // 组件卸载时清理定时器
-  onBeforeUnmount(() => {
-    clearInterval(timeDisplayInterval)
-  })
-})
-
 function getTimeRemaining(index: number): string {
   if (!imageTimestamps.value[index]) {
     return `未知`
   }
 
-  const EXPIRY_TIME = 60 * 60 * 1000 // 1小时
+  // EXPIRY_TIME 来自模块顶层常量
   const timestamp = imageTimestamps.value[index]
   const elapsed = currentTime.value - timestamp
   const remaining = EXPIRY_TIME - elapsed
@@ -499,7 +474,7 @@ function getTimeRemainingClass(index: number): string {
     return `text-muted-foreground`
   }
 
-  const EXPIRY_TIME = 60 * 60 * 1000 // 1小时
+  // EXPIRY_TIME 来自模块顶层常量
   const timestamp = imageTimestamps.value[index]
   const elapsed = currentTime.value - timestamp
   const remaining = EXPIRY_TIME - elapsed

--- a/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
+++ b/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
@@ -28,10 +28,15 @@ import { copyPlain } from '@/utils/clipboard'
 import { store } from '@/utils/storage'
 import AIImageConfig from './AIImageConfig.vue'
 
-// 图片链接有效期：1小时（毫秒）
-
 /* ---------- 组件属性 ---------- */
-const props = defineProps<{ open: boolean }>(); const emit = defineEmits([`update:open`]); const EXPIRY_TIME = 60 * 60 * 1000/* ---------- 编辑器引用 ---------- */
+const props = defineProps<{ open: boolean }>()
+
+const emit = defineEmits([`update:open`])
+
+/** 图片链接有效期：1小时（毫秒） */
+const EXPIRY_TIME = 60 * 60 * 1000
+
+/* ---------- 编辑器引用 ---------- */
 const editorStore = useEditorStore()
 const { editor } = storeToRefs(editorStore)
 const uiStore = useUIStore()

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -34,8 +34,7 @@ const HEADING_TAG_REGEX = /^h\d$/
 const PARAGRAPH_WRAPPER_REGEX = /^<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/
 const MP_WEIXIN_LINK_REGEX = /^https?:\/\/mp\.weixin\.qq\.com/
 
-function buildAddition(): string {
-  return `
+const ADDITION_STYLE = `
     <style>
       .preview-wrapper pre::before {
         position: absolute;
@@ -51,7 +50,6 @@ function buildAddition(): string {
       }
     </style>
   `
-}
 
 function buildFootnoteArray(footnotes: [number, string, string][]): string {
   return footnotes
@@ -464,7 +462,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   markdownParser.use(markedRuby())
 
   return {
-    buildAddition,
+    buildAddition: () => ADDITION_STYLE,
     buildFootnotes,
     setOptions,
     reset,


### PR DESCRIPTION
﻿## Summary

Code quality fixes across AI components and the core renderer, addressing issues found during review.

## Changes

### `apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue`

- **Remove redundant storage reads** in `cleanExpiredImages()`: previously called `store.get()` twice as a presence check before calling `store.getJSON()` (5 I/O ops → 3).
- **Extract `EXPIRY_TIME` constant** to module level; was duplicated inline in `isImageExpired`, `getTimeRemaining`, and `getTimeRemainingClass`.
- **Merge two `onMounted` / two `onBeforeUnmount` hooks** into a single lifecycle pair using a top-level `timerIntervalId` variable; combines the 30 s cleanup-only interval and the 1 s time-display interval into a single 1 s tick that runs cleanup every 30 ticks.
- **Remove unused `lastUsedPrompt` ref** — was written in `generateImage()` but never read.
- **Remove redundant `typeof toast !== 'undefined'` guards** in `copyImageUrl` — `toast` is always available via auto-imports in Vue SFCs.

### `apps/web/src/components/ai/chat-box/AIAssistantPanel.vue`

- **Fix `getSelectedText()` using stale CodeMirror 5 API** (`cm.getSelection()`): `EditorView` (CodeMirror 6) has no such method, so the function always returned an empty string. Replaced with `editorStore.getSelection()`.
- **Use `store.getJSON()` in `onMounted`** instead of manual `store.get()` + `JSON.parse()`, making it consistent with the rest of the codebase.

### `packages/core/src/renderer/renderer-impl.ts`

- **Convert `buildAddition()` to a top-level constant `ADDITION_STYLE`**: the function body was pure with no parameters and returned the same string on every call; inlining it as a constant avoids a function call and string construction on every render.

## Testing

- `pnpm run type-check` passes (vue-tsc exit 0).
- ESLint passes with no new errors.
