### PR TITLE
chore(skills): add create-pr skill and git-commit branch workflow

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: create-pr
+description: Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, PR template usage, and PR creation using the gh CLI tool.
+---
+
+# Create PR
+
+This skill guides you through creating a well-structured GitHub pull request that follows project conventions and best practices.
+
+## Prerequisites Check
+
+Before proceeding, verify the following:
+
+### 1. Check if `gh` CLI is installed
+
+```bash
+gh --version
+```
+
+If not installed, inform the user:
+> The GitHub CLI (`gh`) is required but not installed. Please install it:
+> - macOS: `brew install gh`
+> - Other: https://cli.github.com/
+
+### 2. Check if authenticated with GitHub
+
+```bash
+gh auth status
+```
+
+If not authenticated, guide the user to run `gh auth login`.
+
+### 3. Verify clean working directory
+
+```bash
+git status
+```
+
+If there are uncommitted changes, ask the user whether to:
+- Commit them as part of this PR
+- Stash them temporarily
+- Discard them (with caution)
+
+## Gather Context
+
+### 1. Identify the current branch
+
+```bash
+git branch --show-current
+```
+
+Ensure you're not on `main` or `master`. If so, ask the user to create or switch to a feature branch.
+
+### 2. Find the base branch
+
+```bash
+git remote show origin | grep "HEAD branch"
+```
+
+This is typically `main` or `master`.
+
+### 3. Analyze recent commits relevant to this PR
+
+```bash
+git log origin/main..HEAD --oneline --no-decorate
+```
+
+Review these commits to understand:
+- What changes are being introduced
+- The scope of the PR (single feature/fix or multiple changes)
+- Whether commits should be squashed or reorganized
+
+### 4. Review the diff
+
+```bash
+git diff origin/main..HEAD --stat
+```
+
+This shows which files changed and helps identify the type of change.
+
+## Information Gathering
+
+Before creating the PR, you need the following information. Check if it can be inferred from:
+- Commit messages
+- Branch name (e.g., `fix/issue-123`, `feature/new-login`)
+- Changed files and their content
+
+If any critical information is missing, use `ask_followup_question` to ask the user:
+
+### Required Information
+
+1. **Related Issue Number**: Look for patterns like `#123`, `fixes #123`, or `closes #123` in commit messages
+2. **Description**: What problem does this solve? Why were these changes made?
+3. **Type of Change**: Bug fix, new feature, breaking change, refactor, cosmetic, documentation, or workflow
+4. **Test Procedure**: How was this tested? What could break?
+
+### Example clarifying question
+
+If the issue number is not found:
+> I couldn't find a related issue number in the commit messages or branch name. What GitHub issue does this PR address? (Enter the issue number, e.g., "123" or "N/A" for small fixes)
+
+## Git Best Practices
+
+Before creating the PR, consider these best practices:
+
+### Commit Hygiene
+
+1. **Atomic commits**: Each commit should represent a single logical change
+2. **Clear commit messages**: Follow conventional commit format when possible
+3. **No merge commits**: Prefer rebasing over merging to keep history clean
+
+### Branch Management
+
+1. **Rebase on latest main** (if needed):
+   ```bash
+   git fetch origin
+   git rebase origin/main
+   ```
+
+2. **Squash if appropriate**: If there are many small "WIP" commits, consider interactive rebase:
+   ```bash
+   git rebase -i origin/main
+   ```
+   Only suggest this if commits appear messy and the user is comfortable with rebasing.
+
+### Push Changes
+
+Ensure all commits are pushed:
+```bash
+git push origin HEAD
+```
+
+If the branch was rebased, you may need:
+```bash
+git push origin HEAD --force-with-lease
+```
+
+## Create the Pull Request
+
+**IMPORTANT**: Read and use the PR template at `.github/pull_request_template.md`. The PR body format must **strictly match** the template structure. Do not deviate from the template format.
+
+When filling out the template:
+- Replace `#XXXX` with the actual issue number, or keep as `#XXXX` if no issue exists (for small fixes)
+- Fill in all sections with relevant information gathered from commits and context
+- Mark the appropriate "Type of Change" checkbox(es)
+- Complete the "Pre-flight Checklist" items that apply
+
+### Create PR with gh CLI
+
+**Use a temporary file for the PR body** to avoid shell escaping issues, newline problems, and other command-line flakiness:
+
+1. Write the PR body to a temporary file:
+   ```
+   /tmp/pr-body.md
+   ```
+
+2. Create the PR using the file:
+   ```bash
+   gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main
+   ```
+
+3. Clean up the temporary file:
+   ```bash
+   rm /tmp/pr-body.md
+   ```
+
+For draft PRs:
+```bash
+gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main --draft
+```
+
+**Why use a file?** Passing complex markdown with newlines, special characters, and checkboxes directly via `--body` is error-prone. The `--body-file` flag handles all content reliably.
+
+## Post-Creation
+
+After creating the PR:
+
+1. **Display the PR URL** so the user can review it
+2. **Remind about CI checks**: Tests and linting will run automatically
+3. **Suggest next steps**:
+   - Add reviewers if needed: `gh pr edit --add-reviewer USERNAME`
+   - Add labels if needed: `gh pr edit --add-label "bug"`
+
+## Error Handling
+
+### Common Issues
+
+1. **No commits ahead of main**: The branch has no changes to submit
+   - Ask if the user meant to work on a different branch
+
+2. **Branch not pushed**: Remote doesn't have the branch
+   - Push the branch first: `git push -u origin HEAD`
+
+3. **PR already exists**: A PR for this branch already exists
+   - Show the existing PR: `gh pr view`
+   - Ask if they want to update it instead
+
+4. **Merge conflicts**: Branch conflicts with base
+   - Guide user through resolving conflicts or rebasing
+
+## Summary Checklist
+
+Before finalizing, ensure:
+- [ ] `gh` CLI is installed and authenticated
+- [ ] Working directory is clean
+- [ ] All commits are pushed
+- [ ] Branch is up-to-date with base branch
+- [ ] Related issue number is identified, or placeholder is used
+- [ ] PR description follows the template exactly
+- [ ] Appropriate type of change is selected
+- [ ] Pre-flight checklist items are addressed

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -53,16 +53,23 @@ Ensure you're not on `main` or `master`. If so, ask the user to create or switch
 
 ### 2. Find the base branch
 
