### PR TITLE
fix: highlight performance, AI config race condition, and timer leaks

### DIFF
--- a/apps/web/src/components/ai/SidebarAIToolbar.vue
+++ b/apps/web/src/components/ai/SidebarAIToolbar.vue
@@ -11,7 +11,6 @@ defineProps<{
   showEditor: boolean
 }>()
 const SELECTION_HINT_TIMEOUT_MS = 3000
-const SELECTION_CHECK_INTERVAL_MS = 300
 
 const uiStore = useUIStore()
 const { aiDialogVisible, aiImageDialogVisible } = storeToRefs(uiStore)
@@ -31,7 +30,6 @@ const toolBoxVisible = ref(false)
 // 是否显示选中文本提示动画
 const showSelectionHint = ref(false)
 let selectionHintTimer: NodeJS.Timeout | null = null
-let selectionCheckInterval: NodeJS.Timeout | null = null
 let lastSelectedText = ``
 
 // 检查选中文本的函数
@@ -127,10 +125,11 @@ function openAIToolBox() {
 
 // 监听编辑区点击，自动收起工具栏
 onMounted(() => {
-  // 启动定时检查选中文本
-  selectionCheckInterval = setInterval(() => {
+  // 使用 selectionchange 事件替代轮询，检测选中文本变化
+  const handleSelectionChange = () => {
     checkSelectionAndUpdateHint()
-  }, SELECTION_CHECK_INTERVAL_MS) // 定期检查选中文本
+  }
+  document.addEventListener(`selectionchange`, handleSelectionChange)
 
   const handleInteraction = (e: Event) => {
     // 只有在展开状态才需要处理
@@ -176,17 +175,12 @@ onMounted(() => {
   onUnmounted(() => {
     document.removeEventListener(`click`, handleInteraction, true)
     document.removeEventListener(`touchstart`, handleInteraction, true)
+    document.removeEventListener(`selectionchange`, handleSelectionChange)
 
     // 清理定时器
     if (selectionHintTimer) {
       clearTimeout(selectionHintTimer)
       selectionHintTimer = null
-    }
-
-    // 清理轮询
-    if (selectionCheckInterval) {
-      clearInterval(selectionCheckInterval)
-      selectionCheckInterval = null
     }
   })
 })

--- a/apps/web/src/components/editor/CodemirrorEditor.vue
+++ b/apps/web/src/components/editor/CodemirrorEditor.vue
@@ -41,6 +41,7 @@ useScrollSync(getEditorView, getPreviewContainer, enableScrollSync)
 // --- 复制状态 ---
 const backLight = ref(false)
 const isCoping = ref(false)
+let copyEndTimer: ReturnType<typeof setTimeout> | null = null
 
 function startCopy() {
   backLight.value = true
@@ -49,10 +50,21 @@ function startCopy() {
 
 function endCopy() {
   backLight.value = false
-  setTimeout(() => {
+  if (copyEndTimer) {
+    clearTimeout(copyEndTimer)
+  }
+  copyEndTimer = setTimeout(() => {
     isCoping.value = false
+    copyEndTimer = null
   }, 800)
 }
+
+onUnmounted(() => {
+  if (copyEndTimer) {
+    clearTimeout(copyEndTimer)
+    copyEndTimer = null
+  }
+})
 
 // --- 上传图片透传 ---
 function handleUploadImage(file: File, cb?: any, applyUrl?: boolean) {

--- a/apps/web/src/stores/aiConfig.ts
+++ b/apps/web/src/stores/aiConfig.ts
@@ -36,15 +36,18 @@ export const useAIConfigStore = defineStore(`AIConfig`, () => {
   // API Key（按服务类型分别持久化）
   const apiKey = ref<string>(DEFAULT_SERVICE_KEY)
 
-  // 异步加载初始值（延迟到微任务中，避免与 immediate watcher 竞争）
+  // 异步加载初始值（捕获 type 防止竞态覆盖）
   Promise.resolve().then(async () => {
-    const value = await store.get(`openai_key_${type.value}`)
-    apiKey.value = value || DEFAULT_SERVICE_KEY
+    const capturedType = type.value
+    const value = await store.get(`openai_key_${capturedType}`)
+    if (type.value === capturedType) {
+      apiKey.value = value || DEFAULT_SERVICE_KEY
+    }
   })
 
   // ==================== 响应式逻辑 ====================
 
-  // 监听服务类型变化，自动同步端点和模型
+  // 监听服务类型变化，自动同步端点、模型和 API Key
   watch(
     type,
     async (newType) => {
@@ -59,9 +62,20 @@ export const useAIConfigStore = defineStore(`AIConfig`, () => {
 
       // 保存当前模型
       await store.set(`openai_model_${newType}`, model.value)
+
+      // 加载对应服务的 API Key
+      const keyValue = await store.get(`openai_key_${newType}`)
+      apiKey.value = keyValue || DEFAULT_SERVICE_KEY
     },
     { immediate: true }, // 首次加载时也执行
   )
+
+  // 监听 API Key 变化，持久化存储（仅非默认服务类型）
+  watch(apiKey, async (val) => {
+    if (type.value !== DEFAULT_SERVICE_TYPE) {
+      await store.set(`openai_key_${type.value}`, val)
+    }
+  })
 
   // 监听模型变化，持久化存储
   watch(model, async (val) => {

--- a/apps/web/src/stores/aiConfig.ts
+++ b/apps/web/src/stores/aiConfig.ts
@@ -34,28 +34,12 @@ export const useAIConfigStore = defineStore(`AIConfig`, () => {
   // ==================== API Key 管理 ====================
 
   // API Key（按服务类型分别持久化）
-  const apiKey = customRef<string>((track, trigger) => {
-    let cachedKey = ``
+  const apiKey = ref<string>(DEFAULT_SERVICE_KEY)
 
-    // 异步加载初始值
-    store.get(`openai_key_${type.value}`).then((value) => {
-      cachedKey = value || DEFAULT_SERVICE_KEY
-    })
-
-    return {
-      get() {
-        track()
-        return cachedKey
-      },
-      set(val: string) {
-        cachedKey = val
-        trigger()
-
-        if (type.value !== DEFAULT_SERVICE_TYPE) {
-          store.set(`openai_key_${type.value}`, val)
-        }
-      },
-    }
+  // 异步加载初始值（延迟到微任务中，避免与 immediate watcher 竞争）
+  Promise.resolve().then(async () => {
+    const value = await store.get(`openai_key_${type.value}`)
+    apiKey.value = value || DEFAULT_SERVICE_KEY
   })
 
   // ==================== 响应式逻辑 ====================

--- a/apps/web/src/stores/aiImageConfig.ts
+++ b/apps/web/src/stores/aiImageConfig.ts
@@ -27,34 +27,16 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
   // ==================== 服务相关字段 ====================
 
   // 服务端点（支持自定义服务）
-  const endpoint = customRef<string>((track, trigger) => {
-    let cachedEndpoint = ``
+  const endpoint = ref<string>(``)
 
-    // 异步加载初始值
-    const loadEndpoint = async () => {
-      if (type.value === `custom`) {
-        cachedEndpoint = await store.get(`openai_image_endpoint_${type.value}`) || ``
-      }
-      else {
-        const svc = imageServiceOptions.find(s => s.value === type.value) ?? imageServiceOptions[0]
-        cachedEndpoint = svc.endpoint
-      }
+  // 异步加载初始端点（延迟到微任务中，避免与 immediate watcher 竞争）
+  Promise.resolve().then(async () => {
+    if (type.value === `custom`) {
+      endpoint.value = await store.get(`openai_image_endpoint_${type.value}`) || ``
     }
-    loadEndpoint()
-
-    return {
-      get() {
-        track()
-        return cachedEndpoint
-      },
-      set(val: string) {
-        cachedEndpoint = val
-        trigger()
-
-        if (type.value === `custom`) {
-          store.set(`openai_image_endpoint_${type.value}`, val)
-        }
-      },
+    else {
+      const svc = imageServiceOptions.find(s => s.value === type.value) ?? imageServiceOptions[0]
+      endpoint.value = svc.endpoint
     }
   })
 
@@ -64,28 +46,12 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
   // ==================== API Key 管理 ====================
 
   // API Key（按服务类型分别持久化）
-  const apiKey = customRef<string>((track, trigger) => {
-    let cachedKey = ``
+  const apiKey = ref<string>(DEFAULT_SERVICE_KEY)
 
-    // 异步加载初始值
-    store.get(`openai_image_key_${type.value}`).then((value) => {
-      cachedKey = value || DEFAULT_SERVICE_KEY
-    })
-
-    return {
-      get() {
-        track()
-        return cachedKey
-      },
-      set(val: string) {
-        cachedKey = val
-        trigger()
-
-        if (type.value !== DEFAULT_SERVICE_TYPE) {
-          store.set(`openai_image_key_${type.value}`, val)
-        }
-      },
-    }
+  // 异步加载初始值（延迟到微任务中，避免与 immediate watcher 竞争）
+  Promise.resolve().then(async () => {
+    const value = await store.get(`openai_image_key_${type.value}`)
+    apiKey.value = value || DEFAULT_SERVICE_KEY
   })
 
   // ==================== 响应式逻辑 ====================

--- a/apps/web/src/stores/aiImageConfig.ts
+++ b/apps/web/src/stores/aiImageConfig.ts
@@ -29,14 +29,20 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
   // 服务端点（支持自定义服务）
   const endpoint = ref<string>(``)
 
-  // 异步加载初始端点（延迟到微任务中，避免与 immediate watcher 竞争）
+  // 异步加载初始端点（捕获 type 防止竞态覆盖）
   Promise.resolve().then(async () => {
-    if (type.value === `custom`) {
-      endpoint.value = await store.get(`openai_image_endpoint_${type.value}`) || ``
+    const capturedType = type.value
+    if (capturedType === `custom`) {
+      const value = await store.get(`openai_image_endpoint_${capturedType}`)
+      if (type.value === capturedType) {
+        endpoint.value = value || ``
+      }
     }
     else {
-      const svc = imageServiceOptions.find(s => s.value === type.value) ?? imageServiceOptions[0]
-      endpoint.value = svc.endpoint
+      const svc = imageServiceOptions.find(s => s.value === capturedType) ?? imageServiceOptions[0]
+      if (type.value === capturedType) {
+        endpoint.value = svc.endpoint
+      }
     }
   })
 
@@ -48,19 +54,31 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
   // API Key（按服务类型分别持久化）
   const apiKey = ref<string>(DEFAULT_SERVICE_KEY)
 
-  // 异步加载初始值（延迟到微任务中，避免与 immediate watcher 竞争）
+  // 异步加载初始值（捕获 type 防止竞态覆盖）
   Promise.resolve().then(async () => {
-    const value = await store.get(`openai_image_key_${type.value}`)
-    apiKey.value = value || DEFAULT_SERVICE_KEY
+    const capturedType = type.value
+    const value = await store.get(`openai_image_key_${capturedType}`)
+    if (type.value === capturedType) {
+      apiKey.value = value || DEFAULT_SERVICE_KEY
+    }
   })
 
   // ==================== 响应式逻辑 ====================
 
-  // 监听服务类型变化，自动同步模型
+  // 监听服务类型变化，自动同步端点、模型和 API Key
   watch(
     type,
     async (newType) => {
       const svc = imageServiceOptions.find(s => s.value === newType) ?? imageServiceOptions[0]
+
+      // 同步端点
+      if (newType === `custom`) {
+        const endpointValue = await store.get(`openai_image_endpoint_${newType}`)
+        endpoint.value = endpointValue || ``
+      }
+      else {
+        endpoint.value = svc.endpoint
+      }
 
       if (newType === `custom`) {
         // 自定义服务：从存储读取模型
@@ -77,6 +95,10 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
           await store.set(`openai_image_model_${newType}`, svc.models[0])
         }
       }
+
+      // 加载对应服务的 API Key
+      const keyValue = await store.get(`openai_image_key_${newType}`)
+      apiKey.value = keyValue || DEFAULT_SERVICE_KEY
     },
     { immediate: true }, // 首次加载时也执行
   )
@@ -84,6 +106,20 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
   // 监听模型变化，持久化存储
   watch(model, async (val) => {
     await store.set(`openai_image_model_${type.value}`, val)
+  })
+
+  // 监听 API Key 变化，持久化存储（仅非默认服务类型）
+  watch(apiKey, async (val) => {
+    if (type.value !== DEFAULT_SERVICE_TYPE) {
+      await store.set(`openai_image_key_${type.value}`, val)
+    }
+  })
+
+  // 监听端点变化，持久化存储（仅自定义服务类型）
+  watch(endpoint, async (val) => {
+    if (type.value === `custom`) {
+      await store.set(`openai_image_endpoint_${type.value}`, val)
+    }
   })
 
   // ==================== Actions ====================

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -175,13 +175,13 @@ function splitHighlightedHtmlByLines(html: string): string[] {
 
       currentLine += tag
 
-      // 跟踪标签的开闭状态
-      if (tag.startsWith(`</`)) {
-        // 关闭标签，从栈中移除
+      // 只跟踪 highlight.js 产出的 <span> 标签
+      if (tag.startsWith(`</span`)) {
+        // 关闭 span，从栈中移除
         openTags.pop()
       }
-      else if (tag.startsWith(`<`) && !tag.endsWith(`/>`)) {
-        // 打开标签，加入栈
+      else if (tag.startsWith(`<span`)) {
+        // 打开 span，加入栈
         openTags.push(tag)
       }
     }

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -149,6 +149,60 @@ function formatHighlightedCode(html: string, preserveNewlines = false): string {
 }
 
 /**
+ * 分割高亮后的 HTML 为多行，保持 span 上下文
+ * highlight.js 输出的 HTML 中，span 标签不会跨行，但换行符可能在 span 内部
+ * 此函数将 HTML 按换行符分割，并在每行前后添加必要的开闭标签
+ */
+function splitHighlightedHtmlByLines(html: string): string[] {
+  const lines: string[] = []
+  let currentLine = ``
+  const openTags: string[] = [] // 记录打开的标签，如 '<span class="...">'
+
+  let i = 0
+  while (i < html.length) {
+    if (html[i] === `<`) {
+      // 读取完整标签
+      let tag = `<`
+      i++
+      while (i < html.length && html[i] !== `>`) {
+        tag += html[i]
+        i++
+      }
+      if (i < html.length) {
+        tag += `>`
+        i++
+      }
+
+      currentLine += tag
+
+      // 跟踪标签的开闭状态
+      if (tag.startsWith(`</`)) {
+        // 关闭标签，从栈中移除
+        openTags.pop()
+      }
+      else if (tag.startsWith(`<`) && !tag.endsWith(`/>`)) {
+        // 打开标签，加入栈
+        openTags.push(tag)
+      }
+    }
+    else if (html[i] === `\n`) {
+      // 遇到换行，关闭当前行的所有标签，下一行重新打开
+      lines.push(currentLine)
+      currentLine = openTags.join(``)
+      i++
+    }
+    else {
+      currentLine += html[i]
+      i++
+    }
+  }
+
+  // 最后一行
+  lines.push(currentLine)
+  return lines
+}
+
+/**
  * 高亮代码并格式化（支持行号）
  * @param text 原始代码文本
  * @param language 语言名称
@@ -160,10 +214,11 @@ export function highlightAndFormatCode(text: string, language: string, hljs: any
   let highlighted = ``
 
   if (showLineNumber) {
-    const rawLines = text.replace(/\r\n/g, `\n`).split(`\n`)
+    // 先对整个代码块进行高亮，保持跨行上下文
+    const fullHighlighted = hljs.highlight(text, { language }).value
 
-    const highlightedLines = rawLines.map((lineRaw) => {
-      const lineHtml = hljs.highlight(lineRaw, { language }).value
+    // 分割为多行，保持 span 上下文
+    const highlightedLines = splitHighlightedHtmlByLines(fullHighlighted).map((lineHtml) => {
       const formatted = formatHighlightedCode(lineHtml, false)
       return formatted === `` ? `&nbsp;` : formatted
     })

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -186,8 +186,10 @@ function splitHighlightedHtmlByLines(html: string): string[] {
       }
     }
     else if (html[i] === `\n`) {
-      // 遇到换行，关闭当前行的所有标签，下一行重新打开
-      lines.push(currentLine)
+      // 为当前行补齐所有闭合标签
+      const closingTags = `</span>`.repeat(openTags.length)
+      lines.push(currentLine + closingTags)
+      // 下一行重新打开这些标签
       currentLine = openTags.join(``)
       i++
     }
@@ -214,8 +216,10 @@ export function highlightAndFormatCode(text: string, language: string, hljs: any
   let highlighted = ``
 
   if (showLineNumber) {
-    // 先对整个代码块进行高亮，保持跨行上下文
-    const fullHighlighted = hljs.highlight(text, { language }).value
+    // 先归一化换行符，确保分割逻辑一致
+    const normalizedText = text.replace(/\r\n/g, `\n`)
+    // 对整个代码块进行高亮，保持跨行上下文
+    const fullHighlighted = hljs.highlight(normalizedText, { language }).value
 
     // 分割为多行，保持 span 上下文
     const highlightedLines = splitHighlightedHtmlByLines(fullHighlighted).map((lineHtml) => {


### PR DESCRIPTION
## 修复内容

### #5 代码高亮性能优化
**`packages/core/src/utils/languages.ts`**

原问题：开启行号后，逐行调用 `hljs.highlight()`，100 行代码调用 100 次，丢失跨行 token 上下文。

修复：先对整个代码块调用一次 `hljs.highlight()`，再通过 `splitHighlightedHtmlByLines()` 按换行符分割 HTML，同时维护开闭标签栈以保持 span 上下文完整。

### #7 AI 配置竞态条件
**`apps/web/src/stores/aiConfig.ts`** + **`apps/web/src/stores/aiImageConfig.ts`**

原问题：`customRef` 异步加载 API Key/端点，初始值为空字符串。`immediate: true` watcher 先于异步加载完成时执行，用默认值覆盖了存储值。

修复：用 `ref(默认值)` + `Promise.resolve().then()` 延迟加载替代 `customRef`。初始值立即可用（默认值），异步加载完成后更新。消除了竞态条件。

### #8 SidebarAIToolbar 轮询改事件
**`apps/web/src/components/ai/SidebarAIToolbar.vue`**

原问题：每 300ms 轮询检查选中文本，即使无交互也持续运行。

修复：替换为 `document.addEventListener('selectionchange', ...)` 事件驱动，仅在选区实际变化时触发。

### #9 setTimeout 未清理
**`apps/web/src/components/editor/CodemirrorEditor.vue`**

原问题：`endCopy()` 中 `setTimeout` 无清理，组件卸载后仍执行。

修复：用变量跟踪 timer ID，重复调用时清除旧 timer，`onUnmounted` 中清理。

## 变更文件
| 文件 | 修改说明 |
|------|---------|
| `packages/core/src/utils/languages.ts` | 新增 `splitHighlightedHtmlByLines`，整体高亮后分割 |
| `apps/web/src/stores/aiConfig.ts` | 替换 `customRef` 为 `ref` + 延迟加载 |
| `apps/web/src/stores/aiImageConfig.ts` | 替换两个 `customRef` 为 `ref` + 延迟加载 |
| `apps/web/src/components/ai/SidebarAIToolbar.vue` | 轮询改为 `selectionchange` 事件 |
| `apps/web/src/components/editor/CodemirrorEditor.vue` | 跟踪并清理 `endCopy` timer |

## 验证
- ✅ TypeScript 类型检查通过
- ✅ ESLint 检查通过