### PR TITLE
fix(vscode): defer renderer load and enable self-contained vsix packaging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "cwd": "${workspaceFolder}/apps/vscode",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/apps/vscode", "--enable-proposed-api=vscode.vscode-js-debug"],
       "runtimeExecutable": "${execPath}",
-      "outFiles": ["${workspaceFolder}/apps/vscode/dist/*.js"],
+      "outFiles": ["${workspaceFolder}/apps/vscode/dist/**/*.js"],
       "preLaunchTask": "compile extension"
     }
   ]

--- a/apps/vscode/.gitignore
+++ b/apps/vscode/.gitignore
@@ -1,6 +1,7 @@
 out
 dist
 node_modules
+runtime/node_modules
 .vscode-test/
 *.vsix
 src/**/*.js.map

--- a/apps/vscode/.vscode/launch.json
+++ b/apps/vscode/.vscode/launch.json
@@ -9,9 +9,9 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/dist/*.js"
+        "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "npm: watch"
+      "preLaunchTask": "npm: compile"
     }
   ]
 }

--- a/apps/vscode/.vscode/launch.json
+++ b/apps/vscode/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
+}

--- a/apps/vscode/.vscode/tasks.json
+++ b/apps/vscode/.vscode/tasks.json
@@ -3,6 +3,12 @@
   "tasks": [
     {
       "type": "npm",
+      "script": "compile",
+      "problemMatcher": "$tsc",
+      "group": "build"
+    },
+    {
+      "type": "npm",
       "script": "watch",
       "problemMatcher": "$tsc-watch",
       "isBackground": true,

--- a/apps/vscode/.vscode/tasks.json
+++ b/apps/vscode/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "silent"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": "$tsc",
+      "group": "build"
+    }
+  ]
+}

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -2,10 +2,14 @@
 .vscode-test/**
 out/**
 node_modules/**
+runtime/package.json
+runtime/package-lock.json
 src/**
+scripts/**
 .gitignore
 .yarnrc
 webpack.config.js
+webpack.config.mjs
 vsc-extension-quickstart.md
 **/tsconfig.json
 **/eslint.config.mjs

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -1,46 +1,77 @@
 # doocs-md VS Code Extension
 
-为 doocs-md 提供的 VS Code 扩展，支持在编辑器内实时预览 Markdown 渲染效果。
+为 doocs-md 提供的 VS Code 扩展，支持在编辑器内实时预览 Markdown 渲染为微信图文的效果。
 
 ## 功能特性
 
-- 侧边栏 Markdown 预览视图
+- 侧边栏预览配置（字号、字体、主题、主题色）
 - 支持微信图文特有的样式渲染
-- 可自定义字体
-- 支持自定义字体大小
-- 支持自定义文本主题颜色
-- 支持自定义主题样式
-- 显示字数统计状态
-- 支持 Mac 风格代码块切换
+- 字数统计开关（`countStatus`）
+- Mac 风格代码块开关（`isMacCodeBlock`）
+- 微信外链转引用开关（`citeStatus`）
+- 编辑器标题栏一键打开预览面板
 
 ## 使用方法
 
-1. 安装扩展后，打开 Markdown 文件
-2. 点击活动栏中的 doocs-md 的 icon 图标
-3. 在侧边栏查看实时渲染效果
+1. 在仓库根目录执行 `pnpm install`
+2. 打开任意 `.md` 文件
+3. 点击活动栏 **Markdown Preview** 图标，在侧边栏调整渲染选项
+4. 点击编辑器标题栏预览按钮，或运行命令 `Markdown Preview: Open Markdown Preview`
 
 ## 命令
 
-- `markdown.preview`: 打开 Markdown 预览
-- `markdown.setFontFamily`: 设置预览字体
-- `markdown.toggleCountStatus`: 切换字数统计显示
-- `markdown.toggleMacCodeBlock`: 切换 Mac 风格代码块
+| 命令                          | 说明                   |
+| ----------------------------- | ---------------------- |
+| `markdown.preview`            | 打开 Markdown 预览面板 |
+| `markdown.setFontFamily`      | 设置预览字体           |
+| `markdown.setFontSize`        | 设置预览字号           |
+| `markdown.setTheme`           | 设置预览主题           |
+| `markdown.setPrimaryColor`    | 设置主题色             |
+| `markdown.toggleCountStatus`  | 切换字数统计显示       |
+| `markdown.toggleMacCodeBlock` | 切换 Mac 风格代码块    |
+| `markdown.toggleCiteStatus`   | 切换微信外链转引用     |
 
 ## 与主项目的关系
 