+Determine the default branch once and reuse it as `BASE_BRANCH` in all later commands:
+
 ```bash
-git remote show origin | grep "HEAD branch"
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+
+# Fallback when origin/HEAD is not configured
+if [ -z "$BASE_BRANCH" ]; then
+  BASE_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+fi
 ```
 
-This is typically `main` or `master`.
+This is typically `main` or `master`, but may differ per repo.
 
 ### 3. Analyze recent commits relevant to this PR
 
 ```bash
-git log origin/main..HEAD --oneline --no-decorate
+git log "origin/${BASE_BRANCH}..HEAD" --oneline --no-decorate
 ```
 
 Review these commits to understand:
@@ -73,7 +80,7 @@ Review these commits to understand:
 ### 4. Review the diff
 
 ```bash
-git diff origin/main..HEAD --stat
+git diff "origin/${BASE_BRANCH}..HEAD" --stat
 ```
 
 This shows which files changed and helps identify the type of change.
@@ -82,10 +89,10 @@ This shows which files changed and helps identify the type of change.
 
 Before creating the PR, you need the following information. Check if it can be inferred from:
 - Commit messages
-- Branch name (e.g., `fix/issue-123`, `feature/new-login`)
+- Branch name (e.g., `fix/upload-timeout`, `feat/custom-shortcuts`)
 - Changed files and their content
 
-If any critical information is missing, use `ask_followup_question` to ask the user:
+If any critical information is missing, ask the user directly:
 
 ### Required Information
 
@@ -108,15 +115,15 @@ Before creating the PR, consider these best practices:
 
 ### Branch Management
 
-1. **Rebase on latest main** (if needed):
+1. **Rebase on latest base branch** (if needed):
    ```bash
    git fetch origin
-   git rebase origin/main
+   git rebase "origin/${BASE_BRANCH}"
    ```
 
 2. **Squash if appropriate**: If there are many small "WIP" commits, consider interactive rebase:
    ```bash
-   git rebase -i origin/main
+   git rebase -i "origin/${BASE_BRANCH}"
    ```
    Only suggest this if commits appear messy and the user is comfortable with rebasing.
 
@@ -134,7 +141,13 @@ git push origin HEAD --force-with-lease
 
 ## Create the Pull Request
 
-**IMPORTANT**: Read and use the PR template at `.github/pull_request_template.md` when it exists. The PR body format must **strictly match** the template structure. If the repo has no template, use the sections below.
+Use `CONTRIBUTING.md` (Pull Request 流程) as the source of truth for PR content. If `.github/pull_request_template.md` exists, follow that template exactly. Otherwise, use this structure:
+
+- **Summary** — what changed and why
+- **Related Issue** — only when a real issue is linked (e.g. `Closes #123`); omit entirely if none
+- **Type of Change** — check applicable boxes
+- **Test Procedure** — how you verified the change
+- **Pre-flight Checklist** — mark items that apply
 
 When filling out the PR body:
 - Include **Related Issue** only when a real issue number is known (e.g. `Closes #123`). **Do not** add a Related Issue section or `#XXXX` placeholder when there is no linked issue.
