### PR TITLE
refactor(web): shorten custom component UI labels

### DIFF
--- a/apps/web/src/components/editor/EditorContextMenu.vue
+++ b/apps/web/src/components/editor/EditorContextMenu.vue
@@ -174,7 +174,7 @@ function downloadAsCardImage() {
           </ContextMenuItem>
           <ContextMenuItem @click="toggleShowComponentDialog()">
             <Blocks class="mr-2 h-4 w-4" />
-            自定义组件
+            组件
           </ContextMenuItem>
         </ContextMenuSubContent>
       </ContextMenuSub>

--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -298,7 +298,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
       <DialogHeader class="px-4 sm:px-6 pt-5 pb-4 border-b shrink-0">
         <DialogTitle class="flex items-center gap-2 text-base">
           <Blocks class="size-4.5" />
-          自定义组件
+          组件
         </DialogTitle>
         <DialogDescription class="text-xs leading-relaxed mt-1">
           在 Markdown 中插入 JSX 风格组件，如
@@ -701,7 +701,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
               </div>
               <div v-if="componentStore.userComponents.length === 0" class="text-center py-8 border rounded-xl bg-card/50">
                 <p class="text-xs text-muted-foreground">
-                  暂无自定义组件，点击上方“新建”按钮创建
+                  暂无组件，点击上方”新建”按钮创建
                 </p>
               </div>
               <div v-else class="space-y-2">

--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -701,7 +701,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
               </div>
               <div v-if="componentStore.userComponents.length === 0" class="text-center py-8 border rounded-xl bg-card/50">
                 <p class="text-xs text-muted-foreground">
-                  暂无组件，点击上方”新建”按钮创建
+                  暂无自定义组件，点击上方”新建”按钮创建
                 </p>
               </div>
               <div v-else class="space-y-2">

--- a/apps/web/src/components/editor/editor-header/InsertDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/InsertDropdown.vue
@@ -46,7 +46,7 @@ function openFormulaEditor() {
       </MenubarItem>
       <MenubarItem @click="toggleShowComponentDialog()">
         <Blocks class="mr-2 h-4 w-4" />
-        自定义组件
+        组件
       </MenubarItem>
     </MenubarSubContent>
   </MenubarSub>
@@ -71,7 +71,7 @@ function openFormulaEditor() {
       </MenubarItem>
       <MenubarItem @click="toggleShowComponentDialog()">
         <Blocks class="mr-2 h-4 w-4" />
-        自定义组件
+        组件
       </MenubarItem>
     </MenubarContent>
   </MenubarMenu>

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -120,11 +120,11 @@ export const useUIStore = defineStore(`ui`, () => {
   const isShowTemplateDialog = ref(false)
   const toggleShowTemplateDialog = useToggle(isShowTemplateDialog)
 
-  // 是否展示自定义组件对话框
+  // 是否展示组件对话框
   const isShowComponentDialog = ref(false)
   const toggleShowComponentDialog = useToggle(isShowComponentDialog)
 
-  // 自定义组件对话框 — 打开时预展开的组件名（如 'MpProfile'）
+  // 组件对话框 — 打开时预展开的组件名（如 'MpProfile'）
   const componentDialogTarget = ref<string | null>(null)
 
   function openComponentDialogWithTarget(target: string) {


### PR DESCRIPTION
Clarify component terminology: distinguish the umbrella term from specific custom components.

### Changes

- **EditorContextMenu.vue**: Menu item label shortened to the umbrella term (opens the full component dialog with both tabs)
- **InsertDropdown.vue**: Dropdown item label shortened to the umbrella term
- **CustomComponentDialog.vue**: 
  - Dialog title changed to the umbrella term (dialog shows both built-in and custom component tabs)
  - Empty state message in the custom tab restored to explicitly say 'custom components' to match the tab context

### Terminology

| Context | Label |
|---|---|
| Menu item / dialog title | 组件 (umbrella — includes both built-in and custom) |
| Built-in tab label | 内置组件 |
| Custom tab label | 自定义组件 |
| Empty state in custom tab | 暂无自定义组件 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)