### PR TITLE
refactor(core): replace any types in marked extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,11 @@ pnpm vscode package   # vsce 打包
 
 ```bash
 pnpm cli <cmd>        # 在 @doocs/md-cli 中执行命令
-pnpm mcp <cmd>        # 在 @md/mcp-server 中执行命令
+pnpm mcp <cmd>        # 在 @md/mcp-server 中执行命令（render_markdown 等 MCP 工具）
+pnpm mcp dev          # MCP Server 监听模式
 ```
+
+`@md/mcp-server` 通过 stdio 暴露 `render_markdown`、`list_themes`、`list_colors` 等工具，配置见 [packages/mcp-server/README.md](./packages/mcp-server/README.md) 与 `.vscode/mcp.json`。
 
 ## 架构
 
@@ -147,5 +150,6 @@ After clone, create the link once:
 | Skill        | When to use                                                                     |
 | ------------ | ------------------------------------------------------------------------------- |
 | `git-commit` | Commit changes with Conventional Commits (`/git-commit` or "commit my changes") |
+| `create-pr`  | Create a GitHub pull request (`/create-pr` or "open a PR")                      |
 
 Invoke manually: `/skill-name` in Cursor or Claude Code; OpenCode uses the `skill` tool.

--- a/packages/core/src/extensions/alert.ts
+++ b/packages/core/src/extensions/alert.ts
@@ -1,5 +1,7 @@
 import type { AlertOptions, AlertVariantItem } from '@md/shared/types'
 import type { MarkedExtension, Tokens } from 'marked'
