### PR TITLE
feat: refactor built-in component styles to CSS custom properties for dark-mode clipboard safety

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "diff-match-patch": "^1.0.5",
     "es-toolkit": "^1.47.0",
     "html-to-image": "^1.11.13",
+    "isomorphic-dompurify": "^3.15.0",
     "jszip": "^3.10.1",
     "juice": "^11.1.1",
     "lucide-vue-next": "^1.0.0",

--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -2,6 +2,7 @@
 import type { ComponentPropDef, ComponentPropType, CustomComponentDef } from '@md/shared'
 import type { MpAccount } from '@/stores/mpAccounts'
 import { escapeHtml, previewComponent } from '@md/core'
+import DOMPurify from 'isomorphic-dompurify'
 import { Blocks, Check, ChevronDown, Copy, Download, Lock, Pencil, Plus, Rss, Trash2, Upload, Zap } from 'lucide-vue-next'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCustomComponentStore } from '@/stores/customComponent'
@@ -189,7 +190,8 @@ const previewHtml = computed(() => {
       propValues[p.name] = '0'
   }
   try {
-    return previewComponent(tmpDef, propValues)
+    const raw = previewComponent(tmpDef, propValues)
+    return DOMPurify.sanitize(raw, { ADD_TAGS: [`mp-common-profile`] })
   }
   catch {
     return ''
@@ -555,7 +557,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
               <p><code class="bg-muted px-1 rounded">&#123;&#123;propName&#125;&#125;</code> — 替换为 prop 值（自动 HTML 转义）</p>
               <p><code class="bg-muted px-1 rounded">&#123;&#123;#if prop&#125;&#125;...&#123;&#123;#else&#125;&#125;...&#123;&#123;/if&#125;&#125;</code> — 条件块（支持 else）</p>
               <p><code class="bg-muted px-1 rounded">&#123;&#123;#unless prop&#125;&#125;...&#123;&#123;/unless&#125;&#125;</code> — 反向条件</p>
-              <p><code class="bg-muted px-1 rounded">&#123;&#123;#each arrayProp&#125;&#125;...&#123;&#123;item&#125;&#125;/&#123;&#123;item.key&#125;&#125;...&#123;&#123;/each&#125;&#125;</code> — 数组循环</p>
+              <p><code class="bg-muted px-1 rounded">&#123;&#123;#each arrayProp&#125;&#125;...&#123;&#123;item&#125;&#125;...&#123;&#123;item.key&#125;&#125;...&#123;&#123;/each&#125;&#125;</code> — 数组循环</p>
             </div>
           </div>
 

--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { ComponentPropDef, CustomComponentDef } from '@md/shared'
+import type { ComponentPropDef, ComponentPropType, CustomComponentDef } from '@md/shared'
 import type { MpAccount } from '@/stores/mpAccounts'
-import { escapeHtml } from '@md/core'
-import { Blocks, Check, ChevronDown, Copy, Lock, Pencil, Plus, Rss, Trash2, Zap } from 'lucide-vue-next'
+import { escapeHtml, previewComponent } from '@md/core'
+import { Blocks, Check, ChevronDown, Copy, Download, Lock, Pencil, Plus, Rss, Trash2, Upload, Zap } from 'lucide-vue-next'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCustomComponentStore } from '@/stores/customComponent'
 import { useEditorStore } from '@/stores/editor'
@@ -29,6 +29,7 @@ interface PropRow {
   description: string
   default: string
   required: boolean
+  type: ComponentPropType
 }
 
 const formData = reactive({
@@ -71,6 +72,7 @@ function openEditForm(def: CustomComponentDef) {
         description: p.description || '',
         default: p.default || '',
         required: !!p.required,
+        type: (p.type || 'string') as ComponentPropType,
       }))
     : []
   formErrors.name = ''
@@ -79,7 +81,7 @@ function openEditForm(def: CustomComponentDef) {
 }
 
 function addPropRow() {
-  propRows.value.push({ name: '', description: '', default: '', required: false })
+  propRows.value.push({ name: '', description: '', default: '', required: false, type: 'string' })
 }
 
 function removePropRow(idx: number) {
@@ -121,6 +123,7 @@ function buildProps(): ComponentPropDef[] {
       description: r.description.trim() || undefined,
       default: r.default || undefined,
       required: r.required || undefined,
+      type: r.type !== 'string' ? r.type : undefined,
     }))
 }
 
@@ -159,6 +162,107 @@ const TEMPLATE_PLACEHOLDER = `<section style="text-align:center;">
 </section>`
 
 // ──────────────────────────────────────────────