@@ -146,24 +159,18 @@ When filling out the PR body:
 
 **Use a temporary file for the PR body** to avoid shell escaping issues, newline problems, and other command-line flakiness:
 
-1. Write the PR body to a temporary file:
-   ```
-   /tmp/pr-body.md
-   ```
+1. Write the PR body to a temporary file (e.g. `$env:TEMP/pr-body.md` on Windows, `/tmp/pr-body.md` on macOS/Linux).
 
 2. Create the PR using the file:
    ```bash
-   gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main
+   gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base "$BASE_BRANCH"
    ```
 
-3. Clean up the temporary file:
-   ```bash
-   rm /tmp/pr-body.md
-   ```
+3. Clean up the temporary file after the PR is created.
 
 For draft PRs:
 ```bash
-gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main --draft
+gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base "$BASE_BRANCH" --draft
 ```
 
 **Why use a file?** Passing complex markdown with newlines, special characters, and checkboxes directly via `--body` is error-prone. The `--body-file` flag handles all content reliably.
@@ -182,7 +189,7 @@ After creating the PR:
 
 ### Common Issues
 
-1. **No commits ahead of main**: The branch has no changes to submit
+1. **No commits ahead of base branch**: The branch has no changes to submit
    - Ask if the user meant to work on a different branch
 
 2. **Branch not pushed**: Remote doesn't have the branch

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -89,15 +89,12 @@ If any critical information is missing, use `ask_followup_question` to ask the u
 
 ### Required Information
 
-1. **Related Issue Number**: Look for patterns like `#123`, `fixes #123`, or `closes #123` in commit messages
+1. **Related Issue Number** (optional): Look for patterns like `#123`, `fixes #123`, or `closes #123` in commit messages. If none is found, **omit the Related Issue section** from the PR body — do not use placeholders like `#XXXX`.
 2. **Description**: What problem does this solve? Why were these changes made?
 3. **Type of Change**: Bug fix, new feature, breaking change, refactor, cosmetic, documentation, or workflow
 4. **Test Procedure**: How was this tested? What could break?
 
-### Example clarifying question
-
-If the issue number is not found:
-> I couldn't find a related issue number in the commit messages or branch name. What GitHub issue does this PR address? (Enter the issue number, e.g., "123" or "N/A" for small fixes)
+Only ask about a related issue when the change clearly looks like it should close one (e.g. branch name `fix/issue-123`). For small or self-contained changes, skip the question and leave the section out.
 
 ## Git Best Practices
 
@@ -137,11 +134,11 @@ git push origin HEAD --force-with-lease
 
 ## Create the Pull Request
 
-**IMPORTANT**: Read and use the PR template at `.github/pull_request_template.md`. The PR body format must **strictly match** the template structure. Do not deviate from the template format.
+**IMPORTANT**: Read and use the PR template at `.github/pull_request_template.md` when it exists. The PR body format must **strictly match** the template structure. If the repo has no template, use the sections below.
 
-When filling out the template:
-- Replace `#XXXX` with the actual issue number, or keep as `#XXXX` if no issue exists (for small fixes)
-- Fill in all sections with relevant information gathered from commits and context
+When filling out the PR body:
+- Include **Related Issue** only when a real issue number is known (e.g. `Closes #123`). **Do not** add a Related Issue section or `#XXXX` placeholder when there is no linked issue.
+- Fill in all other sections with relevant information gathered from commits and context
 - Mark the appropriate "Type of Change" checkbox(es)
 - Complete the "Pre-flight Checklist" items that apply
 
@@ -205,7 +202,7 @@ Before finalizing, ensure:
 - [ ] Working directory is clean
 - [ ] All commits are pushed
 - [ ] Branch is up-to-date with base branch
-- [ ] Related issue number is identified, or placeholder is used
-- [ ] PR description follows the template exactly
+- [ ] Related Issue section included only when a real issue is linked (no `#XXXX` placeholder)
+- [ ] PR description follows the template or project conventions
 - [ ] Appropriate type of change is selected
 - [ ] Pre-flight checklist items are addressed

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -74,7 +74,7 @@ If the current branch is `main` or `master`, create a feature branch **before** 
 git branch --show-current
 ```
 
-**Branch naming** (see `AGENTS.md`, `CONTRIBUTING.md`):
+**Branch naming** — documented prefixes in `CONTRIBUTING.md`: `feat/`, `fix/`, `docs/`. For other commit types, use the commit type as prefix (e.g. `chore/`):
 
 ```
 <type>/<kebab-case-description>
