### PR TITLE
fix(web): add rel="noopener noreferrer" to all target="_blank" links

### DIFF
--- a/apps/web/src/components/editor/dialogs/CustomUploadForm.vue
+++ b/apps/web/src/components/editor/dialogs/CustomUploadForm.vue
@@ -71,7 +71,7 @@ function formCustomSave() {
         class="p-0 h-auto text-left whitespace-normal"
         as="a"
         href="https://github.com/doocs/md/blob/main/docs/custom-upload.md"
-        target="_blank"
+        target="_blank" rel="noopener noreferrer"
       >
         参数详情？
       </Button>

--- a/apps/web/src/components/editor/dialogs/ImportMarkdownDialog.vue
+++ b/apps/web/src/components/editor/dialogs/ImportMarkdownDialog.vue
@@ -357,7 +357,7 @@ watch(isShowImportMdDialog, (visible) => {
               基于
               <a
                 href="https://github.com/doocs/anything-md"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 class="underline hover:text-muted-foreground"
               >Anything-MD</a>
               提供转换服务

--- a/apps/web/src/components/editor/dialogs/MpAccountConfigDialog.vue
+++ b/apps/web/src/components/editor/dialogs/MpAccountConfigDialog.vue
@@ -105,7 +105,7 @@ function submit(formValues: any) {
               <template #hint>
                 <a
                   href="https://github.com/doocs/md/blob/main/docs/mp-card.md"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   class="text-xs text-muted-foreground hover:text-primary underline-offset-2 hover:underline"
                 >如何获取公众号 ID？</a>
               </template>

--- a/apps/web/src/components/editor/dialogs/UploadImgDialog.vue
+++ b/apps/web/src/components/editor/dialogs/UploadImgDialog.vue
@@ -591,7 +591,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何获取 GitHub Token？
                 </Button>
@@ -687,7 +687,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://help.aliyun.com/document_detail/31883.html"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何使用阿里云 OSS？
                 </Button>
@@ -772,7 +772,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://cloud.tencent.com/document/product/436/38484"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何使用腾讯云 COS？
                 </Button>
@@ -857,7 +857,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://developer.qiniu.com/kodo"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何使用七牛云 Kodo？
                 </Button>
@@ -935,7 +935,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="http://docs.minio.org.cn/docs/master/minio-client-complete-guide"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何使用 MinIO？
                 </Button>
@@ -1089,7 +1089,7 @@ function onTabScroll(e: WheelEvent) {
                     class="p-0 h-auto text-left whitespace-normal"
                     as="a"
                     href="https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Getting_Started_Guide.html"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                   >
                     如何开启公众号开发者模式并获取应用账号密钥？
                   </Button>
@@ -1098,7 +1098,7 @@ function onTabScroll(e: WheelEvent) {
                     class="p-0 h-auto text-left whitespace-normal"
                     as="a"
                     href="https://md-pages.doocs.org/tutorial/"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                   >
                     如何在浏览器插件中使用公众号图床？
                   </Button>
@@ -1160,7 +1160,7 @@ function onTabScroll(e: WheelEvent) {
                     class="p-0 h-auto text-left whitespace-normal"
                     as="a"
                     href="https://developers.cloudflare.com/r2/api/s3/api/"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                   >
                     如何使用 S3 API 操作 Cloudflare R2？
                   </Button>
@@ -1169,7 +1169,7 @@ function onTabScroll(e: WheelEvent) {
                     class="p-0 h-auto text-left whitespace-normal"
                     as="a"
                     href="https://developers.cloudflare.com/r2/buckets/cors/"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                   >
                     如何设置跨域(CORS)？
                   </Button>
@@ -1224,7 +1224,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://help.upyun.com/"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何使用 又拍云？
                 </Button>
@@ -1258,7 +1258,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://github.com/doocs/md/blob/main/docs/telegram-usage.md"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   如何使用 Telegram？
                 </Button>
@@ -1340,7 +1340,7 @@ function onTabScroll(e: WheelEvent) {
                   class="p-0 h-auto text-left whitespace-normal"
                   as="a"
                   href="https://cloudinary.com/documentation/upload_images"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   Cloudinary 使用文档
                 </Button>

--- a/apps/web/src/components/editor/editor-header/PostTaskDialog.vue
+++ b/apps/web/src/components/editor/editor-header/PostTaskDialog.vue
@@ -109,7 +109,7 @@ watch(() => props.open, (newVal) => {
                   :href="account.editResp.draftLink"
                   class="ml-2 text-blue-500 hover:underline"
                   referrerPolicy="no-referrer"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >查看草稿</a>
               </template>
             </div>

--- a/apps/web/src/entrypoints/popup/App.vue
+++ b/apps/web/src/entrypoints/popup/App.vue
@@ -29,11 +29,11 @@ function onOpenOption() {
         1.开启公众号开发者模式
         <span><a
           href="https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Getting_Started_Guide.html"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >查看文档</a></span>
       </div>
       <div>
-        2.配置IP白名单<span><a href="https://md-pages.doocs.org/tutorial" target="_blank">使用教程</a></span>
+        2.配置IP白名单<span><a href="https://md-pages.doocs.org/tutorial" target="_blank" rel="noopener noreferrer">使用教程</a></span>
       </div>
       <div>
         <button class="button" @click="onOpenOption">


### PR DESCRIPTION
## Summary

Prevent reverse tabnabbing attacks by adding `rel="noopener noreferrer"` to all external `target="_blank"` links.

## Changes

| File | Links Fixed |
|------|-------------|
| `UploadImgDialog.vue` | 12 |
| `App.vue` (popup) | 2 |
| `CustomUploadForm.vue` | 1 |
| `ImportMarkdownDialog.vue` | 1 |
| `MpAccountConfigDialog.vue` | 1 |
| `PostTaskDialog.vue` | 1 |

**Total:** 18 links across 6 components

## Why

Links with `target="_blank"` without `rel="noopener noreferrer"` are vulnerable to reverse tabnabbing — the opened page can access `window.opener` and redirect the original page to a phishing URL.

✅ All changes pass ESLint and TypeScript type check.