### PR TITLE
chore: remove commented-out code across codebase

### DIFF
--- a/apps/web/src/assets/less/app.less
+++ b/apps/web/src/assets/less/app.less
@@ -1,9 +1,3 @@
-//* {
-//  box-sizing: border-box;
-//  margin: 0;
-//  padding: 0;
-//}
-
 html,
 body {
   height: 100%;
@@ -74,8 +68,6 @@ section {
 
 .preview {
   position: relative;
-  // margin: 0 -20px;
-  // width: 375px;
   min-height: 100%;
   margin: 0 auto;
   padding: 20px;

--- a/apps/web/src/modules/build-extension.ts
+++ b/apps/web/src/modules/build-extension.ts
@@ -208,7 +208,6 @@ export function htmlScriptToLocal(
               await writeFile(outFile, textContent, `utf8`)
               // Replace unsafe inline script
               const virtualScript = document.createElement(`script`)
-              // virtualScript.type = `module`
               virtualScript.src = `/${fileName}`
               script.replaceWith(virtualScript)
             })()

--- a/apps/web/src/utils/file.ts
+++ b/apps/web/src/utils/file.ts
@@ -797,9 +797,6 @@ export async function fileUpload(content: string, file: File) {
     case `formCustom`:
       return formCustomUpload(content, file)
     default:
-      // return file.size / 1024 < 1024
-      //     ? giteeUpload(content, file.name)
-      //     : ghFileUpload(content, file.name);
       return ghFileUpload(content, file.name)
   }
 }

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -26,7 +26,7 @@ function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
     svg.removeAttribute(`width`)
 
     // 行内公式对齐 https://groups.google.com/g/mathjax-users/c/zThKffrrCvE?pli=1
-    // 直接覆盖 style 会覆盖 MathJax 的样式，需要手动设置
+    // 直接覆盖 style 会覆盖 MathJax 的样式，需要逐个属性设置
     // svg.style = `max-width: 300vw !important; display: initial; flex-shrink: 0;`
 
     if (withStyle) {

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -27,7 +27,6 @@ function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
 
     // 行内公式对齐 https://groups.google.com/g/mathjax-users/c/zThKffrrCvE?pli=1
     // 直接覆盖 style 会覆盖 MathJax 的样式，需要逐个属性设置
-    // svg.style = `max-width: 300vw !important; display: initial; flex-shrink: 0;`
 
     if (withStyle) {
       svg.style.display = `initial`

--- a/packages/core/src/utils/markdownHelpers.ts
+++ b/packages/core/src/utils/markdownHelpers.ts
@@ -74,8 +74,6 @@ export function postProcessHtml(baseHtml: string, reading: ReadTimeResults, rend
   // 阅读时间及字数统计
   let html = baseHtml
   html = renderer.buildReadingTime(reading) + html
-  // 新主题系统：通过 CSS 去除第一行的 margin-top
-  // html = html.replace(/(style=".*?)"/, `$1;margin-top: 0"`)
   // 引用脚注
   html += renderer.buildFootnotes()
   // 附加的一些 style

--- a/packages/shared/src/editor/basicSetup.ts
+++ b/packages/shared/src/editor/basicSetup.ts
@@ -47,7 +47,6 @@ import { indentationMarkers } from '@replit/codemirror-indentation-markers'
 /// and an array literal), copy it into your own code, and adjust it
 /// as desired.
 export const basicSetup: Extension = (() => [
-  // lineNumbers(), // 移除行号显示
   highlightActiveLineGutter(),
   highlightSpecialChars(),
   history(),


### PR DESCRIPTION
- Remove old giteeUpload conditional in file.ts
- Remove deprecated margin-top replacement in markdownHelpers.ts
- Remove commented lineNumbers() call in basicSetup.ts
- Remove commented script.type assignment in build-extension.ts
- Remove old svg.style override comment in katex.ts
- Remove commented CSS reset and preview layout rules in app.less
- Remove debug color logging comment in util.js