+// 实时预览
+// ──────────────────────────────────────────────
+const isShowPreview = ref(false)
+
+const previewHtml = computed(() => {
+  if (!formData.template.trim())
+    return ''
+  const props = buildProps()
+  const tmpDef: CustomComponentDef = {
+    id: '__preview__',
+    name: formData.name.trim() || 'Preview',
+    template: formData.template,
+    props,
+  }
+  // 用每个 prop 的默认值（或占位）渲染预览
+  const propValues: Record<string, string> = {}
+  for (const p of props) {
+    if (p.default !== undefined && p.default !== '')
+      propValues[p.name] = p.default
+    else if (p.type === 'array')
+      propValues[p.name] = '[]'
+    else if (p.type === 'boolean')
+      propValues[p.name] = 'true'
+    else if (p.type === 'number')
+      propValues[p.name] = '0'
+  }
+  try {
+    return previewComponent(tmpDef, propValues)
+  }
+  catch {
+    return ''
+  }
+})
+
+// ──────────────────────────────────────────────
+// 导入 / 导出
+// ──────────────────────────────────────────────
+function exportComponents() {
+  const data = JSON.stringify(componentStore.userComponents, null, 2)
+  const blob = new Blob([data], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `md-components-${Date.now()}.json`
+  a.click()
+  URL.revokeObjectURL(url)
+  toast.success('已导出自定义组件')
+}
+
+const importFileRef = ref<HTMLInputElement | null>(null)
+
+function triggerImport() {
+  importFileRef.value?.click()
+}
+
+function onImportFile(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file)
+    return
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    try {
+      const parsed: CustomComponentDef[] = JSON.parse(e.target?.result as string)
+      if (!Array.isArray(parsed))
+        throw new Error('格式错误')
+      let imported = 0
+      for (const def of parsed) {
+        if (!def.name || !def.template)
+          continue
+        const existing = componentStore.userComponents.find(c => c.name === def.name)
+        if (existing) {
+          componentStore.updateComponent(existing.id, {
+            name: def.name,
+            description: def.description,
+            template: def.template,
+            props: def.props || [],
+          })
+        }
+        else {
+          componentStore.createComponent({
+            name: def.name,
+            description: def.description,
+            template: def.template,
+            props: def.props || [],
+          })
+        }
+        imported++
+      }
+      toast.success(`成功导入 ${imported} 个组件`)
+    }
+    catch {
+      toast.error('导入失败，请确认文件格式正确')
+    }
+    // reset input so the same file can be re-imported
+    if (importFileRef.value)
+      importFileRef.value.value = ''
+  }
+  reader.readAsText(file)
+}
+
+// ──────────────────────────────────────────────
 // 列表操作
 // ──────────────────────────────────────────────
 function insertSnippet(def: CustomComponentDef) {
@@ -181,6 +285,12 @@ function onUpdate(val: boolean) {
     toggleShowComponentDialog(false)
     isShowForm.value = false
   }
+}
+
+const PREVIEW_FALLBACK_HTML = `<span style="color:#aaa;font-size:12px;">（无内容）</span>`
+
+function getPropDefaultPlaceholder(type: string): string {
+  return type === 'array' ? '["item1","item2"]' : '默认值'
 }
 
 // ──────────────────────────────────────────────
@@ -352,21 +462,42 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
             </div>
             <template v-if="propRows.length > 0">
               <!-- 桌面端：网格表头 -->
-              <div class="hidden sm:grid grid-cols-12 gap-2 px-1">
+              <div class="hidden sm:grid grid-cols-13 gap-2 px-1">
                 <span class="col-span-3 text-xs text-muted-foreground">名称</span>
+                <span class="col-span-2 text-xs text-muted-foreground">类型</span>
                 <span class="col-span-4 text-xs text-muted-foreground">描述</span>
                 <span class="col-span-3 text-xs text-muted-foreground">默认值</span>
-                <span class="col-span-2" />
+                <span class="col-span-1" />
               </div>
               <div class="space-y-2">
                 <div
                   v-for="(row, idx) in propRows"
                   :key="idx"
-                  class="flex flex-col sm:grid sm:grid-cols-12 gap-2 items-start sm:items-center p-3 sm:p-0 border sm:border-0 rounded-lg sm:rounded-none bg-muted/20 sm:bg-transparent"
+                  class="flex flex-col sm:grid sm:grid-cols-13 gap-2 items-start sm:items-center p-3 sm:p-0 border sm:border-0 rounded-lg sm:rounded-none bg-muted/20 sm:bg-transparent"
                 >
                   <div class="w-full sm:col-span-3 flex gap-1 items-center">
                     <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">名称</span>
                     <Input v-model="row.name" placeholder="propName" class="h-8 text-sm flex-1" />
+                  </div>
+                  <div class="w-full sm:col-span-2 flex gap-1 items-center">
+                    <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">类型</span>
+                    <select
+                      v-model="row.type"
+                      class="h-8 w-full rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    >
+                      <option value="string">
+                        string
+                      </option>
+                      <option value="number">
+                        number
+                      </option>
+                      <option value="boolean">
+                        boolean
+                      </option>
+                      <option value="array">
+                        array
+                      </option>
+                    </select>
                   </div>
                   <div class="w-full sm:col-span-4 flex gap-1 items-center">
                     <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">描述</span>
@@ -374,12 +505,15 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                   </div>
                   <div class="w-full sm:col-span-3 flex gap-1 items-center">
                     <span class="text-xs text-muted-foreground sm:hidden w-12 shrink-0">默认值</span>
-                    <Input v-model="row.default" placeholder="默认值" class="h-8 text-sm flex-1" />
+                    <Input
+                      v-model="row.default"
+                      :placeholder="getPropDefaultPlaceholder(row.type)"
+                      class="h-8 text-sm flex-1"
+                    />
                   </div>