+import type { AlertRendererFn, AlertRendererThis, AlertToken } from '../types/marked-tokens'
+import { asAlertRenderer } from '../types/marked-tokens'
 import { ucfirst } from '../utils'
 
 /**
@@ -24,7 +26,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
   }
 
   // 提取公共的渲染逻辑
-  function renderAlert(this: any, token: any) {
+  const renderAlert: AlertRendererFn = function (this: AlertRendererThis, token: AlertToken) {
     const { meta, tokens = [] } = token
     const text = this.parser.parse(tokens)
     // 新主题系统：使用 CSS 选择器而非内联样式
@@ -87,7 +89,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
       {
         name: `alert`,
         level: `block`,
-        renderer: renderAlert,
+        renderer: asAlertRenderer(renderAlert),
       },
       {
         name: `alertContainer`,
@@ -114,7 +116,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
             }
           }
         },
-        renderer: renderAlert,
+        renderer: asAlertRenderer(renderAlert),
       },
     ],
   }

--- a/packages/core/src/extensions/infographic.ts
+++ b/packages/core/src/extensions/infographic.ts
@@ -1,4 +1,6 @@
-import type { MarkedExtension } from 'marked'
+import type { MarkedExtension, Token } from 'marked'
+import type { InfographicToken } from '../types/marked-tokens'
+import { asDiagramToken, asTextTokenRenderer, isCodeToken } from '../types/marked-tokens'
 import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 
@@ -115,7 +117,7 @@ export function markedInfographic(options?: InfographicOptionsSource): MarkedExt
             }
           }
         },
-        renderer(token: any) {
+        renderer: asTextTokenRenderer((token: InfographicToken) => {
           const code = token.text
           const currentOptions = resolveOptions(options)
           const cacheKey = simpleHash(`${code}-${currentOptions?.themeMode || 'light'}`)
@@ -131,12 +133,12 @@ export function markedInfographic(options?: InfographicOptionsSource): MarkedExt
           renderInfographic(id, code, cacheKey, currentOptions)
 
           return `<!--infographic-start--><div id="${id}" class="${className}" style="width: 100%;">正在加载 Infographic...</div><!--infographic-end-->`
-        },
+        }),
       },
     ],
-    walkTokens(token: any) {
-      if (token.type === 'code' && token.lang === 'infographic') {
-        token.type = 'infographic'
+    walkTokens(token: Token) {
+      if (isCodeToken(token) && token.lang === 'infographic') {
+        asDiagramToken<InfographicToken>(token, 'infographic')
       }
     },
   }

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -1,5 +1,7 @@
 /// <reference path="../mathjax.d.ts" />
 import type { MarkedExtension } from 'marked'
+import type { KatexRenderFn, KatexToken } from '../types/marked-tokens'
+import { asKatexRenderer } from '../types/marked-tokens'
 import { escapeHtml } from '../utils/basicHelpers'
 
 export interface MarkedKatexOptions {
@@ -15,8 +17,8 @@ const blockRule = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
 const inlineLatexRule = /^\\\(([^\\]*(?:\\.[^\\]*)*?)\\\)/
 const blockLatexRule = /^\\\[([^\\]*(?:\\.[^\\]*)*?)\\\]/
 
-function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
-  return (token: any) => {
+function createRenderer(defaultDisplay: boolean, withStyle: boolean = true): KatexRenderFn {
+  return (token: KatexToken) => {
     const display = token.displayMode ?? defaultDisplay
 
     window.MathJax.texReset()
@@ -44,12 +46,12 @@ function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
   }
 }
 
-function inlineKatex(options: MarkedKatexOptions | undefined, renderer: any) {
+function inlineKatex(options: MarkedKatexOptions | undefined, renderer: KatexRenderFn) {
   const nonStandard = options && options.nonStandard
   const ruleReg = nonStandard ? inlineRuleNonStandard : inlineRule
   return {
     name: `inlineKatex`,
-    level: `inline`,
+    level: `inline` as const,
     start(src: string) {
       let index
       let indexSrc = src
@@ -82,14 +84,14 @@ function inlineKatex(options: MarkedKatexOptions | undefined, renderer: any) {
         }
       }
     },
-    renderer,
+    renderer: asKatexRenderer(renderer),
   }
 }
 
-function blockKatex(_options: MarkedKatexOptions | undefined, renderer: any) {
+function blockKatex(_options: MarkedKatexOptions | undefined, renderer: KatexRenderFn) {
   return {
     name: `blockKatex`,
-    level: `block`,
+    level: `block` as const,
     tokenizer(src: string) {
       const match = src.match(blockRule)
       if (match) {
@@ -101,14 +103,14 @@ function blockKatex(_options: MarkedKatexOptions | undefined, renderer: any) {
         }
       }
     },
-    renderer,
+    renderer: asKatexRenderer(renderer),
   }
 }
 
-function inlineLatexKatex(_options: MarkedKatexOptions | undefined, renderer: any) {
+function inlineLatexKatex(_options: MarkedKatexOptions | undefined, renderer: KatexRenderFn) {
   return {
     name: `inlineLatexKatex`,
-    level: `inline`,
+    level: `inline` as const,
     start(src: string) {
       const index = src.indexOf(`\\(`)
       return index !== -1 ? index : undefined
@@ -124,14 +126,14 @@ function inlineLatexKatex(_options: MarkedKatexOptions | undefined, renderer: an
         }
       }
     },
-    renderer,
+    renderer: asKatexRenderer(renderer),
   }
 }
 
-function blockLatexKatex(_options: MarkedKatexOptions | undefined, renderer: any) {
+function blockLatexKatex(_options: MarkedKatexOptions | undefined, renderer: KatexRenderFn) {
   return {
     name: `blockLatexKatex`,
-    level: `block`,
+    level: `block` as const,
     start(src: string) {
       const index = src.indexOf(`\\[`)
       return index !== -1 ? index : undefined
@@ -147,7 +149,7 @@ function blockLatexKatex(_options: MarkedKatexOptions | undefined, renderer: any
         }
       }
     },
-    renderer,
+    renderer: asKatexRenderer(renderer),
   }
 }
 

--- a/packages/core/src/extensions/markup.ts
+++ b/packages/core/src/extensions/markup.ts
@@ -1,4 +1,6 @@
 import type { MarkedExtension } from 'marked'
+import type { MarkupHighlightToken, MarkupUnderlineToken, MarkupWavylineToken } from '../types/marked-tokens'
+import { asTextTokenRenderer } from '../types/marked-tokens'
 
 /**
  * 扩展标记语法：
@@ -27,10 +29,9 @@ export function markedMarkup(): MarkedExtension {
             }
           }
         },
-        renderer(token: any) {
-          // 新主题系统：使用 class 而非内联样式
+        renderer: asTextTokenRenderer((token: MarkupHighlightToken) => {
           return `<span class="markup-highlight">${token.text}</span>`
-        },
+        }),
       },
 
       // 下划线语法 ++文本++
@@ -51,10 +52,9 @@ export function markedMarkup(): MarkedExtension {
             }
           }
         },
-        renderer(token: any) {
-          // 新主题系统：使用 class 而非内联样式
+        renderer: asTextTokenRenderer((token: MarkupUnderlineToken) => {
           return `<span class="markup-underline">${token.text}</span>`
-        },
+        }),
       },
 
       // 波浪线语法 ~文本~
@@ -62,11 +62,9 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_wavyline`,
         level: `inline`,
         start(src: string) {
-          // 查找单个 ~ 但不是连续的 ~~
           return src.match(/~(?!~)/)?.index
         },
         tokenizer(src: string) {
-          // 匹配 ~文本~ 但确保不是 ~~文本~~
           const rule = /^~([^~\n]+)~(?!~)/
           const match = rule.exec(src)
           if (match) {
@@ -77,10 +75,9 @@ export function markedMarkup(): MarkedExtension {
             }
           }
         },
-        renderer(token: any) {
-          // 新主题系统：使用 class 而非内联样式
+        renderer: asTextTokenRenderer((token: MarkupWavylineToken) => {
           return `<span class="markup-wavyline">${token.text}</span>`
-        },
+        }),
       },
     ],
   }

--- a/packages/core/src/extensions/mermaid.ts
+++ b/packages/core/src/extensions/mermaid.ts
@@ -1,4 +1,6 @@
-import type { MarkedExtension } from 'marked'
+import type { MarkedExtension, Token } from 'marked'
+import type { MermaidToken } from '../types/marked-tokens'
+import { asDiagramToken, asTextTokenRenderer, isCodeToken } from '../types/marked-tokens'
 import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 
@@ -69,7 +71,7 @@ export function markedMermaid(): MarkedExtension {
             }
           }
         },
-        renderer(token: any) {
+        renderer: asTextTokenRenderer((token: MermaidToken) => {
           const code = token.text
           const cacheKey = simpleHash(code)
 
@@ -84,12 +86,12 @@ export function markedMermaid(): MarkedExtension {
           renderMermaid(id, code, cacheKey)
 
           return `<!--mermaid-start--><div id="${id}" class="${className}">正在加载 Mermaid...</div><!--mermaid-end-->`
-        },
+        }),
       },
     ],
-    walkTokens(token: any) {
-      if (token.type === 'code' && token.lang === 'mermaid') {
-        token.type = 'mermaid'
+    walkTokens(token: Token) {
+      if (isCodeToken(token) && token.lang === 'mermaid') {
+        asDiagramToken<MermaidToken>(token, 'mermaid')
       }
     },
   }

--- a/packages/core/src/extensions/plantuml.ts
+++ b/packages/core/src/extensions/plantuml.ts
@@ -1,5 +1,7 @@
-import type { MarkedExtension, Tokens } from 'marked'
+import type { MarkedExtension, Token } from 'marked'
+import type { PlantUMLToken } from '../types/marked-tokens'
 import { deflateSync } from 'fflate'
+import { asDiagramToken, asTextTokenRenderer, isCodeToken } from '../types/marked-tokens'
 import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 
@@ -153,7 +155,7 @@ function generatePlantUMLUrl(code: string, options: Required<PlantUMLOptions>): 
 /**
  * 渲染 PlantUML 图表
  */