-本扩展是[doocs-md](https://github.com/doocs/md)的配套工具，使用相同的渲染方式，确保预览效果与最终微信图文完全一致。
+本扩展是 [doocs-md](https://github.com/doocs/md) 的配套工具，使用 `@md/core` 渲染引擎，确保预览效果与 Web 版微信图文一致。
 
 ## 开发
 
 - **Node.js ≥ 22**
+- 在 monorepo 根目录安装依赖：`pnpm install`
 
 ```sh
-# 安装依赖
-npm install
-
-# 开发模式
-npm run watch
-
-# 打包
-npm run build
+# 在仓库根目录
+pnpm vscode watch      # webpack 监听编译
+pnpm vscode build      # 生产构建
+pnpm vscode test       # 渲染路径 smoke test
+pnpm vscode package    # 打包 .vsix
 ```
+
+### F5 调试
+
+**推荐打开 monorepo 根目录 `D:\repo\md`**（根目录 `.vscode/launch.json` 已配置好）。
+
+1. `pnpm install` && `pnpm vscode build`（首次或改 webpack 配置后）
+2. 按 `F5` 选择 **Run Extension**
+3. 在弹出的 **`[Extension Development Host]` 新窗口** 中打开 `.md` 文件
+4. 运行 `Open Markdown Preview` 或点击标题栏预览按钮
+
+改代码时另开终端跑 `pnpm vscode watch`，改完后在 Extension Development Host 窗口 `Developer: Reload Window`。
+
+### 常见问题
+
+**`command 'markdown.preview' not found`** 或 **`no data provider registered`**
+
+- 在 **Extension Development Host 新窗口** 操作，不是原调试窗口
+- 先 **关闭所有正在调试的扩展窗口**，再重新 `pnpm vscode build`（避免 `extension.js` 被占用）
+- F5 后运行 `pnpm vscode test` 确认构建与预览路径正常
+- 若看不到 `activate` 日志，说明扩展加载失败，把完整错误贴出来
+
+### 手动验证清单
+
+- [ ] 侧边栏「Preview」树视图正常加载（无 data provider 报错）
+- [ ] 切换主题/字号后预览实时更新
+- [ ] 开启「微信外链转引用」后，外链显示 `[n]` 上标
+- [ ] 开启「计数状态」后预览顶部显示阅读统计
+- [ ] 开启「Mac 代码块」后代码块样式变化

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "doocs-md",
   "displayName": "doocs-md",
   "version": "0.0.1",
-  "description": "",
+  "description": "Preview WeChat-formatted Markdown with doocs/md renderer",
   "repository": {
     "type": "git",
     "url": "https://github.com/doocs/md"
@@ -13,9 +13,8 @@
   ],
   "main": "./dist/extension.js",
   "engines": {
-    "vscode": "^1.91.0"
+    "vscode": "^1.120.0"
   },
-  "activationEvents": [],
   "contributes": {
     "viewsContainers": {
       "activitybar": [
@@ -43,6 +42,21 @@
           "light": "./public/icon-256-gray.png",
           "dark": "./public/icon-256-gray.png"
         }
+      },
+      {
+        "command": "markdown.setFontSize",
+        "title": "Set Font Size",
+        "category": "Markdown Preview"
+      },
+      {
+        "command": "markdown.setTheme",
+        "title": "Set Theme",
+        "category": "Markdown Preview"
+      },
+      {
+        "command": "markdown.setPrimaryColor",
+        "title": "Set Primary Color",
+        "category": "Markdown Preview"
       },
       {
         "command": "markdown.setFontFamily",
@@ -77,23 +91,28 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run build",
-    "compile": "webpack",
+    "compile": "webpack && node scripts/copy-runtime-deps.mjs",
     "watch": "webpack --watch",
-    "build": "webpack --mode production --devtool hidden-source-map",
-    "package": "vsce package --no-dependencies --allow-package-secrets github"
+    "build": "webpack --mode production --devtool hidden-source-map && node scripts/copy-runtime-deps.mjs",
+    "package": "vsce package --no-dependencies --allow-package-secrets github",
+    "test": "npm run build && node --import tsx/esm scripts/smoke-test.mjs && node scripts/verify-preview.mjs && node scripts/verify-activate.mjs && node scripts/verify-vsix-deps.mjs"
   },
   "dependencies": {
     "@md/core": "workspace:*",
     "@md/shared": "workspace:*",
     "@types/webpack": "^5.28.5",
     "isomorphic-dompurify": "^3.16.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "ts-loader": "^9.6.0",
     "tsconfig-paths-webpack-plugin": "^4.2.0"
   },
   "devDependencies": {
+    "@types/node": "^25.9.2",
     "@types/vscode": "^1.120.0",
     "@vscode/vsce": "^3.9.2",
+    "tsx": "^4.22.4",
+    "webpack": "^5.107.2",
     "webpack-cli": "^7.0.3"
   }
 }

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -92,7 +92,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build",
     "compile": "webpack && node scripts/copy-runtime-deps.mjs",
-    "watch": "webpack --watch",
+    "watch": "node scripts/copy-runtime-deps.mjs && webpack --watch",
     "build": "webpack --mode production --devtool hidden-source-map && node scripts/copy-runtime-deps.mjs",
     "package": "vsce package --no-dependencies --allow-package-secrets github",
     "test": "npm run build && node --import tsx/esm scripts/smoke-test.mjs && node scripts/verify-preview.mjs && node scripts/verify-activate.mjs && node scripts/verify-vsix-deps.mjs"
@@ -102,7 +102,6 @@
     "@md/shared": "workspace:*",
     "@types/webpack": "^5.28.5",
     "isomorphic-dompurify": "^3.16.0",
-    "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "ts-loader": "^9.6.0",
     "tsconfig-paths-webpack-plugin": "^4.2.0"

--- a/apps/vscode/runtime/package.json
+++ b/apps/vscode/runtime/package.json
@@ -3,6 +3,6 @@
   "type": "commonjs",
   "private": true,
   "dependencies": {
-    "isomorphic-dompurify": "^3.16.0"
+    "isomorphic-dompurify": "3.16.0"
   }
 }

--- a/apps/vscode/runtime/package.json
+++ b/apps/vscode/runtime/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "doocs-md-runtime",
+  "type": "commonjs",
+  "private": true,
+  "dependencies": {
+    "isomorphic-dompurify": "^3.16.0"
+  }
+}