-                  <div class="flex items-center gap-2 sm:col-span-2 sm:justify-center">
-                    <label class="flex items-center gap-1 text-xs cursor-pointer select-none">
+                  <div class="flex items-center gap-2 sm:col-span-1 sm:justify-center">
+                    <label class="flex items-center gap-1 text-xs cursor-pointer select-none" title="必填">
                       <input v-model="row.required" type="checkbox" class="cursor-pointer">
-                      必填
                     </label>
                     <Button
                       variant="ghost"
@@ -419,8 +553,25 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
             </p>
             <div class="text-xs text-muted-foreground space-y-0.5">
               <p><code class="bg-muted px-1 rounded">&#123;&#123;propName&#125;&#125;</code> — 替换为 prop 值（自动 HTML 转义）</p>
-              <p><code class="bg-muted px-1 rounded">&#123;&#123;#if propName&#125;&#125;...&#123;&#123;/if&#125;&#125;</code> — prop 非空时显示该块</p>
+              <p><code class="bg-muted px-1 rounded">&#123;&#123;#if prop&#125;&#125;...&#123;&#123;#else&#125;&#125;...&#123;&#123;/if&#125;&#125;</code> — 条件块（支持 else）</p>
+              <p><code class="bg-muted px-1 rounded">&#123;&#123;#unless prop&#125;&#125;...&#123;&#123;/unless&#125;&#125;</code> — 反向条件</p>
+              <p><code class="bg-muted px-1 rounded">&#123;&#123;#each arrayProp&#125;&#125;...&#123;&#123;item&#125;&#125;/&#123;&#123;item.key&#125;&#125;...&#123;&#123;/each&#125;&#125;</code> — 数组循环</p>
             </div>
+          </div>
+
+          <!-- 实时预览 -->
+          <div v-if="formData.template.trim()" class="space-y-1.5">
+            <div class="flex items-center justify-between">
+              <Label class="text-muted-foreground">预览（使用默认 prop 值）</Label>
+              <Button variant="ghost" size="sm" class="h-6 px-2 text-xs" @click="isShowPreview = !isShowPreview">
+                {{ isShowPreview ? '收起' : '展开' }}
+              </Button>
+            </div>
+            <div
+              v-if="isShowPreview"
+              class="rounded-lg border bg-white dark:bg-card p-3 text-sm overflow-x-auto"
+              v-html="previewHtml || PREVIEW_FALLBACK_HTML"
+            />
           </div>
 
           <div class="flex gap-2 justify-end">
@@ -522,6 +673,9 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                                 属性名
                               </th>
                               <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
+                                类型
+                              </th>
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-14">
                                 状态
                               </th>
                               <th class="text-left px-3 py-2 font-medium text-muted-foreground">
@@ -540,6 +694,9 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                             >
                               <td class="px-3 py-2">
                                 <code class="font-mono text-primary font-medium">{{ prop.name }}</code>
+                              </td>
+                              <td class="px-3 py-2">
+                                <code class="text-[10px] bg-muted/60 px-1.5 py-0.5 rounded text-muted-foreground">{{ prop.type || 'string' }}</code>
                               </td>
                               <td class="px-3 py-2">
                                 <span
@@ -566,6 +723,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                         >
                           <div class="flex items-center gap-2">
                             <code class="font-mono text-sm font-semibold text-primary">{{ prop.name }}</code>
+                            <code class="text-[10px] bg-muted/60 px-1.5 py-0.5 rounded text-muted-foreground">{{ prop.type || 'string' }}</code>
                             <span
                               class="inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-medium"
                               :class="propTypeBadge(prop).class"
@@ -684,6 +842,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
             </TabsContent>
 
             <TabsContent value="custom" class="mt-4 space-y-4">
+              <input ref="importFileRef" type="file" accept=".json" class="hidden" @change="onImportFile">
               <div class="flex items-center justify-between">
                 <div class="flex items-center gap-1.5">
                   <Blocks class="size-3.5 text-muted-foreground" />
@@ -694,10 +853,20 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                     {{ componentStore.userComponents.length }} 个
                   </span>
                 </div>
-                <Button variant="outline" size="sm" class="h-6 px-2 text-xs" @click="openCreateForm">
-                  <Plus class="mr-1 size-3" />
-                  新建
-                </Button>
+                <div class="flex items-center gap-1.5">
+                  <Button variant="outline" size="sm" class="h-6 px-2 text-xs gap-1" :disabled="componentStore.userComponents.length === 0" @click="exportComponents">
+                    <Download class="size-3" />
+                    导出
+                  </Button>
+                  <Button variant="outline" size="sm" class="h-6 px-2 text-xs gap-1" @click="triggerImport">
+                    <Upload class="size-3" />
+                    导入
+                  </Button>
+                  <Button variant="outline" size="sm" class="h-6 px-2 text-xs" @click="openCreateForm">
+                    <Plus class="mr-1 size-3" />
+                    新建
+                  </Button>
+                </div>
               </div>
               <div v-if="componentStore.userComponents.length === 0" class="text-center py-8 border rounded-xl bg-card/50">
                 <p class="text-xs text-muted-foreground">
@@ -774,6 +943,9 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                                   属性名
                                 </th>
                                 <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
+                                  类型
+                                </th>
+                                <th class="text-left px-3 py-2 font-medium text-muted-foreground w-14">
                                   状态
                                 </th>
                                 <th class="text-left px-3 py-2 font-medium text-muted-foreground">