-function renderPlantUMLDiagram(token: Tokens.Code, options: Required<PlantUMLOptions>, cacheKey: string): string {
+function renderPlantUMLDiagram(token: Pick<PlantUMLToken, 'text'>, options: Required<PlantUMLOptions>, cacheKey: string): string {
   const { text: code } = token
 
   // 检查代码是否包含 PlantUML 标记
@@ -280,7 +282,7 @@ export function markedPlantUML(options: PlantUMLOptions = {}): MarkedExtension {
             }
           }
         },
-        renderer(token: any) {
+        renderer: asTextTokenRenderer((token: PlantUMLToken) => {
           const cacheKey = simpleHash(token.text)
 
           // 有缓存直接返回
@@ -290,13 +292,12 @@ export function markedPlantUML(options: PlantUMLOptions = {}): MarkedExtension {
           }
 
           return renderPlantUMLDiagram(token, resolvedOptions, cacheKey)
-        },
+        }),
       },
     ],
-    walkTokens(token: any) {
-      // 处理现有的代码块，如果语言是 plantuml 就转换类型
-      if (token.type === `code` && token.lang === `plantuml`) {
-        token.type = `plantuml`
+    walkTokens(token: Token) {
+      if (isCodeToken(token) && token.lang === `plantuml`) {
+        asDiagramToken<PlantUMLToken>(token, `plantuml`)
       }
     },
   }

--- a/packages/core/src/extensions/ruby.ts
+++ b/packages/core/src/extensions/ruby.ts
@@ -1,4 +1,6 @@
 import type { MarkedExtension } from 'marked'
+import type { RubyToken } from '../types/marked-tokens'
+import { asTextTokenRenderer } from '../types/marked-tokens'
 
 /**
  * 注音/拼音标注扩展
@@ -54,7 +56,7 @@ export function markedRuby(): MarkedExtension {
 
           return undefined
         },
-        renderer(token: any) {
+        renderer: asTextTokenRenderer((token: RubyToken) => {
           const { text, ruby, format } = token
 
           // 检查是否有分隔符
@@ -118,7 +120,7 @@ export function markedRuby(): MarkedExtension {
           }
 
           return `<ruby data-text="${text}" data-ruby="${ruby}" data-format="${format}">${text}<rp>(</rp><rt>${ruby}</rt><rp>)</rp></ruby>`
-        },
+        }),
       },
     ],
   }

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -1,4 +1,5 @@
 import type { IOpts, RendererAPI } from '@md/shared/types'
+import type { FrontMatterData } from '@md/shared/types/front-matter'
 import type { ReadTimeResults } from '@md/shared/utils/readingTime'
 import type { RendererObject, Tokens } from 'marked'
 import readingTime from '@md/shared/utils/readingTime'
@@ -152,7 +153,7 @@ function renderDiffCode(text: string, baseLang: string): string {
 }
 
 interface ParseResult {
-  yamlData: Record<string, any>
+  yamlData: FrontMatterData
   markdownContent: string
   readingTime: ReadTimeResults
 }
@@ -160,13 +161,13 @@ interface ParseResult {
 function parseFrontMatterAndContent(markdownText: string): ParseResult {
   try {
     const parsed = frontMatter(markdownText)
-    const yamlData = parsed.attributes
+    const yamlData = parsed.attributes as FrontMatterData
     const markdownContent = parsed.body
 
     const readingTimeResult = readingTime(markdownContent)
 
     return {
-      yamlData: yamlData as Record<string, any>,
+      yamlData,
       markdownContent,
       readingTime: readingTimeResult,
     }

--- a/packages/core/src/types/marked-tokens.ts
+++ b/packages/core/src/types/marked-tokens.ts
@@ -1,0 +1,96 @@
+import type { RendererExtensionFunction, RendererThis, Token, Tokens } from 'marked'
+
+/** Base shape shared by custom block/inline extension tokens. */
+export interface TextToken {
+  type: string
+  raw: string
+  text: string
+}
+
+export interface MermaidToken extends TextToken {
+  type: 'mermaid'
+}
+
+export interface InfographicToken extends TextToken {
+  type: 'infographic'
+}
+
+export interface PlantUMLToken extends TextToken {
+  type: 'plantuml'
+}
+
+export interface MarkupHighlightToken extends TextToken {
+  type: 'markup_highlight'
+}
+
+export interface MarkupUnderlineToken extends TextToken {
+  type: 'markup_underline'
+}
+
+export interface MarkupWavylineToken extends TextToken {
+  type: 'markup_wavyline'
+}
+
+export interface RubyToken extends TextToken {
+  type: 'ruby'
+  ruby: string
+  format: 'basic' | 'basic-hat'
+}
+
+export interface KatexToken extends TextToken {
+  type: 'inlineKatex' | 'blockKatex' | 'inlineLatexKatex' | 'blockLatexKatex'
+  displayMode?: boolean
+}
+
+export type KatexRenderFn = (token: KatexToken) => string
+
+export interface AlertMeta {
+  className: string
+  variant: string
+  icon: string
+  title: string
+  titleClassName: string
+  fromContainer: boolean
+}
+
+export interface AlertToken extends Tokens.Generic {
+  type: 'alert'
+  text: string
+  tokens?: Token[]
+  meta: AlertMeta
+}
+
+export type AlertRendererThis = RendererThis
+export type AlertRendererFn = (this: AlertRendererThis, token: AlertToken) => string
+
+/** Adapt a typed renderer to marked's Tokens.Generic signature. */
+export function asTextTokenRenderer<T extends TextToken>(
+  fn: (token: T) => string,
+): RendererExtensionFunction {
+  return (token: Tokens.Generic) => fn(token as T)
+}
+
+/** Adapt a typed KaTeX renderer to marked's Tokens.Generic signature. */
+export function asKatexRenderer(fn: KatexRenderFn): RendererExtensionFunction {
+  return (token: Tokens.Generic) => fn(token as KatexToken)
+}
+
+/** Adapt a typed alert renderer (uses `this.parser`) to marked's signature. */
+export function asAlertRenderer(fn: AlertRendererFn): RendererExtensionFunction {
+  return function (this: AlertRendererThis, token: Tokens.Generic) {
+    return fn.call(this, token as AlertToken)
+  }
+}
+
+/** Narrow a marked token to a fenced code block. */
+export function isCodeToken(token: Token): token is Tokens.Code {
+  return token.type === 'code'
+}
+
+/** Re-type a code block token for diagram extensions (mermaid, plantuml, infographic). */
+export function asDiagramToken<T extends TextToken>(
+  token: Tokens.Code,
+  type: T['type'],
+): T {
+  return Object.assign(token, { type }) as unknown as T
+}

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -1,4 +1,4 @@
-import type { LanguageFn } from 'highlight.js'
+import type { HLJSApi, LanguageFn } from 'highlight.js'
 import bash from 'highlight.js/lib/languages/bash'
 import c from 'highlight.js/lib/languages/c'
 import cpp from 'highlight.js/lib/languages/cpp'
@@ -94,7 +94,7 @@ function grammarUrlFor(language: string): string {
  * @param language 语言名称
  * @param hljs highlight.js 实例
  */
-export async function loadAndRegisterLanguage(language: string, hljs: any): Promise<void> {
+export async function loadAndRegisterLanguage(language: string, hljs: HLJSApi): Promise<void> {
   // 如果已经注册，直接返回
   if (hljs.getLanguage(language)) {
     return
@@ -212,7 +212,7 @@ function splitHighlightedHtmlByLines(html: string): string[] {
  * @param showLineNumber 是否显示行号
  * @returns 格式化后的 HTML
  */
-export function highlightAndFormatCode(text: string, language: string, hljs: any, showLineNumber: boolean): string {
+export function highlightAndFormatCode(text: string, language: string, hljs: HLJSApi, showLineNumber: boolean): string {
   let highlighted = ``
 
   if (showLineNumber) {
@@ -247,7 +247,7 @@ export function highlightAndFormatCode(text: string, language: string, hljs: any
   return highlighted
 }
 
-export function highlightCodeBlock(codeBlock: Element, language: string, hljs: any): void {
+export function highlightCodeBlock(codeBlock: Element, language: string, hljs: HLJSApi): void {
   const rawCode = codeBlock.getAttribute(`data-raw-code`)
   const showLineNumber = codeBlock.getAttribute(`data-show-line-number`) === `true`
 
@@ -270,7 +270,7 @@ export function highlightCodeBlock(codeBlock: Element, language: string, hljs: a
  * @param hljs highlight.js 实例
  * @param container 容器元素（可选，默认为 document）
  */
-export function highlightPendingBlocks(hljs: any, container: Document | Element = document): void {
+export function highlightPendingBlocks(hljs: HLJSApi, container: Document | Element = document): void {
   const pendingBlocks = container.querySelectorAll(`code[data-language-pending]`)
 
   pendingBlocks.forEach((codeBlock) => {

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,8 +6,8 @@ Exposes the `doocs/md` markdown rendering engine and AI service configuration to
 
 ## Prerequisites
 
-- **Node.js** ≥ 18
-- **pnpm** ≥ 9 (for monorepo workspace)
+- **Node.js** ≥ 22.22.2（与 monorepo 根目录 `.nvmrc` 一致）
+- **pnpm** ≥ 9（monorepo workspace）
 - Clone the monorepo and install dependencies:
 
 ```bash
@@ -26,10 +26,12 @@ Convert Markdown text to styled HTML using the full doocs/md rendering pipeline.
 | ------------------ | ---------------------------------- | ----------- | ----------------------------------------------- |
 | `markdown`         | `string`                           | —           | Markdown source text                            |
 | `theme`            | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)               |
+| `primaryColor`     | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)        |
 | `isMacCodeBlock`   | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar |
 | `isShowLineNumber` | `boolean`                          | `false`     | Show line numbers in code blocks                |
 | `citeStatus`       | `boolean`                          | `false`     | Convert links to footnote-style citations       |
 | `countStatus`      | `boolean`                          | `false`     | Prepend a reading-time estimate                 |
+| `themeMode`        | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions               |
 
 Returns `{ html, frontMatter, readingTime: { words, minutes } }`.
 
@@ -38,6 +40,7 @@ Returns `{ html, frontMatter, readingTime: { words, minutes } }`.
 | Tool                   | Description                                                                       |
 | ---------------------- | --------------------------------------------------------------------------------- |
 | `list_themes`          | List all available visual themes with labels and authors                          |
+| `list_colors`          | List all available primary accent colors                                          |
 | `list_ai_services`     | List all built-in AI service providers with endpoints and models                  |
 | `explain_extensions`   | Describe every Markdown extension beyond CommonMark (KaTeX, Mermaid, PlantUML, …) |
 | `get_renderer_options` | Describe all renderer configuration options                                       |

--- a/packages/shared/src/types/front-matter.ts
+++ b/packages/shared/src/types/front-matter.ts
@@ -1,0 +1,2 @@
+/** YAML front-matter attributes parsed from markdown source. */
+export type FrontMatterData = Record<string, unknown>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './ai-services-types'
 export * from './common'
 export * from './component'
+export * from './front-matter'
 export * from './renderer-types'
 export * from './template'

--- a/packages/shared/src/types/renderer-types.ts
+++ b/packages/shared/src/types/renderer-types.ts
@@ -1,5 +1,6 @@
 import type { ReadTimeResults } from '../utils/readingTime'
 import type { IOpts } from './common'
+import type { FrontMatterData } from './front-matter'
 
 export interface RendererAPI {
   /* —— 生命周期 —— */
@@ -9,7 +10,7 @@ export interface RendererAPI {
 
   /* —— Markdown 处理 —— */
   parseFrontMatterAndContent: (markdown: string) => {
-    yamlData: Record<string, any>
+    yamlData: FrontMatterData
     markdownContent: string
     readingTime: ReadTimeResults
   }


### PR DESCRIPTION
﻿## Summary

- Replace `any` usage in `@md/core` marked extensions with typed custom tokens (`marked-tokens.ts`)
- Add renderer adapter helpers (`asTextTokenRenderer`, `asKatexRenderer`, `asAlertRenderer`) so strict `vue-tsc` build passes with marked's `Tokens.Generic` API
- Introduce `FrontMatterData` (`Record<string, unknown>`) for YAML front-matter parsing
- Type highlight.js helpers with `HLJSApi`
- Sync `AGENTS.md` (create-pr skill, MCP commands) and `packages/mcp-server/README.md` with current implementation

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Cosmetic
- [x] Documentation
- [ ] Workflow

## Test Procedure

- [x] `pnpm run type-check`
- [x] `pnpm web build` (includes `vue-tsc --build`)

## Pre-flight Checklist

- [x] Changes are focused on type safety and docs sync
- [x] No secrets or credentials included
- [x] Build and type-check pass locally
- [x] Public type surface updated (`FrontMatterData`, `RendererAPI.yamlData`)