--- a/apps/vscode/scripts/copy-runtime-deps.mjs
+++ b/apps/vscode/scripts/copy-runtime-deps.mjs
@@ -1,0 +1,53 @@
+/**
+ * Install production runtime deps into runtime/ for self-contained vsix packaging.
+ * Webpack externals resolve isomorphic-dompurify from this folder.
+ */
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const vscodeRoot = path.resolve(__dirname, `..`)
+const runtimeDir = path.join(vscodeRoot, `runtime`)
+const runtimePkg = path.join(runtimeDir, `package.json`)
+const lockFile = path.join(runtimeDir, `package-lock.json`)
+
+const runtimePackage = {
+  name: `doocs-md-runtime`,
+  private: true,
+  type: `commonjs`,
+  dependencies: {
+    'isomorphic-dompurify': `^3.16.0`,
+  },
+}
+
+fs.mkdirSync(runtimeDir, { recursive: true })
+fs.writeFileSync(runtimePkg, `${JSON.stringify(runtimePackage, null, 2)}\n`)
+
+const needsInstall = !fs.existsSync(
+  path.join(runtimeDir, `node_modules`, `isomorphic-dompurify`, `package.json`),
+)
+
+if (needsInstall || process.env.FORCE_RUNTIME_INSTALL === `1`) {
+  if (fs.existsSync(lockFile))
+    fs.rmSync(lockFile)
+  execSync(`npm install --omit=dev --no-package-lock`, {
+    cwd: runtimeDir,
+    stdio: `inherit`,
+  })
+}
+
+const dompurifyPkg = path.join(runtimeDir, `node_modules`, `isomorphic-dompurify`, `package.json`)
+const jsdomPkg = path.join(runtimeDir, `node_modules`, `jsdom`, `package.json`)
+
+if (!fs.existsSync(dompurifyPkg)) {
+  throw new Error(`runtime install failed: isomorphic-dompurify missing`)
+}
+
+if (!fs.existsSync(jsdomPkg)) {
+  throw new Error(`runtime install failed: jsdom missing (required by isomorphic-dompurify)`)
+}
+
+console.log(`✓ runtime deps ready at ${path.join(runtimeDir, `node_modules`)}`)

--- a/apps/vscode/scripts/copy-runtime-deps.mjs
+++ b/apps/vscode/scripts/copy-runtime-deps.mjs
@@ -1,9 +1,10 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
 /**
  * Install production runtime deps into runtime/ for self-contained vsix packaging.
  * Webpack externals resolve isomorphic-dompurify from this folder.
  */
-import { execSync } from 'node:child_process'
-import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -14,25 +15,46 @@ const runtimeDir = path.join(vscodeRoot, `runtime`)
 const runtimePkg = path.join(runtimeDir, `package.json`)
 const lockFile = path.join(runtimeDir, `package-lock.json`)
 
