### PR TITLE
fix(web): clean up back top scroll listener and blob downloads

### DIFF
--- a/apps/web/src/components/ui/back-top/BackTop.vue
+++ b/apps/web/src/components/ui/back-top/BackTop.vue
@@ -33,6 +33,10 @@ const throttledScroll = throttle((el: Target) => {
   }
 }, 200, { edges: [`leading`, `trailing`] })
 
+function handleScroll() {
+  throttledScroll(target.value)
+}
+
 onMounted(() => {
   if (props.target) {
     target.value = document.getElementById(props.target)
@@ -41,15 +45,11 @@ onMounted(() => {
     target.value = window
   }
 
-  target.value!.addEventListener(`scroll`, () => {
-    throttledScroll(target.value)
-  })
+  target.value?.addEventListener(`scroll`, handleScroll)
 })
 
 onUnmounted(() => {
-  target.value!.removeEventListener(`scroll`, () => {
-    throttledScroll(target.value)
-  })
+  target.value?.removeEventListener(`scroll`, handleScroll)
 })
 </script>
 

--- a/apps/web/src/stores/cssEditor.ts
+++ b/apps/web/src/stores/cssEditor.ts
@@ -352,7 +352,9 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
         }
       })
       const blob = await zip.generateAsync({ type: `blob` })
-      downloadFile(URL.createObjectURL(blob), `css-schemes.zip`)
+      const url = URL.createObjectURL(blob)
+      downloadFile(url, `css-schemes.zip`)
+      URL.revokeObjectURL(url)
     }
 
     cssContentConfig.value.selectedIds = []

--- a/packages/shared/src/utils/fileHelpers.ts
+++ b/packages/shared/src/utils/fileHelpers.ts
@@ -21,9 +21,10 @@ export function downloadFile(content: string, filename: string, mimeType: string
   const downLink = document.createElement(`a`)
   downLink.download = filename
   downLink.style.display = `none`
+  let objectUrl: string | null = null
 
   // 检查是否是 base64 data URL
-  if (content.startsWith(`data:`)) {
+  if (content.startsWith(`data:`) || content.startsWith(`blob:`)) {
     downLink.href = content
   }
   else if (mimeType === `text/html`) {
@@ -31,7 +32,8 @@ export function downloadFile(content: string, filename: string, mimeType: string
   }
   else {
     const blob = new Blob([content], { type: mimeType })
-    downLink.href = URL.createObjectURL(blob)
+    objectUrl = URL.createObjectURL(blob)
+    downLink.href = objectUrl
   }
 
   document.body.appendChild(downLink)
@@ -39,8 +41,8 @@ export function downloadFile(content: string, filename: string, mimeType: string
   document.body.removeChild(downLink)
 
   // 如果是 blob URL，释放内存
-  if (!content.startsWith(`data:`) && mimeType !== `text/html`) {
-    URL.revokeObjectURL(downLink.href)
+  if (objectUrl) {
+    URL.revokeObjectURL(objectUrl)
   }
 }
 


### PR DESCRIPTION
## Summary
- fix: clean up BackTop scroll listener to prevent memory leaks
- fix: improve blob download handling in `downloadFile`
- fix: release Blob URL after ZIP export in CSS Editor

## Details
1. BackTop scroll listener:
   - Use a stable function reference for the scroll handler
   - Remove event listener when component unmounts
   - Avoid anonymous function that can't be removed

2. downloadFile utility:
   - Directly use `data:` / `blob:` URLs without modification
   - Fix potential download corruption caused by incorrect URL handling

3. CSS Editor ZIP export:
   - Call `URL.revokeObjectURL()` after download
   - Prevent memory leaks from unreleased Blob URLs