### PR TITLE
fix: prevent overlapping matches in search tab

### DIFF
--- a/apps/web/src/components/ui/search-tab/SearchTab.vue
+++ b/apps/web/src/components/ui/search-tab/SearchTab.vue
@@ -213,7 +213,7 @@ function findAllMatches() {
             { line: actualLineNumber, ch: index },
             { line: actualLineNumber, ch: index + searchTerm.length },
           ])
-          startIndex = index + 1
+          startIndex = index + searchTerm.length
           index = lineForCompare.indexOf(searchTermForCompare, startIndex)
         }
       })


### PR DESCRIPTION
修复匹配命中异常。

---

复现场景：

```
# 探索 Markdown 的奇妙世界

## Markdown 基础语法

### 1. 标题：让你的内容层次分明
```

修复前，搜索 `##`，可以匹配出三个，观察浏览器与IDE搜索规则，都只有两个。