+function resolveDompurifyVersion() {
+  const requireFromVscode = createRequire(path.join(vscodeRoot, `package.json`))
+  let dir = path.dirname(requireFromVscode.resolve(`isomorphic-dompurify`))
+
+  for (let depth = 0; depth < 6; depth++) {
+    const candidate = path.join(dir, `package.json`)
+    if (fs.existsSync(candidate)) {
+      const pkg = JSON.parse(fs.readFileSync(candidate, `utf8`))
+      if (pkg.name === `isomorphic-dompurify`)
+        return pkg.version
+    }
+    dir = path.dirname(dir)
+  }
+
+  throw new Error(`could not resolve isomorphic-dompurify version from workspace install`)
+}
+
+const dompurifyVersion = resolveDompurifyVersion()
+
 const runtimePackage = {
   name: `doocs-md-runtime`,
   private: true,
   type: `commonjs`,
   dependencies: {
-    'isomorphic-dompurify': `^3.16.0`,
+    'isomorphic-dompurify': dompurifyVersion,
   },
 }
 
 fs.mkdirSync(runtimeDir, { recursive: true })
 fs.writeFileSync(runtimePkg, `${JSON.stringify(runtimePackage, null, 2)}\n`)
 
-const needsInstall = !fs.existsSync(
-  path.join(runtimeDir, `node_modules`, `isomorphic-dompurify`, `package.json`),
-)
+const installedDompurifyPkg = path.join(runtimeDir, `node_modules`, `isomorphic-dompurify`, `package.json`)
+const needsInstall = !fs.existsSync(installedDompurifyPkg)
+  || JSON.parse(fs.readFileSync(installedDompurifyPkg, `utf8`)).version !== dompurifyVersion
 
 if (needsInstall || process.env.FORCE_RUNTIME_INSTALL === `1`) {
   if (fs.existsSync(lockFile))
     fs.rmSync(lockFile)
+  if (fs.existsSync(path.join(runtimeDir, `node_modules`)))
+    fs.rmSync(path.join(runtimeDir, `node_modules`), { recursive: true })
   execSync(`npm install --omit=dev --no-package-lock`, {
     cwd: runtimeDir,
     stdio: `inherit`,
@@ -46,8 +68,15 @@ if (!fs.existsSync(dompurifyPkg)) {
   throw new Error(`runtime install failed: isomorphic-dompurify missing`)
 }
 
+const installedVersion = JSON.parse(fs.readFileSync(dompurifyPkg, `utf8`)).version
+if (installedVersion !== dompurifyVersion) {
+  throw new Error(
+    `runtime isomorphic-dompurify version mismatch: expected ${dompurifyVersion}, got ${installedVersion}`,
+  )
+}
+
 if (!fs.existsSync(jsdomPkg)) {
   throw new Error(`runtime install failed: jsdom missing (required by isomorphic-dompurify)`)
 }
 
-console.log(`✓ runtime deps ready at ${path.join(runtimeDir, `node_modules`)}`)
+console.log(`✓ runtime deps ready at ${path.join(runtimeDir, `node_modules`)} (isomorphic-dompurify@${dompurifyVersion})`)

--- a/apps/vscode/scripts/smoke-test.mjs
+++ b/apps/vscode/scripts/smoke-test.mjs
@@ -1,0 +1,53 @@
+/**
+ * Smoke test for the VSCode extension rendering path.
+ * Verifies initRenderer options used by the extension produce expected HTML.
+ *
+ * Run from repo root: pnpm vscode test
+ */
+import { initRenderer } from '@md/core/renderer'
+import { modifyHtmlContent } from '@md/core/utils'
+
+const markdown = `# Hello
+
+Visit [Example Site](https://example.com) for details.
+
+\`\`\`js
+console.log('ok')
+\`\`\`
+`
+
+function assert(condition, message) {
+  if (!condition)
+    throw new Error(message)
+}
+
+function runCase(name, opts, checks) {
+  const renderer = initRenderer({ legend: `none`, ...opts })
+  const html = modifyHtmlContent(markdown, renderer)
+
+  for (const [label, fn] of checks) {
+    assert(fn(html), `${name}: ${label}`)
+  }
+
+  console.log(`✓ ${name}`)
+}
+
+runCase(`default renderer`, {}, [
+  [`contains heading`, html => html.includes(`Hello`)],
+  [`contains external link`, html => html.includes(`example.com`)],
+  [`cite disabled`, html => !html.includes(`<sup>[`)],
+])
+
+runCase(`citeStatus enabled`, { citeStatus: true }, [
+  [`converts link to citation`, html => html.includes(`<sup>[`) && html.includes(`example.com`)],
+])
+
+runCase(`countStatus enabled`, { countStatus: true }, [
+  [`includes reading stats`, html => /阅读|分钟|字/.test(html)],
+])
+
+runCase(`mac code block`, { isMacCodeBlock: true }, [
+  [`enables mac-sign style`, html => html.includes(`.mac-sign`) && html.includes(`display: flex`)],
+])
+
+console.log(`\nAll VSCode extension smoke tests passed.`)

--- a/apps/vscode/scripts/verify-activate.mjs
+++ b/apps/vscode/scripts/verify-activate.mjs
@@ -1,0 +1,83 @@
+/**
+ * Verify extension.js loads and activate() registers commands (vscode API mocked).
+ */
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const vscodeRoot = path.resolve(__dirname, `..`)
+
+const registered = []
+
+const vscodeMock = {
+  commands: {
+    registerCommand(id, _handler) {
+      registered.push(id)
+      return { dispose() {} }
+    },
+    executeCommand() {},
+  },
+  window: {
+    activeTextEditor: undefined,
+    registerTreeDataProvider() {},
+    onDidChangeActiveTextEditor() {
+      return { dispose() {} }
+    },
+    createWebviewPanel() {
+      return {
+        title: ``,
+        webview: { html: `` },
+        onDidDispose() {},
+        reveal() {},
+      }
+    },
+    showErrorMessage() {},
+  },
+  EventEmitter: class {
+    event = () => ({ dispose() {} })
+    fire() {}
+  },
+  TreeItem: class {
+    constructor(label, state) {
+      this.label = label
+      this.collapsibleState = state
+    }
+  },
+  TreeItemCollapsibleState: { None: 0, Expanded: 1 },
+  ThemeIcon: class {},
+  ViewColumn: { Two: 2 },
+  workspace: {
+    onDidChangeTextDocument() {
+      return { dispose() {} }
+    },
+    workspaceState: { get: () => undefined, update: () => {} },
+  },
+  ExtensionContext: class {},
+}
+
+const require = createRequire(import.meta.url)
+const Module = require(`node:module`)
+const originalLoad = Module._load
+Module._load = function (request, parent, isMain) {
+  if (request === `vscode`)
+    return vscodeMock
+  return originalLoad.call(this, request, parent, isMain)
+}
+
+const ext = require(path.join(vscodeRoot, `dist`, `extension.js`))
+const context = {
+  subscriptions: [],
+  workspaceState: { get: () => undefined, update: async () => {} },
+}
+ext.activate(context)
+
+const required = [`markdown.preview`, `markdown.toggleCiteStatus`]
+for (const cmd of required) {
+  if (!registered.includes(cmd)) {
+    throw new Error(`Missing registered command: ${cmd}`)
+  }
+}
+
+console.log(`✓ activate() registered ${registered.length} commands`)
+console.log(`✓ markdown.preview is available`)

--- a/apps/vscode/scripts/verify-preview.mjs
+++ b/apps/vscode/scripts/verify-preview.mjs
@@ -1,0 +1,27 @@
+/**
+ * Verify bundled previewRenderer.js can render HTML in Node.
+ */
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const { buildPreviewHtml } = require(path.join(__dirname, `..`, `dist`, `previewRenderer.js`))
+
+const html = buildPreviewHtml({
+  markdown: `# Test\n\n[link](https://example.com)`,
+  primaryColor: `#000000`,
+  fontFamily: `sans-serif`,
+  fontSize: `16px`,
+  theme: `default`,
+  countStatus: false,
+  isMacCodeBlock: false,
+  citeStatus: false,
+})
+
+if (!html.includes(`Test`) || !html.includes(`example.com`)) {
+  throw new Error(`previewRenderer output missing expected content`)
+}
+
+console.log(`✓ previewRenderer.js renders HTML in Node`)

--- a/apps/vscode/scripts/verify-vsix-deps.mjs
+++ b/apps/vscode/scripts/verify-vsix-deps.mjs
@@ -1,0 +1,15 @@
+/**
+ * Verify packaged runtime deps resolve from dist/ like an installed vsix.
+ */
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const vscodeRoot = path.resolve(__dirname, `..`)
+const requireFromDist = createRequire(path.join(vscodeRoot, `dist`, `previewRenderer.js`))
+
+requireFromDist(`../runtime/node_modules/isomorphic-dompurify`)
+requireFromDist(`../runtime/node_modules/jsdom`)
+
+console.log(`✓ vsix runtime deps resolve from dist/`)

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -29,9 +29,9 @@ function updateMarkdownFileContext(editor: vscode.TextEditor | undefined) {
 export function activate(context: vscode.ExtensionContext) {
   // Register sidebar FIRST — must complete before any heavy renderer import.
   const treeDataProvider = new MarkdownTreeDataProvider(context)
-  vscode.window.registerTreeDataProvider(`markdown.preview.view`, treeDataProvider)
 
   context.subscriptions.push(
+    vscode.window.registerTreeDataProvider(`markdown.preview.view`, treeDataProvider),
     treeDataProvider.onDidChangeTreeData(() => {
       refreshActivePanel?.()
     }),

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,22 +1,44 @@
-import type { ThemeName } from '@md/shared'
-import { initRenderer } from '@md/core/renderer'
-import { generateCSSVariables } from '@md/core/theme'
-import { modifyHtmlContent } from '@md/core/utils'
-import { baseCSSContent, themeMap } from '@md/shared'
+import type { ThemeName } from '@md/shared/configs'
+import type { PreviewOptions } from './previewRenderer'
+import { createRequire } from 'node:module'
 import * as vscode from 'vscode'
-import { css } from './css'
 import { MarkdownTreeDataProvider } from './treeDataProvider'
+
+const requirePreview = createRequire(__filename)
+
+type PreviewRendererModule = typeof import('./previewRenderer')
 
 let activePanel: vscode.WebviewPanel | undefined
 let activePreviewEditor: vscode.TextEditor | undefined
 let refreshActivePanel: (() => void) | undefined
+let previewModule: PreviewRendererModule | undefined
+
+function loadPreviewRenderer(): PreviewRendererModule {
+  if (!previewModule) {
+    // Separate webpack entry — loaded only when preview opens.
+    previewModule = requirePreview(`./previewRenderer`) as PreviewRendererModule
+  }
+  return previewModule
+}
+
+function updateMarkdownFileContext(editor: vscode.TextEditor | undefined) {
+  const isMarkdown = editor?.document.languageId === `markdown`
+  vscode.commands.executeCommand(`setContext`, `markdownFileActive`, Boolean(isMarkdown))
+}
 
 export function activate(context: vscode.ExtensionContext) {
-  // Register TreeDataProvider
+  // Register sidebar FIRST — must complete before any heavy renderer import.
   const treeDataProvider = new MarkdownTreeDataProvider(context)
   vscode.window.registerTreeDataProvider(`markdown.preview.view`, treeDataProvider)
 
-  // Command for registering style settings
+  context.subscriptions.push(
+    treeDataProvider.onDidChangeTreeData(() => {
+      refreshActivePanel?.()
+    }),
+  )
+
+  updateMarkdownFileContext(vscode.window.activeTextEditor)
+
   context.subscriptions.push(
     vscode.commands.registerCommand(`markdown.setFontSize`, (size: string) => {
       treeDataProvider.updateFontSize(size)
@@ -47,7 +69,6 @@ export function activate(context: vscode.ExtensionContext) {
       return
     }
 
-    // 如果已有面板且未关闭，则直接显示
     if (activePanel) {
       activePreviewEditor = editor
       activePanel.title = `Markdown Preview - ${editor.document.fileName}`
@@ -56,14 +77,13 @@ export function activate(context: vscode.ExtensionContext) {
       return
     }
 
-    // Create and display a new webview panel
     const panel = vscode.window.createWebviewPanel(
-      `markdownPreview`, // 视图类型
-      `Markdown Preview - ${editor.document.fileName}`, // 面板标题
-      vscode.ViewColumn.Two, // 在第二栏显示
+      `markdownPreview`,
+      `Markdown Preview - ${editor.document.fileName}`,
+      vscode.ViewColumn.Two,
       {
-        enableScripts: true, // 启用JS
-        retainContextWhenHidden: true, // 保持状态
+        enableScripts: true,
+        retainContextWhenHidden: true,
       },
     )
 
@@ -78,75 +98,51 @@ export function activate(context: vscode.ExtensionContext) {
       }
     })
 
-    const treeDataSubscription = treeDataProvider.onDidChangeTreeData(() => {
-      refreshActivePanel?.()
-    })
-
-    function updateWebview() {
+    async function updateWebview() {
       const previewEditor = activePreviewEditor
       if (!previewEditor || previewEditor.document.languageId !== `markdown`)
         return
 
-      panel.title = `Markdown Preview - ${previewEditor.document.fileName}`
+      try {
+        panel.title = `Markdown Preview - ${previewEditor.document.fileName}`
 
-      // 使用新主题系统
-      const renderer = initRenderer({
-        countStatus: treeDataProvider.getCurrentCountStatus(),
-        isMacCodeBlock: treeDataProvider.getCurrentMacCodeBlock(),
-        citeStatus: treeDataProvider.getCurrentCiteStatus(),
-        legend: `none`,
-      })
-
-      const markdownContent = previewEditor.document.getText()
-      const html = modifyHtmlContent(markdownContent, renderer)
-
-      // 生成主题 CSS
-      const variables = generateCSSVariables({
-        primaryColor: treeDataProvider.getCurrentPrimaryColor(),
-        fontFamily: treeDataProvider.getCurrentFontFamily(),
-        fontSize: treeDataProvider.getCurrentFontSize(),
-        isUseIndent: false,
-        isUseJustify: false,
-      })
-
-      const themeCSS = themeMap[treeDataProvider.getCurrentTheme() as ThemeName]
-      const completeCss = `${variables}\n\n${baseCSSContent}\n\n${themeCSS}\n\n${css}`
-
-      panel.webview.html = wrapHtmlTag(html, completeCss)
+        const { buildPreviewHtml } = loadPreviewRenderer()
+        panel.webview.html = buildPreviewHtml({
+          markdown: previewEditor.document.getText(),
+          primaryColor: treeDataProvider.getCurrentPrimaryColor(),
+          fontFamily: treeDataProvider.getCurrentFontFamily(),
+          fontSize: treeDataProvider.getCurrentFontSize(),
+          theme: treeDataProvider.getCurrentTheme(),
+          countStatus: treeDataProvider.getCurrentCountStatus(),
+          isMacCodeBlock: treeDataProvider.getCurrentMacCodeBlock(),
+          citeStatus: treeDataProvider.getCurrentCiteStatus(),
+        } satisfies PreviewOptions)
+      }
+      catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        vscode.window.showErrorMessage(`Markdown preview failed: ${message}`)
+        console.error(`[doocs-md] preview error:`, error)
+      }
     }
 
-    refreshActivePanel = updateWebview
+    refreshActivePanel = () => { void updateWebview() }
 
-    // render first webview
-    updateWebview()
+    void updateWebview()
 
-    // Monitor the changes of documents
     const changeSubscription = vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
       if (activePreviewEditor && e.document === activePreviewEditor.document) {
-        updateWebview()
+        void updateWebview()
       }
     })
 
-    // Cancel the subscription when the panel is closed
     panel.onDidDispose(() => {
       changeSubscription.dispose()
-      treeDataSubscription.dispose()
     })
   })
 
   context.subscriptions.push(disposable)
 
-  // When the Markdown file is opened, the preview button is displayed in the status bar.
-  vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor | undefined) => {
-    if (editor && editor.document.languageId === `markdown`) {
-      vscode.commands.executeCommand(`setContext`, `markdownFileActive`, true)
-    }
-    else {
-      vscode.commands.executeCommand(`setContext`, `markdownFileActive`, false)
-    }
-  })
-}
-
-function wrapHtmlTag(html: string, css: string) {
-  return `<html><head><meta charset="utf-8" /><style>${css}</style></head><body><div style="width: 375px; margin: auto;padding:20px;background:white;position: relative;min-height: 100%;margin: 0 auto;padding: 20px;font-size: 14px;box-sizing: border-box;outline: none;transition: all 300ms ease-in-out;word-wrap: break-word;">${html}</div></body></html>`
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(updateMarkdownFileContext),
+  )
 }

--- a/apps/vscode/src/previewRenderer.ts
+++ b/apps/vscode/src/previewRenderer.ts
@@ -1,0 +1,45 @@
+import type { ThemeName } from '@md/shared/configs/theme'
+import { initRenderer } from '@md/core/renderer'
+import { generateCSSVariables } from '@md/core/theme'
+import { modifyHtmlContent } from '@md/core/utils'
+import { baseCSSContent, themeMap } from '@md/shared/configs/theme'
+import { css } from './css'
+
+export interface PreviewOptions {
+  markdown: string
+  primaryColor: string
+  fontFamily: string
+  fontSize: string
+  theme: ThemeName
+  countStatus: boolean
+  isMacCodeBlock: boolean
+  citeStatus: boolean
+}
+
+export function buildPreviewHtml(options: PreviewOptions): string {
+  const renderer = initRenderer({
+    countStatus: options.countStatus,
+    isMacCodeBlock: options.isMacCodeBlock,
+    citeStatus: options.citeStatus,
+    legend: `none`,
+  })
+
+  const html = modifyHtmlContent(options.markdown, renderer)
+
+  const variables = generateCSSVariables({
+    primaryColor: options.primaryColor,
+    fontFamily: options.fontFamily,
+    fontSize: options.fontSize,
+    isUseIndent: false,
+    isUseJustify: false,
+  })
+
+  const themeCSS = themeMap[options.theme]
+  const completeCss = `${variables}\n\n${baseCSSContent}\n\n${themeCSS}\n\n${css}`
+
+  return wrapHtmlTag(html, completeCss)
+}
+
+function wrapHtmlTag(html: string, cssText: string) {
+  return `<html><head><meta charset="utf-8" /><style>${cssText}</style></head><body><div style="width: 375px; margin: auto;padding:20px;background:white;position: relative;min-height: 100%;margin: 0 auto;padding: 20px;font-size: 14px;box-sizing: border-box;outline: none;transition: all 300ms ease-in-out;word-wrap: break-word;">${html}</div></body></html>`
+}

--- a/apps/vscode/src/styleChoices.ts
+++ b/apps/vscode/src/styleChoices.ts
@@ -1,4 +1,5 @@
-import { codeBlockThemeOptions, colorOptions, fontFamilyOptions, fontSizeOptions, legendOptions, themeOptions } from '@md/shared/configs'
+import { codeBlockThemeOptions, colorOptions, fontFamilyOptions, fontSizeOptions, legendOptions } from '@md/shared/configs/style'
+import { themeOptions } from '@md/shared/configs/theme'
 
 export {
   codeBlockThemeOptions,

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "@/*": ["../*"]
     },
-    "types": ["vscode"],
+    "types": ["vscode", "node"],
     "strict": true,
     "sourceMap": true,
     "esModuleInterop": true

--- a/apps/vscode/webpack.config.mjs
+++ b/apps/vscode/webpack.config.mjs
@@ -9,19 +9,23 @@ const currentDir = import.meta.dirname
 /** @typedef {import('webpack').Configuration} WebpackConfig */
 
 /** @type WebpackConfig */
-
 export default function config() {
   return {
     target: `node`,
     mode: `none`,
-    entry: `./src/extension.ts`,
+    entry: {
+      extension: `./src/extension.ts`,
+      previewRenderer: `./src/previewRenderer.ts`,
+    },
     output: {
       path: path.resolve(currentDir, `dist`),
-      filename: `extension.js`,
+      filename: `[name].js`,
       libraryTarget: `commonjs2`,
     },
     externals: {
-      vscode: `commonjs vscode`,
+      'vscode': `commonjs vscode`,
+      // Shipped in runtime/node_modules for --no-dependencies vsix packaging.
+      'isomorphic-dompurify': `commonjs ../runtime/node_modules/isomorphic-dompurify`,
     },
     resolve: {
       extensions: [`.ts`, `.js`],
@@ -56,6 +60,8 @@ export default function config() {
     optimization: {
       usedExports: true,
       sideEffects: true,
+      splitChunks: false,
+      runtimeChunk: false,
     },
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "pnpm web dev",
     "web": "pnpm --filter @md/web",
     "vscode": "pnpm --prefix ./apps/vscode",
+    "vscode:test": "pnpm --prefix ./apps/vscode test",
     "mcp": "pnpm --filter @md/mcp-server",
     "cli": "pnpm --filter @doocs/md-cli",
     "build:cli": "pnpm web build && npx shx rm -rf packages/md-cli/dist && npx shx rm -rf dist/**/*.map && npx shx cp -r apps/web/dist packages/md-cli/ && cd packages/md-cli && npm pack",

--- a/packages/shared/src/configs/shortcut-key.ts
+++ b/packages/shared/src/configs/shortcut-key.ts
@@ -1,4 +1,4 @@
-const isMac = /Mac/i.test(navigator.userAgent)
+const isMac = typeof navigator !== `undefined` && /Mac/i.test(navigator.userAgent)
 
 export const ctrlKey = `Mod`
 export const altKey = `Alt`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       isomorphic-dompurify:
         specifier: ^3.16.0
         version: 3.16.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -119,12 +122,21 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.2
+        version: 25.9.2
       '@types/vscode':
         specifier: ^1.120.0
         version: 1.120.0
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      webpack:
+        specifier: ^5.107.2
+        version: 5.107.2(postcss@8.5.15)(webpack-cli@7.0.3)
       webpack-cli:
         specifier: ^7.0.3
         version: 7.0.3(webpack@5.107.2)
@@ -9991,8 +10003,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.0
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,9 +109,6 @@ importers:
       isomorphic-dompurify:
         specifier: ^3.16.0
         version: 3.16.0
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
       postcss:
         specifier: ^8.5.15
         version: 8.5.15


### PR DESCRIPTION
## Summary

- Fix VS Code extension activation failures (`markdown.preview` not found, sidebar `no data provider registered`) by deferring heavy renderer loading until preview opens
- Split rendering into `previewRenderer.ts` with a separate webpack entry and lazy `createRequire` load
- Ship `isomorphic-dompurify` runtime deps under `runtime/node_modules` so `--no-dependencies` vsix installs work offline
- Guard `navigator` access in `shortcut-key.ts` for Node/extension host environments
- Add smoke/activate/preview/vsix dependency tests, F5 debug config, and updated extension README

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] `pnpm vscode test` — build, smoke tests, preview renderer, activate registration, vsix runtime deps
- [x] `pnpm vscode package` — produces `doocs-md-0.0.1.vsix` (~16 MB) with `dist/` and `runtime/`
- [x] F5 extension debug — sidebar and preview panel work in Extension Development Host
- [x] Install `.vsix` in VS Code and open Markdown preview

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits (English)
- [x] Changes are focused on the VS Code extension fix
- [x] Documentation updated (`apps/vscode/README.md`)
- [x] No secrets or credentials included
- [x] Pre-commit hooks passed (eslint)