@@ -792,6 +964,9 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                               >
                                 <td class="px-3 py-2">
                                   <code class="font-mono text-primary font-medium">{{ prop.name }}</code>
+                                </td>
+                                <td class="px-3 py-2">
+                                  <code class="text-[10px] bg-muted/60 px-1.5 py-0.5 rounded text-muted-foreground">{{ prop.type || 'string' }}</code>
                                 </td>
                                 <td class="px-3 py-2">
                                   <span
@@ -818,6 +993,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                           >
                             <div class="flex items-center gap-2">
                               <code class="font-mono text-sm font-semibold text-primary">{{ prop.name }}</code>
+                              <code class="text-[10px] bg-muted/60 px-1.5 py-0.5 rounded text-muted-foreground">{{ prop.type || 'string' }}</code>
                               <span
                                 class="inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-medium"
                                 :class="propTypeBadge(prop).class"

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,4 +1,4 @@
-import { initializeMermaid } from '@md/core/utils'
+import { initComponentDarkVars, initializeMermaid } from '@md/core'
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 import App from './App.vue'
@@ -13,6 +13,8 @@ import '@/assets/less/theme.less'
 
 // 异步初始化 mermaid，避免初始化顺序问题
 initializeMermaid().catch(console.error)
+// 注入组件暗色模式 CSS 变量（独立样式元素，不污染剪贴板）
+initComponentDarkVars()
 
 setupComponents()
 

