### PR TITLE
fix: improve type safety and clean up build warnings

### DIFF
--- a/apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue
+++ b/apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue
@@ -169,9 +169,7 @@ const selectedGroup = computed(() => {
 
 function renderWithMathJax(latex: string, display: boolean): string {
   try {
-    // @ts-expect-error MathJax is a global variable
     window.MathJax.texReset()
-    // @ts-expect-error MathJax is a global variable
     const mjxContainer = window.MathJax.tex2svg(latex, { display })
     const svg = mjxContainer.firstChild as SVGElement
     svg.style.display = display ? `block` : `initial`

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -61,6 +61,12 @@ export default defineConfig(({ mode }) => {
     css: { devSourcemap: true },
     build: {
       rollupOptions: {
+        onwarn(warning, warn) {
+          // @vueuse/core 中的 /* #__PURE__ */ 注释位置不符合 Rolldown 要求，忽略该警告
+          if (warning.code === `INVALID_ANNOTATION` && warning.message?.includes(`@vueuse/core`))
+            return
+          warn(warning)
+        },
         output: {
           chunkFileNames: `static/js/md-[name]-[hash].js`,
           entryFileNames: `static/js/md-[name]-[hash].js`,

--- a/packages/core/src/extensions/alert.ts
+++ b/packages/core/src/extensions/alert.ts
@@ -24,9 +24,8 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
   }
 
   // 提取公共的渲染逻辑
-  function renderAlert(token: any) {
+  function renderAlert(this: any, token: any) {
     const { meta, tokens = [] } = token
-    // @ts-expect-error marked renderer context has parser property
     const text = this.parser.parse(tokens)
     // 新主题系统：使用 CSS 选择器而非内联样式
     let tmpl = `<blockquote class="${meta.className} ${meta.className}-${meta.variant}">\n`

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -1,3 +1,4 @@
+/// <reference path="../mathjax.d.ts" />
 import type { MarkedExtension } from 'marked'
 import { escapeHtml } from '../utils/basicHelpers'
 
@@ -18,9 +19,7 @@ function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
   return (token: any) => {
     const display = token.displayMode ?? defaultDisplay
 
-    // @ts-expect-error MathJax is a global variable
     window.MathJax.texReset()
-    // @ts-expect-error MathJax is a global variable
     const mjxContainer = window.MathJax.tex2svg(token.text, { display })
     const svg = mjxContainer.firstChild
     const width = svg.style[`min-width`] || svg.getAttribute(`width`)
@@ -34,7 +33,7 @@ function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
       svg.style.display = `initial`
       svg.style.setProperty(`max-width`, `300vw`, `important`)
       svg.style.flexShrink = `0`
-      svg.style.width = width
+      svg.style.width = width || ``
     }
 
     if (!display) {

--- a/packages/core/src/mathjax.d.ts
+++ b/packages/core/src/mathjax.d.ts
@@ -1,0 +1,17 @@
+/**
+ * 类型声明：MathJax 全局变量
+ * MathJax 通过 <script> 标签加载到 window 上，无官方 TypeScript 声明
+ */
+
+interface MathJaxDocument {
+  firstChild: SVGElement & { style: CSSStyleDeclaration & Record<string, string | null> }
+}
+
+interface MathJaxGlobal {
+  texReset: () => void
+  tex2svg: (tex: string, options?: { display?: boolean }) => MathJaxDocument
+}
+
+interface Window {
+  MathJax: MathJaxGlobal
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@md/shared",
   "type": "module",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "private": true,
   "exports": {
     ".": "./src/index.ts",

--- a/packages/shared/src/types/prettier.d.ts
+++ b/packages/shared/src/types/prettier.d.ts
@@ -1,0 +1,50 @@
+/**
+ * 类型声明：prettier v2.8.8 缺少 TypeScript 声明
+ * 为 prettier/standalone 和各 parser 子路径提供模块声明
+ */
+
+declare module 'prettier/standalone' {
+  import type { Plugin } from 'prettier'
+
+  interface Options {
+    parser: string
+    plugins: Plugin[]
+    printWidth?: number
+    tabWidth?: number
+    useTabs?: boolean
+    semi?: boolean
+    singleQuote?: boolean
+    quoteProps?: 'as-needed' | 'consistent' | 'preserve'
+    trailingComma?: 'es5' | 'all' | 'none'
+    bracketSpacing?: boolean
+    bracketSameLine?: boolean
+    arrowParens?: 'avoid' | 'always'
+    proseWrap?: 'always' | 'never' | 'preserve'
+    htmlWhitespaceSensitivity?: 'css' | 'strict' | 'ignore'
+    endOfLine?: 'lf' | 'crlf' | 'cr' | 'auto'
+    [key: string]: any
+  }
+
+  export function format(source: string, options: Options): Promise<string>
+}
+
+declare module 'prettier/parser-babel' {
+  import type { Plugin } from 'prettier'
+
+  const plugin: Plugin
+  export default plugin
+}
+
+declare module 'prettier/parser-markdown' {
+  import type { Plugin } from 'prettier'
+
+  const plugin: Plugin
+  export default plugin
+}
+
+declare module 'prettier/parser-postcss' {
+  import type { Plugin } from 'prettier'
+
+  const plugin: Plugin
+  export default plugin
+}

--- a/packages/shared/src/utils/fileHelpers.ts
+++ b/packages/shared/src/utils/fileHelpers.ts
@@ -1,10 +1,7 @@
-// @ts-expect-error - prettier v2.8.8 doesn't have proper TypeScript declarations
+/// <reference path="../types/prettier.d.ts" />
 import parserBabel from 'prettier/parser-babel'
-// @ts-expect-error - prettier v2.8.8 doesn't have proper TypeScript declarations
 import parserMarkdown from 'prettier/parser-markdown'
-// @ts-expect-error - prettier v2.8.8 doesn't have proper TypeScript declarations
 import parserPostcss from 'prettier/parser-postcss'
-// @ts-expect-error - prettier v2.8.8 doesn't have proper TypeScript declarations
 import * as prettier from 'prettier/standalone'
 
 /**


### PR DESCRIPTION
## 变更内容

### 1. 统一 Monorepo 包版本号
- `@md/shared` 从 `1.0.0` 升级至 `2.1.0`，与其余包保持一致

### 2. 消除 `@ts-expect-error` 注释

| 文件 | 修复方式 |
|------|---------|
| `packages/shared/src/utils/fileHelpers.ts` (4 处) | 新增 `prettier.d.ts` 模块声明，为 `prettier/standalone` 及 parser 子路径提供类型 |
| `packages/core/src/extensions/katex.ts` (2 处) | 新增 `mathjax.d.ts` 扩展 `Window` 接口 |
| `apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue` (2 处) | 复用上述 `mathjax.d.ts` 声明 |
| `packages/core/src/extensions/alert.ts` (1 处) | 为 `renderAlert` 添加 `this: any` 参数 |

### 3. 抑制构建警告
- 在 `vite.config.ts` 中通过 `rollupOptions.onwarn` 过滤 `@vueuse/core` 的 `INVALID_ANNOTATION` 警告

## 验证

- ✅ `pnpm run type-check` — 无错误
- ✅ `pnpm run lint` — 无错误
- ✅ `pnpm web build` — 4.93s 构建成功，无警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)