@@ -85,7 +85,7 @@ git branch --show-current
 | `feat`      | `feat/`       | `feat/custom-shortcuts` |
 | `fix`       | `fix/`        | `fix/upload-timeout` |
 | `docs`      | `docs/`       | `docs/contributing-guide` |
-| other types | `<type>/`     | `chore/add-create-pr-skill` |
+| other types | `<type>/`     | `chore/add-create-pr-skill` (aligns with commit type; not listed in CONTRIBUTING.md) |
 
 Rules for `<kebab-case-description>`:
 
@@ -162,5 +162,5 @@ EOF
 ## Project Notes (doocs/md)
 
 - Commit messages must be in **English** (see `AGENTS.md`)
-- Branch naming: `feat/`, `fix/`, `docs/` (plus `<type>/` for other commit types); never commit on `main`/`master` — create a branch first (step 2)
+- Branch naming: `feat/`, `fix/`, `docs/` per `CONTRIBUTING.md`; for other commit types use `<type>/` prefix; never commit on `main`/`master` — create a branch first (step 2)
 - Pre-commit runs `eslint --fix` via lint-staged; if the hook modifies files, fix and create a new commit instead of amending

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit
-description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Creating a feature branch when on main/master before committing, (3) Generating conventional commit messages from diff, (4) Interactive commit with optional type/scope/description overrides, (5) Intelligent file staging for logical grouping'
 license: MIT
 allowed-tools: Bash
 ---
@@ -64,7 +64,43 @@ git diff
 git status --porcelain
 ```
 
-### 2. Stage Files (if needed)
+From the diff, determine the commit **type** and a short **description** (needed for branch naming in step 2).
+
+### 2. Ensure Feature Branch
+
+If the current branch is `main` or `master`, create a feature branch **before** staging or committing.
+
+```bash
+git branch --show-current
+```
+
+**Branch naming** (see `AGENTS.md`, `CONTRIBUTING.md`):
+
+```
+<type>/<kebab-case-description>
+```
+
+| Commit type | Branch prefix | Example |
+| ----------- | ------------- | ------- |
+| `feat`      | `feat/`       | `feat/custom-shortcuts` |
+| `fix`       | `fix/`        | `fix/upload-timeout` |
+| `docs`      | `docs/`       | `docs/contributing-guide` |
+| other types | `<type>/`     | `chore/add-create-pr-skill` |
+
+Rules for `<kebab-case-description>`:
+
+- Lowercase, words separated by hyphens
+- Derived from the commit description (drop scope, articles, punctuation)
+- Keep it short (2–5 words), e.g. `add create pr skill` → `add-create-pr-skill`
+
+```bash
+# Example: chore commit about adding create-pr skill
+git checkout -b chore/add-create-pr-skill
+```
+
+Do **not** commit directly on `main` or `master`. If the user explicitly asks to commit on the default branch, confirm before proceeding.
+
+### 3. Stage Files (if needed)
 
 If nothing is staged or you want to group changes differently:
 
@@ -82,7 +118,7 @@ git add -p
 
 **Never commit secrets** (.env, credentials.json, private keys).
 
-### 3. Generate Commit Message
+### 4. Generate Commit Message
 
 Analyze the diff to determine:
 
@@ -90,7 +126,7 @@ Analyze the diff to determine:
 - **Scope**: What area/module is affected?
 - **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
 
-### 4. Execute Commit
+### 5. Execute Commit
 
 ```bash
 # Single line
@@ -126,5 +162,5 @@ EOF
 ## Project Notes (doocs/md)
 
 - Commit messages must be in **English** (see `AGENTS.md`)
-- Branch naming: `feat/description`, `fix/description`
+- Branch naming: `feat/`, `fix/`, `docs/` (plus `<type>/` for other commit types); never commit on `main`/`master` — create a branch first (step 2)
 - Pre-commit runs `eslint --fix` via lint-staged; if the hook modifies files, fix and create a new commit instead of amending


### PR DESCRIPTION
## Summary

Add agent skills to streamline git commit and PR workflows for AI agents working in this repo.

- **`create-pr`**: New skill for creating GitHub pull requests via `gh` CLI, following project conventions.
- **`git-commit`**: When on `main`/`master`, create a feature branch before committing (branch naming aligned with `AGENTS.md` / `CONTRIBUTING.md`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic change
- [x] Documentation
- [x] Workflow / tooling

## Test Procedure

- Verified `git-commit` workflow: branch `chore/add-agent-skills` created from `main`, commit passed pre-commit hooks.
- Skills are markdown-only; no runtime code changes.

## Pre-flight Checklist

- [x] Changes are focused and scoped to agent skills
- [x] Commit message follows Conventional Commits (English)
- [x] Branch naming follows project convention (`chore/add-agent-skills`)