--- a/apps/web/src/stores/customComponent.ts
+++ b/apps/web/src/stores/customComponent.ts
@@ -105,11 +105,27 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
   }
 
   /**
-   * 生成该组件的 Markdown 使用示例字符串（包含所有 props）
+   * 生成该组件的 Markdown 使用示例字符串
+   * 优先使用 example 字段；否则自动构造，根据 prop.type 生成合适的占位值
    */
   function buildSnippet(def: CustomComponentDef): string {
+    if (def.example)
+      return def.example
     const propsStr = def.props
-      .map(p => `${p.name}="${p.default ?? ``}"`)
+      .map((p) => {
+        let placeholder: string
+        if (p.default !== undefined && p.default !== ``)
+          placeholder = p.default
+        else if (p.type === `array`)
+          placeholder = `[]`
+        else if (p.type === `boolean`)
+          placeholder = `true`
+        else if (p.type === `number`)
+          placeholder = `0`
+        else
+          placeholder = p.name
+        return `${p.name}="${placeholder}"`
+      })
       .join(` `)
     return `<${def.name}${propsStr ? ` ${propsStr}` : ``} />`
   }

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -285,7 +285,7 @@ function injectTipColors(props: Record<string, string>): Record<string, string> 
  *   - `{{children}}` 保留原始 HTML 不转义
  */
 function processTemplate(html: string, props: Record<string, string>): string {
-  // 1. {{#each}} 循环（非贪婪，支持嵌套通过递归实现）
+  // 1. {{#each}} 循环（非贪婪；循环体内部通过递归支持嵌套的 #if/#unless，但不支持 #each 嵌套）
   html = html.replace(/\{\{#each\s+([\w-]+)\}\}([\s\S]*?)\{\{\/each\}\}/g, (_, propKey, body) => {
     let items: unknown[]
     try { items = JSON.parse(props[propKey] || `[]`) }
@@ -349,7 +349,7 @@ function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string
   }
   Object.assign(props, rawProps)
 
-  // 2. 特殊渲染器（TableBlock / Timeline / InfoGrid / Callout）
+  // 2. 特殊渲染器（TableBlock / InfoGrid）
   const specialRenderer = SPECIAL_RENDERERS[def.name]
   if (specialRenderer) {
     return specialRenderer(props)

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -42,30 +42,9 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
     alt="QR Code"
     style="width: {{size}}px; height: {{size}}px; display: block; margin: 0 auto; border-radius: 4px;"
   />
-  <p style="text-align: center; font-size: 14px; color: #888; margin-top: 8px; margin-bottom: 0;">{{text}}</p>
+  <p style="text-align: center; font-size: 14px; color: {{_textTertiary_}}; margin-top: 8px; margin-bottom: 0;">{{text}}</p>
 </section>`,
     example: `<QRCodeBlock url="https://md.doocs.org" text="扫码访问" size="150" />`,
-  },
-  {
-    id: `builtin-card`,
-    name: `CardBlock`,
-    description: `卡片组件，展示带标题和描述的卡片`,
-    builtIn: true,
-    props: [
-      { name: `title`, description: `卡片标题`, required: true },
-      { name: `description`, description: `卡片描述文字` },
-      { name: `url`, description: `跳转链接（可选）` },
-      { name: `cover`, description: `封面图片 URL（可选）` },
-    ],
-    template: `<section style="border: 1px solid #e8e8e8; border-radius: 8px; overflow: hidden; margin: 16px 0; background: #fff;">
-  {{#if cover}}<img src="{{cover}}" alt="{{title}}" style="width: 100%; height: 160px; object-fit: cover; display: block;" />{{/if}}
-  <section style="padding: 16px;">
-    <p style="margin: 0 0 8px; font-size: 16px; font-weight: bold; color: #333;">{{title}}</p>
-    {{#if description}}<p style="margin: 0; font-size: 14px; color: #666; line-height: 1.6;">{{description}}</p>{{/if}}
-    {{#if url}}<a href="{{url}}" style="display: inline-block; margin-top: 12px; font-size: 13px; color: #07c160; text-decoration: none;">阅读全文 →</a>{{/if}}
-  </section>
-</section>`,
-    example: `<CardBlock title="Doocs 开源社区" description="低门槛、高质量的互联网技术社区" url="https://doocs.github.io" />`,
   },
   {
     id: `builtin-author`,
@@ -82,8 +61,8 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
     <img src="{{avatar}}" alt="{{name}}" style="width: 56px; height: 56px; border-radius: 50%; display: block;" />
   </section>
   <section style="display: table-cell; vertical-align: middle; padding-left: 12px;">
-    <p style="margin: 0 0 4px; font-size: 15px; font-weight: bold; color: #333;">{{name}}</p>
-    <p style="margin: 0; font-size: 13px; color: #888; line-height: 1.5;">{{bio}}</p>
+    <p style="margin: 0 0 4px; font-size: 15px; font-weight: bold; color: {{_textPrimary_}};">{{name}}</p>
+    <p style="margin: 0; font-size: 13px; color: {{_textTertiary_}}; line-height: 1.5;">{{bio}}</p>
   </section>
 </section>`,
     example: `<AuthorBlock name="yanglbme" avatar="https://avatars.githubusercontent.com/u/21008209?v=4" bio="Creator of Doocs" />`,
@@ -104,6 +83,46 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
 </section>`,
     example: `<TipBlock type="info" title="提示" content="这是一条提示信息" />`,
   },
+  {
+    id: `builtin-table`,
+    name: `TableBlock`,
+    description: `表格组件，用 JSON 数组渲染样式化表格，支持斑马纹`,
+    builtIn: true,
+    props: [
+      { name: `headers`, description: `列标题 JSON 字符串数组`, required: true, type: `array` },
+      { name: `rows`, description: `数据行 JSON 二维数组`, required: true, type: `array` },
+      { name: `striped`, description: `斑马纹行（true/false）`, default: `true` },
+      { name: `caption`, description: `表格标题（可选）` },
+    ],
+    template: ``,
+    example: `<TableBlock headers='["名称","版本","状态"]' rows='[["Vue","3.x","✅ 稳定"],["Vite","8.x","✅ 稳定"],["pnpm","10.x","✅ 稳定"]]' caption="技术栈清单" />`,
+  },
+  {
+    id: `builtin-info-grid`,
+    name: `InfoGrid`,
+    description: `信息网格组件，以多列展示键值对信息`,
+    builtIn: true,
+    props: [
+      { name: `items`, description: `JSON 数组，每项含 label、value 字段`, required: true, type: `array` },
+      { name: `cols`, description: `列数（1-3）`, default: `2` },
+    ],
+    template: ``,
+    example: `<InfoGrid items='[{"label":"作者","value":"yanglbme"},{"label":"版本","value":"v1.0"},{"label":"许可证","value":"MIT"},{"label":"语言","value":"TypeScript"}]' cols="2" />`,
+  },
+  {
+    id: `builtin-badge-group`,
+    name: `BadgeGroup`,
+    description: `标签组组件，展示一组彩色标签`,
+    builtIn: true,
+    props: [
+      { name: `tags`, description: `JSON 字符串数组，标签列表`, required: true, type: `array` },
+      { name: `color`, description: `标签主色调（hex）`, default: `#07c160` },
+    ],
+    template: `<section style="display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0;">
+{{#each tags}}<span style="display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 13px; font-weight: 500; background: {{color}}1a; color: {{color}}; border: 1px solid {{color}}40;">{{item}}</span>{{/each}}
+</section>`,
+    example: `<BadgeGroup tags='["Vue 3","TypeScript","Vite","Tailwind CSS"]' color="#07c160" />`,
+  },
 ]
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -121,6 +140,122 @@ function parseProps(propsStr: string): Record<string, string> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// 特殊渲染器（内置组件专用，处理 JSON 数组等复杂逻辑）
+// ────────────────────────────────────────────────────────────────────────────
+
+// ────────────────────────────────────────────────────────────────────────────
+// CSS 变量与调色板（light 模式回退值，深色通过外部注入覆盖）
+// ────────────────────────────────────────────────────────────────────────────
+
+/** CSS 变量名→light 回退值的简写，注入为模板变量（下划线前缀防止与用户 prop 冲突） */
+function injectPaletteVars(props: Record<string, string>): Record<string, string> {
+  return {
+    _bgPrimary_: `var(--md-comp-bg, #fff)`,
+    _bgSecondary_: `var(--md-comp-bg-secondary, #f5f5f5)`,
+    _bgStripe_: `var(--md-comp-bg-stripe, #fafafa)`,
+    _textPrimary_: `var(--md-comp-text-primary, #333)`,
+    _textSecondary_: `var(--md-comp-text-secondary, #666)`,
+    _textTertiary_: `var(--md-comp-text-tertiary, #999)`,
+    _borderDefault_: `var(--md-comp-border-default, #e0e0e0)`,
+    _borderLight_: `var(--md-comp-border-light, #eee)`,
+    ...props,
+  }
+}
+
+/** CSS 变量简写对象，供特殊渲染器直接内联 */
+const CV = {
+  bg: `var(--md-comp-bg, #fff)`,
+  bgSec: `var(--md-comp-bg-secondary, #f5f5f5)`,
+  bgStripe: `var(--md-comp-bg-stripe, #fafafa)`,
+  txtP: `var(--md-comp-text-primary, #333)`,
+  txtS: `var(--md-comp-text-secondary, #666)`,
+  txtT: `var(--md-comp-text-tertiary, #999)`,
+  border: `var(--md-comp-border-default, #e0e0e0)`,
+  borderL: `var(--md-comp-border-light, #eee)`,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 特殊渲染器（内置组件专用，处理 JSON 数组等复杂逻辑）
+// ────────────────────────────────────────────────────────────────────────────
+
+function renderTableBlock(props: Record<string, string>): string {
+  let headers: string[] = []
+  let rows: string[][] = []
+  try { headers = JSON.parse(props.headers || `[]`) }
+  catch { headers = [] }
+  try {
+    const rawRows = JSON.parse(props.rows || `[]`)
+    rows = Array.isArray(rawRows) ? rawRows : []
+  }
+  catch { rows = [] }
+
+  const striped = props.striped !== `false`
+  const caption = props.caption || ``
+
+  const thStyle = `padding: 8px 12px; text-align: left; font-weight: 600; font-size: 13px; color: ${CV.txtS}; background: ${CV.bgSec}; border-bottom: 2px solid ${CV.border};`
+  const tdStyle = `padding: 8px 12px; font-size: 13px; color: ${CV.txtP}; border-bottom: 1px solid ${CV.borderL};`
+
+  let html = `<section style="overflow-x: auto; margin: 16px 0;">\n`
+  html += `  <table style="width: 100%; border-collapse: collapse; font-size: 13px;">\n`
+  if (caption) {
+    html += `    <caption style="font-size: 13px; color: ${CV.txtS}; margin-bottom: 8px; text-align: left; caption-side: top;">${escapeHtml(caption)}</caption>\n`
+  }
+  if (headers.length > 0) {
+    html += `    <thead>\n      <tr>\n`
+    for (const h of headers) {
+      html += `        <th style="${thStyle}">${escapeHtml(String(h))}</th>\n`
+    }
+    html += `      </tr>\n    </thead>\n`
+  }
+  html += `    <tbody>\n`
+  for (let i = 0; i < rows.length; i++) {
+    const row = Array.isArray(rows[i]) ? rows[i] : []
+    const rowStyle = striped && i % 2 === 1 ? ` style="background: ${CV.bgStripe};"` : ``
+    html += `      <tr${rowStyle}>\n`
+    for (const cell of row) {
+      html += `        <td style="${tdStyle}">${escapeHtml(String(cell))}</td>\n`
+    }
+    html += `      </tr>\n`
+  }
+  html += `    </tbody>\n  </table>\n</section>`
+  return html
+}
+
+function renderInfoGrid(props: Record<string, string>): string {
+  let items: Array<{ label?: string, value?: string }> = []
+  try { items = JSON.parse(props.items || `[]`) }
+  catch { items = [] }
+  const cols = Math.min(Math.max(Number(props.cols) || 2, 1), 3)
+  const colWidth = `${Math.floor(100 / cols)}%`
+
+  let html = `<section style="margin: 16px 0; border: 1px solid ${CV.borderL}; border-radius: 8px; overflow: hidden; background: ${CV.bg};">\n`
+  html += `  <section style="display: table; width: 100%; border-collapse: collapse;">\n`
+  for (let r = 0; r < items.length; r += cols) {
+    html += `    <section style="display: table-row;">\n`
+    for (let c = 0; c < cols; c++) {
+      const item = items[r + c]
+      const borderBottom = r + cols < items.length ? `1px solid ${CV.borderL}` : `none`
+      const borderRight = c < cols - 1 ? `1px solid ${CV.borderL}` : `none`
+      html += `      <section style="display: table-cell; width: ${colWidth}; padding: 10px 14px; border-bottom: ${borderBottom}; border-right: ${borderRight}; vertical-align: top; box-sizing: border-box;">\n`
+      if (item) {
+        html += `        <p style="margin: 0 0 2px; font-size: 11px; color: ${CV.txtT}; text-transform: uppercase; letter-spacing: 0.5px;">${escapeHtml(item.label || ``)}</p>\n`
+        html += `        <p style="margin: 0; font-size: 14px; font-weight: 500; color: ${CV.txtP};">${escapeHtml(item.value || ``)}</p>\n`
+      }
+      html += `      </section>\n`
+    }
+    html += `    </section>\n`
+  }
+  html += `  </section>\n</section>`
+  return html
+}
+
+/** 特殊渲染器注册表 */
+const SPECIAL_RENDERERS: Record<string, (props: Record<string, string>) => string> = {
+  TableBlock: renderTableBlock,
+  InfoGrid: renderInfoGrid,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // TipBlock 类型颜色映射
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -131,7 +266,6 @@ const TIP_COLORS: Record<string, { borderColor: string, bgColor: string, textCol
   danger: { borderColor: `#ff4d4f`, bgColor: `#fff2f0`, textColor: `#a8071a` },
 }
 
-/** 为 TipBlock 注入颜色变量 */
 function injectTipColors(props: Record<string, string>): Record<string, string> {
   const type = props.type || `info`
   const colors = TIP_COLORS[type] || TIP_COLORS.info
@@ -139,14 +273,71 @@ function injectTipColors(props: Record<string, string>): Record<string, string> 
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// 模板渲染
+// 模板渲染引擎
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
+ * 递归处理模板字符串，支持：
+ *   - `{{#each arrayProp}}...{{item}}...{{item.key}}...{{@index}}...{{/each}}`
+ *   - `{{#if prop}}...{{#else}}...{{/if}}`
+ *   - `{{#unless prop}}...{{/unless}}`
+ *   - `{{propName}}` 基础替换（自动 HTML 转义）
+ *   - `{{children}}` 保留原始 HTML 不转义
+ */
+function processTemplate(html: string, props: Record<string, string>): string {
+  // 1. {{#each}} 循环（非贪婪，支持嵌套通过递归实现）
+  html = html.replace(/\{\{#each\s+([\w-]+)\}\}([\s\S]*?)\{\{\/each\}\}/g, (_, propKey, body) => {
+    let items: unknown[]
+    try { items = JSON.parse(props[propKey] || `[]`) }
+    catch { items = [] }
+    if (!Array.isArray(items))
+      return ``
+
+    return items.map((item, index) => {
+      let itemBody = body
+      itemBody = itemBody.replace(/\{\{@index\}\}/g, String(index))
+      if (typeof item === `object` && item !== null) {
+        const obj = item as Record<string, unknown>
+        itemBody = itemBody.replace(/\{\{item\.([\w-]+)\}\}/g, (_: string, key: string) => {
+          return obj[key] !== undefined ? escapeHtml(String(obj[key])) : ``
+        })
+      }
+      else {
+        itemBody = itemBody.replace(/\{\{item\}\}/g, escapeHtml(String(item ?? ``)))
+      }
+      // 递归处理循环体内的 #if/#unless/prop 替换
+      return processTemplate(itemBody, props)
+    }).join(``)
+  })
+
+  // 2. {{#if prop}}...{{#else}}...{{/if}}
+  html = html.replace(/\{\{#if\s+([\w-]+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, content) => {
+    const elseIdx = content.indexOf(`{{#else}}`)
+    if (elseIdx >= 0) {
+      return props[key] ? content.slice(0, elseIdx) : content.slice(elseIdx + 9)
+    }
+    return props[key] ? content : ``
+  })
+
+  // 3. {{#unless prop}}...{{/unless}}
+  html = html.replace(/\{\{#unless\s+([\w-]+)\}\}([\s\S]*?)\{\{\/unless\}\}/g, (_, key, content) => {
+    return !props[key] ? content : ``
+  })
+
+  // 4. {{propName}} 替换；{{children}} 不转义
+  html = html.replace(/\{\{([\w-]+)\}\}/g, (_, key) => {
+    if (key === `children`)
+      return props[key] ?? ``
+    return props[key] !== undefined ? escapeHtml(props[key]) : ``
+  })
+
+  return html
+}
+
+/**
  * 将组件定义和 props 渲染为 HTML 字符串。
- * 支持：
- *   - `{{propName}}` 基础占位符替换（值自动转义）
- *   - `{{#if propName}}...{{/if}}` 条件块（prop 存在且非空时显示）
+ * 优先使用 SPECIAL_RENDERERS，否则走 processTemplate 模板引擎。
+ * 颜色通过 CSS 自定义属性适配暗色模式，回退值为 light 模式颜色。
  */
 function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string>): string {
   // 1. 合并默认值
@@ -158,25 +349,28 @@ function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string
   }
   Object.assign(props, rawProps)
 
-  // 2. TipBlock 特殊处理：注入颜色变量
-  const finalProps = def.name === `TipBlock` ? injectTipColors(props) : props
+  // 2. 特殊渲染器（TableBlock / Timeline / InfoGrid / Callout）
+  const specialRenderer = SPECIAL_RENDERERS[def.name]
+  if (specialRenderer) {
+    return specialRenderer(props)
+  }
 
-  let html = def.template
+  // 3. 注入调色板变量 + TipBlock 颜色
+  const propsWithPalette = injectPaletteVars(
+    def.name === `TipBlock` ? injectTipColors(props) : props,
+  )
 
-  // 3. 处理 {{#if prop}}...{{/if}} 条件块
-  html = html.replace(/\{\{#if\s+([\w-]+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, content) => {
-    return finalProps[key] ? content : ``
-  })
+  return processTemplate(def.template, propsWithPalette)
+}
 
-  // 4. 替换 {{propName}} 占位符（转义值）；{{children}} 保留原始 HTML 不转义
-  html = html.replace(/\{\{([\w-]+)\}\}/g, (_, key) => {
-    if (key === `children`) {
-      return finalProps[key] ?? ``
-    }
-    return finalProps[key] !== undefined ? escapeHtml(finalProps[key]) : ``
-  })
-
-  return html
+/**
+ * 预览组件渲染结果（供编辑器 UI 实时预览使用）
+ */
+export function previewComponent(
+  def: CustomComponentDef,
+  propsOverride?: Record<string, string>,
+): string {
+  return renderTemplate(def, propsOverride ?? {})
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/theme/componentDarkVars.ts
+++ b/packages/core/src/theme/componentDarkVars.ts
@@ -1,0 +1,39 @@
+/**
+ * 组件暗色模式 CSS 变量注入
+ *
+ * 使用独立样式元素（id="md-comp-dark"），不会被 getThemeStyles() 读取，
+ * 因此不会污染复制到微信公众号的 HTML 剪贴板内容。
+ *
+ * 暗色变量通过 .dark 选择器激活（Tailwind 暗色模式将 .dark 挂载在 <html> 上），
+ * 自动覆盖 #output 预览区和组件对话框预览区，无需分别处理。
+ *
+ * 组件内联样式使用 var(--md-comp-xxx, lightFallback) 格式：
+ *   - 编辑器暗色模式：.dark 选择器激活深色变量 → 深色显示 ✓
+ *   - 复制到微信（不含此样式元素）：变量未定义 → 使用浅色回退值 ✓
+ */
+
+const COMP_DARK_VARS_CSS = `.dark {
+  --md-comp-bg: #1e1e1e;
+  --md-comp-bg-secondary: #2d2d2d;
+  --md-comp-bg-stripe: #2a2a2a;
+  --md-comp-text-primary: #e0e0e0;
+  --md-comp-text-secondary: #b0b0b0;
+  --md-comp-text-tertiary: #888;
+  --md-comp-border-default: #404040;
+  --md-comp-border-light: #333;
+}`
+
+/**
+ * 初始化组件暗色模式 CSS 变量（页面加载时调用一次）。
+ * 注入 <style id="md-comp-dark"> 到 <head>，通过 .dark 选择器在暗色模式自动激活。
+ */
+export function initComponentDarkVars(): void {
+  if (typeof document === `undefined`)
+    return
+  if (document.getElementById(`md-comp-dark`))
+    return
+  const style = document.createElement(`style`)
+  style.id = `md-comp-dark`
+  style.textContent = COMP_DARK_VARS_CSS
+  document.head.appendChild(style)
+}

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,3 +1,4 @@
+export * from './componentDarkVars'
 export * from './cssProcessor'
 export * from './cssScopeWrapper'
 export * from './cssVariables'

--- a/packages/shared/src/types/component.ts
+++ b/packages/shared/src/types/component.ts
@@ -5,6 +5,9 @@
  *   <QRCodeBlock url="https://example.com" text="扫码访问" />
  */
 
+/** 组件 Prop 类型 */
+export type ComponentPropType = 'string' | 'number' | 'boolean' | 'array'
+
 /** 组件 Prop 定义 */
 export interface ComponentPropDef {
   /** Prop 名称 */
@@ -15,6 +18,8 @@ export interface ComponentPropDef {
   default?: string
   /** 是否必填 */
   required?: boolean
+  /** Prop 类型（默认 string） */
+  type?: ComponentPropType
 }
 
 /** 组件定义 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
+      isomorphic-dompurify:
+        specifier: ^3.15.0
+        version: 3.15.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -5451,6 +5454,7 @@ packages:
 
   lucide-vue-next@1.0.0:
     resolution: {integrity: sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==}
+    deprecated: Package deprecated. Please use @lucide/vue instead.
     peerDependencies:
       vue: '>=3.0.1'
 
@@ -10056,8 +10060,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.59.3(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.0
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:


### PR DESCRIPTION
﻿## 问题

暗色模式下，内置组件（如 `TableBlock`）的斑马纹等样式使用硬编码的深色 hex 值（如 `#252525`）。这些值会被 `juice` 内联到 HTML 中，复制到微信公众号后，在微信的白底环境里显示黑色背景。

## 解决方案

将所有内置组件的颜色从硬编码 hex 改为 CSS 自定义属性 + 亮色回退值的形式：

```css
/* Before */
background: #252525;

/* After */
background: var(--md-comp-bg-stripe, #fafafa);
```

### 核心原理

- 组件内联样式使用 `var(--md-comp-xxx, lightFallback)`
- 新增 `componentDarkVars.ts`：注入 `<style id="md-comp-dark">`，通过 `.dark { --md-comp-xxx: darkValue }` 在编辑器暗色模式下覆盖变量
- `getThemeStyles()` 只读取 `#md-theme` 元素，`#md-comp-dark` **不会**进入剪贴板
- 微信端无 `.dark` 类 → CSS 变量未定义 → 自动使用亮色回退值 ✅

## 变更内容

### `packages/core`
- `extensions/component.ts`：所有特殊渲染器（`TableBlock`、`InfoGrid`）及模板变量改用 CSS var
- `theme/componentDarkVars.ts`（新增）：`initComponentDarkVars()` 函数，页面初始化时注入暗色变量样式表
- `theme/index.ts`：导出 `componentDarkVars`
- 移除内置组件：`CardBlock`、`Callout`、`Timeline`、`SectionDivider`

### `packages/shared`
- `types/component.ts`：新增 `ComponentPropType` 类型和 `type` 字段

### `apps/web`
- `main.ts`：启动时调用 `initComponentDarkVars()`
- `CustomComponentDialog.vue`：UI 改进，移除 `themeMode` 参数（现由 CSS vars 处理）
- `customComponent` store：配套更新
