### PR TITLE
feat(mcp-server): expand render options and add Cursor MCP config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "md": {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx/esm",
+        "${workspaceFolder}/packages/mcp-server/run.mjs"
+      ],
+      "cwd": "${workspaceFolder}/packages/mcp-server"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ pnpm mcp <cmd>        # 在 @md/mcp-server 中执行命令（render_markdown 等
 pnpm mcp dev          # MCP Server 监听模式
 ```
 
-`@md/mcp-server` 通过 stdio 暴露 `render_markdown`、`list_themes`、`list_colors` 等工具，配置见 [packages/mcp-server/README.md](./packages/mcp-server/README.md) 与 `.vscode/mcp.json`。
+`@md/mcp-server` 通过 stdio 暴露 `render_markdown`、`list_themes`、`list_colors` 等工具，配置见 [packages/mcp-server/README.md](./packages/mcp-server/README.md)、[`.vscode/mcp.json`](./.vscode/mcp.json) 与 [`.cursor/mcp.json`](./.cursor/mcp.json)。
 
 ## 架构
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -22,24 +22,24 @@ pnpm install
 
 Convert Markdown text to styled HTML using the full doocs/md rendering pipeline.
 
-| Parameter          | Type                               | Default     | Description                                           |
-| ------------------ | ---------------------------------- | ----------- | ----------------------------------------------------- |
-| `markdown`         | `string`                           | —           | Markdown source text                                  |
-| `theme`            | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)                     |
-| `primaryColor`     | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)              |
-| `fontFamily`       | `string`                           | 无衬线预设  | Font family stack (see `list_fonts`)                  |
-| `fontSize`         | `string (px)`                      | `"16px"`    | Base font size (see `list_font_sizes`)                |
-| `legend`           | `string`                           | `"alt"`     | Image caption format (see `list_legend_formats`)      |
-| `isMacCodeBlock`   | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar       |
-| `isShowLineNumber` | `boolean`                          | `false`     | Show line numbers in code blocks                      |
-| `citeStatus`       | `boolean`                          | `false`     | Convert links to footnote-style citations             |
-| `countStatus`      | `boolean`                          | `false`     | Prepend a reading-time estimate                       |
-| `themeMode`        | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions                     |
-| `isUseIndent`      | `boolean`                          | `false`     | Indent paragraph first lines                          |
-| `isUseJustify`     | `boolean`                          | `false`     | Justify paragraph text                                |
-| `headingStyles`    | `object`                           | `{}`        | Per-level heading styles (see `list_heading_styles`)  |
-| `codeBlockTheme`   | `string (url)`                     | GitHub 主题 | highlight.js theme URL (see `list_code_block_themes`) |
-| `customCSS`        | `string`                           | `""`        | Additional custom CSS (highest priority)              |
+| Parameter          | Type                               | Default     | Description                                            |
+| ------------------ | ---------------------------------- | ----------- | ------------------------------------------------------ |
+| `markdown`         | `string`                           | —           | Markdown source text                                   |
+| `theme`            | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)                      |
+| `primaryColor`     | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)               |
+| `fontFamily`       | `string`                           | 无衬线预设  | Font family stack (see `list_fonts`)                   |
+| `fontSize`         | `string (px)`                      | `"16px"`    | Base font size (see `list_font_sizes`)                 |
+| `legend`           | `string`                           | `"alt"`     | Image caption format (see `list_legend_formats`)       |
+| `isMacCodeBlock`   | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar        |
+| `isShowLineNumber` | `boolean`                          | `false`     | Show line numbers in code blocks                       |
+| `citeStatus`       | `boolean`                          | `false`     | Convert links to footnote-style citations              |
+| `countStatus`      | `boolean`                          | `false`     | Prepend a reading-time estimate                        |
+| `themeMode`        | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions                      |
+| `isUseIndent`      | `boolean`                          | `false`     | Indent paragraph first lines                           |
+| `isUseJustify`     | `boolean`                          | `false`     | Justify paragraph text                                 |
+| `headingStyles`    | `object`                           | `{}`        | Per-level heading styles (see `list_heading_styles`)   |
+| `codeBlockTheme`   | preset URL                         | GitHub 主题 | highlight.js preset from `list_code_block_themes` only |
+| `customCSS`        | `string`                           | `""`        | Additional custom CSS (highest priority)               |
 
 Returns `{ html, frontMatter, readingTime: { words, minutes } }`.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -22,28 +22,41 @@ pnpm install
 
 Convert Markdown text to styled HTML using the full doocs/md rendering pipeline.
 
-| Parameter          | Type                               | Default     | Description                                     |
-| ------------------ | ---------------------------------- | ----------- | ----------------------------------------------- |
-| `markdown`         | `string`                           | —           | Markdown source text                            |
-| `theme`            | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)               |
-| `primaryColor`     | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)        |
-| `isMacCodeBlock`   | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar |
-| `isShowLineNumber` | `boolean`                          | `false`     | Show line numbers in code blocks                |
-| `citeStatus`       | `boolean`                          | `false`     | Convert links to footnote-style citations       |
-| `countStatus`      | `boolean`                          | `false`     | Prepend a reading-time estimate                 |
-| `themeMode`        | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions               |
+| Parameter          | Type                               | Default     | Description                                           |
+| ------------------ | ---------------------------------- | ----------- | ----------------------------------------------------- |
+| `markdown`         | `string`                           | —           | Markdown source text                                  |
+| `theme`            | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)                     |
+| `primaryColor`     | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)              |
+| `fontFamily`       | `string`                           | 无衬线预设  | Font family stack (see `list_fonts`)                  |
+| `fontSize`         | `string (px)`                      | `"16px"`    | Base font size (see `list_font_sizes`)                |
+| `legend`           | `string`                           | `"alt"`     | Image caption format (see `list_legend_formats`)      |
+| `isMacCodeBlock`   | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar       |
+| `isShowLineNumber` | `boolean`                          | `false`     | Show line numbers in code blocks                      |
+| `citeStatus`       | `boolean`                          | `false`     | Convert links to footnote-style citations             |
+| `countStatus`      | `boolean`                          | `false`     | Prepend a reading-time estimate                       |
+| `themeMode`        | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions                     |
+| `isUseIndent`      | `boolean`                          | `false`     | Indent paragraph first lines                          |
+| `isUseJustify`     | `boolean`                          | `false`     | Justify paragraph text                                |
+| `headingStyles`    | `object`                           | `{}`        | Per-level heading styles (see `list_heading_styles`)  |
+| `codeBlockTheme`   | `string (url)`                     | GitHub 主题 | highlight.js theme URL (see `list_code_block_themes`) |
+| `customCSS`        | `string`                           | `""`        | Additional custom CSS (highest priority)              |
 
 Returns `{ html, frontMatter, readingTime: { words, minutes } }`.
 
 ### Other tools
 
-| Tool                   | Description                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| `list_themes`          | List all available visual themes with labels and authors                          |
-| `list_colors`          | List all available primary accent colors                                          |
-| `list_ai_services`     | List all built-in AI service providers with endpoints and models                  |
-| `explain_extensions`   | Describe every Markdown extension beyond CommonMark (KaTeX, Mermaid, PlantUML, …) |
-| `get_renderer_options` | Describe all renderer configuration options                                       |
+| Tool                     | Description                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `list_themes`            | List all available visual themes with labels and authors                          |
+| `list_colors`            | List all available primary accent colors                                          |
+| `list_fonts`             | List preset font family options                                                   |
+| `list_font_sizes`        | List preset font size options                                                     |
+| `list_legend_formats`    | List image caption format options                                                 |
+| `list_heading_styles`    | List heading style presets                                                        |
+| `list_code_block_themes` | List highlight.js code block theme URLs                                           |
+| `list_ai_services`       | List all built-in AI service providers with endpoints and models                  |
+| `explain_extensions`     | Describe every Markdown extension beyond CommonMark (KaTeX, Mermaid, PlantUML, …) |
+| `get_renderer_options`   | Describe all renderer configuration options                                       |
 
 ## Setup
 
@@ -90,19 +103,25 @@ Replace `C:/path/to/md` with the absolute path to your cloned repository.
 
 ### Cursor
 
-Add to `.cursor/mcp.json` at the project root:
+Add to `.cursor/mcp.json` at the project root (already included in this repo):
 
 ```json
 {
   "mcpServers": {
     "md": {
       "command": "node",
-      "args": ["--import", "tsx/esm", "packages/mcp-server/run.mjs"],
-      "cwd": "packages/mcp-server"
+      "args": [
+        "--import",
+        "tsx/esm",
+        "${workspaceFolder}/packages/mcp-server/run.mjs"
+      ],
+      "cwd": "${workspaceFolder}/packages/mcp-server"
     }
   }
 }
 ```
+
+Then open **Cursor Settings → MCP** and enable the `md` server.
 
 ### Windsurf / Other MCP Clients
 
@@ -147,7 +166,7 @@ pnpm --filter @md/mcp-server start
 pnpm --filter @md/mcp-server dev
 ```
 
-To test manually, pipe a valid JSON-RPC `initialize` message to stdin or use [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+To test manually, use [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
 ```bash
 npx @modelcontextprotocol/inspector node --import tsx/esm run.mjs

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@md/mcp-server",
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "MCP server for doocs/md – exposes markdown rendering and AI service information to AI agents",
   "bin": {

--- a/packages/mcp-server/src/config-options.ts
+++ b/packages/mcp-server/src/config-options.ts
@@ -1,0 +1,112 @@
+export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+export type HeadingStyleType = 'default' | 'color-only' | 'border-bottom' | 'border-left' | 'custom'
+
+/**
+ * Static option lists for MCP tools.
+ * Defined here (not imported from @md/shared/configs/style) because style.ts
+ * pulls in theme-css with Vite ?raw imports that Node.js cannot resolve.
+ */
+
+export const colorOptions = [
+  { value: `#0F4C81`, label: `经典蓝`, desc: `稳重冷静` },
+  { value: `#009874`, label: `翡翠绿`, desc: `自然平衡` },
+  { value: `#FA5151`, label: `活力橘`, desc: `热情活力` },
+  { value: `#FECE00`, label: `柠檬黄`, desc: `明亮温暖` },
+  { value: `#92617E`, label: `薰衣紫`, desc: `优雅神秘` },
+  { value: `#55C9EA`, label: `天空蓝`, desc: `清爽自由` },
+  { value: `#B76E79`, label: `玫瑰金`, desc: `奢华现代` },
+  { value: `#556B2F`, label: `橄榄绿`, desc: `沉稳自然` },
+  { value: `#333333`, label: `石墨黑`, desc: `内敛极简` },
+  { value: `#A9A9A9`, label: `雾烟灰`, desc: `柔和低调` },
+  { value: `#FFB7C5`, label: `樱花粉`, desc: `浪漫甜美` },
+] as const
+
+export const themeOptions = [
+  { value: `default`, label: `经典`, desc: `` },
+  { value: `grace`, label: `优雅`, desc: `@brzhang` },
+  { value: `simple`, label: `简洁`, desc: `@okooo5km` },
+] as const
+
+export const fontFamilyOptions = [
+  {
+    label: `无衬线`,
+    value: `-apple-system-font,BlinkMacSystemFont, Helvetica Neue, PingFang SC, Hiragino Sans GB , Microsoft YaHei UI , Microsoft YaHei ,Arial,sans-serif`,
+    desc: `字体123Abc`,
+  },
+  {
+    label: `衬线`,
+    value: `Optima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif`,
+    desc: `字体123Abc`,
+  },
+  {
+    label: `等宽`,
+    value: `Menlo, Monaco, 'Courier New', monospace`,
+    desc: `字体123Abc`,
+  },
+] as const
+
+export const fontSizeOptions = [
+  { label: `14px`, value: `14px`, desc: `更小` },
+  { label: `15px`, value: `15px`, desc: `稍小` },
+  { label: `16px`, value: `16px`, desc: `推荐` },
+  { label: `17px`, value: `17px`, desc: `稍大` },
+  { label: `18px`, value: `18px`, desc: `更大` },
+] as const
+
+export const legendOptions = [
+  { label: `title 优先`, value: `title-alt`, desc: `` },
+  { label: `alt 优先`, value: `alt-title`, desc: `` },
+  { label: `只显示 title`, value: `title`, desc: `` },
+  { label: `只显示 alt`, value: `alt`, desc: `` },
+  { label: `文件名`, value: `filename`, desc: `` },
+  { label: `不显示`, value: `none`, desc: `` },
+] as const
+
+export type LegendValue = typeof legendOptions[number][`value`]
+
+export const headingStyleOptions = [
+  { label: `默认`, value: `default`, desc: `` },
+  { label: `主题色文字`, value: `color-only`, desc: `` },
+  { label: `下边框`, value: `border-bottom`, desc: `` },
+  { label: `左边框`, value: `border-left`, desc: `` },
+  { label: `自定义`, value: `custom`, desc: `` },
+] as const
+
+export type HeadingStylesInput = Partial<Record<HeadingLevel, HeadingStyleType>>
+
+const codeBlockUrlPrefix = `https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/npm/highlightjs/11.11.1/styles/`
+
+const codeBlockThemeList = [
+  `github`,
+  `github-dark`,
+  `atom-one-light`,
+  `atom-one-dark`,
+  `monokai`,
+  `vs`,
+  `xcode`,
+  `nord`,
+  `tokyo-night-light`,
+  `tokyo-night-dark`,
+] as const
+
+export const codeBlockThemeOptions = codeBlockThemeList.map(name => ({
+  label: name,
+  value: `${codeBlockUrlPrefix}${name}.min.css`,
+  desc: ``,
+}))
+
+export const defaultRenderOptions = {
+  theme: `default` as const,
+  primaryColor: colorOptions[0].value,
+  fontFamily: fontFamilyOptions[0].value,
+  fontSize: fontSizeOptions[2].value,
+  legend: legendOptions[3].value as LegendValue,
+  codeBlockTheme: codeBlockThemeOptions[0].value,
+  isMacCodeBlock: false,
+  isShowLineNumber: false,
+  citeStatus: false,
+  countStatus: false,
+  themeMode: `light` as const,
+  isUseIndent: false,
+  isUseJustify: false,
+}

--- a/packages/mcp-server/src/config-options.ts
+++ b/packages/mcp-server/src/config-options.ts
@@ -95,6 +95,18 @@ export const codeBlockThemeOptions = codeBlockThemeList.map(name => ({
   desc: ``,
 }))
 
+export const allowedCodeBlockThemeUrls = new Set(
+  codeBlockThemeOptions.map(option => option.value),
+)
+
+export function assertAllowedCodeBlockThemeUrl(url: string): void {
+  if (!allowedCodeBlockThemeUrls.has(url)) {
+    throw new Error(
+      `codeBlockTheme must be a preset URL from list_code_block_themes. Received: ${url}`,
+    )
+  }
+}
+
 export const defaultRenderOptions = {
   theme: `default` as const,
   primaryColor: colorOptions[0].value,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -96,12 +96,11 @@ export const renderMarkdownInputSchema = {
     .optional()
     .describe(`Per-level heading style presets. Use list_heading_styles for options.`),
   codeBlockTheme: z
-    .string()
-    .url()
+    .enum(codeBlockThemeOptions.map(option => option.value) as [string, ...string[]])
     .optional()
     .describe(
-      `URL of a highlight.js theme stylesheet for code blocks. `
-      + `Use list_code_block_themes for presets. Defaults to the GitHub theme.`,
+      `Preset highlight.js theme URL for code blocks. `
+      + `Use list_code_block_themes for allowed values. Defaults to the GitHub theme.`,
     ),
   customCSS: z
     .string()
@@ -344,7 +343,7 @@ server.registerTool(
       { name: `isUseIndent`, type: `boolean`, default: false, description: `Paragraph first-line indent.` },
       { name: `isUseJustify`, type: `boolean`, default: false, description: `Justified paragraph text.` },
       { name: `headingStyles`, type: `object`, default: `{}`, description: `Per-level heading styles. See list_heading_styles.` },
-      { name: `codeBlockTheme`, type: `string (url)`, default: `github.min.css`, description: `highlight.js theme URL.` },
+      { name: `codeBlockTheme`, type: `preset url enum`, default: `github.min.css`, description: `highlight.js preset from list_code_block_themes.` },
       { name: `customCSS`, type: `string`, default: `''`, description: `User custom CSS appended last.` },
     ],
   }),

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,88 +1,124 @@
 #!/usr/bin/env node
 
-import type { ThemeName } from '@md/shared/configs'
-import fs from 'node:fs'
-import path from 'node:path'
 import process from 'node:process'
-import { initRenderer } from '@md/core/renderer'
-
-import { generateCSSVariables } from '@md/core/theme/cssVariables'
-import { postProcessHtml, renderMarkdown } from '@md/core/utils'
 import { serviceOptions } from '@md/shared/configs/ai-service-options'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
+import {
+  codeBlockThemeOptions,
+  colorOptions,
+  fontFamilyOptions,
+  fontSizeOptions,
+  headingStyleOptions,
+  legendOptions,
+  themeOptions,
+} from './config-options'
 
-// colorOptions / themeOptions are defined inline because importing from
-// @md/shared/configs/style or @md/shared/configs/theme triggers
-// theme-css/index.ts which uses Vite's ?raw CSS imports (unsupported in Node.js).
+import { buildRenderedOutput } from './render-article'
 
-const colorOptions = [
-  { value: `#0F4C81`, label: `经典蓝`, desc: `稳重冷静` },
-  { value: `#009874`, label: `翡翠绿`, desc: `自然平衡` },
-  { value: `#FA5151`, label: `活力橘`, desc: `热情活力` },
-  { value: `#FECE00`, label: `柠檬黄`, desc: `明亮温暖` },
-  { value: `#92617E`, label: `薰衣紫`, desc: `优雅神秘` },
-  { value: `#55C9EA`, label: `天空蓝`, desc: `清爽自由` },
-  { value: `#B76E79`, label: `玫瑰金`, desc: `奢华现代` },
-  { value: `#556B2F`, label: `橄榄绿`, desc: `沉稳自然` },
-  { value: `#333333`, label: `石墨黑`, desc: `内敛极简` },
-  { value: `#A9A9A9`, label: `雾烟灰`, desc: `柔和低调` },
-  { value: `#FFB7C5`, label: `樱花粉`, desc: `浪漫甜美` },
-] as const
+const headingStyleEnum = z.enum([`default`, `color-only`, `border-bottom`, `border-left`, `custom`])
 
-const themeOptions = [
-  { value: `default`, label: `经典`, desc: `` },
-  { value: `grace`, label: `优雅`, desc: `@brzhang` },
-  { value: `simple`, label: `简洁`, desc: `@okooo5km` },
-] as const
-
-/**
- * @md MCP Server
- *
- * Exposes the doocs/md markdown rendering engine and AI service configuration
- * to AI agents via the Model Context Protocol (MCP).
- *
- * Tools provided:
- *   - render_markdown        Convert Markdown text to styled HTML
- *   - list_themes            List all available visual themes
- *   - list_colors            List all available primary accent colors
- *   - list_ai_services       List all built-in AI service providers
- *   - explain_extensions     Describe supported Markdown extensions
- *   - get_renderer_options   Describe all renderer configuration options
- */
-
-// Load CSS files at runtime (Node.js doesn't support ?raw imports)
-const themeDir = path.resolve(import.meta.dirname, `../../shared/src/configs/theme-css`)
-
-function loadCSSFile(filename: string): string {
-  try {
-    return fs.readFileSync(path.join(themeDir, filename), `utf-8`)
-  }
-  catch (err) {
-    throw new Error(`[md-mcp-server] Failed to load CSS file: ${filename}. Ensure the monorepo source structure is intact.`, { cause: err })
-  }
+export const renderMarkdownInputSchema = {
+  markdown: z.string().describe(`The Markdown source text to render.`),
+  theme: z
+    .enum([`default`, `grace`, `simple`])
+    .optional()
+    .default(`default`)
+    .describe(`Visual theme to apply. One of: default (经典), grace (优雅), simple (简洁).`),
+  primaryColor: z
+    .string()
+    .regex(/^#[0-9A-F]{6}$/i, `Must be a valid 6-digit hex color`)
+    .optional()
+    .default(`#0F4C81`)
+    .describe(
+      `Primary accent color (hex). Use list_colors to see presets. Default: #0F4C81 (经典蓝). `
+      + `This color is applied via CSS variable --md-primary-color and affects headings, links, alerts, etc.`,
+    ),
+  fontFamily: z
+    .string()
+    .optional()
+    .describe(`Font family stack. Use list_fonts for presets or pass any CSS font-family value.`),
+  fontSize: z
+    .string()
+    .regex(/^\d+px$/, `Must be a pixel size like 16px`)
+    .optional()
+    .describe(`Base font size (e.g. 16px). Use list_font_sizes for presets.`),
+  legend: z
+    .enum([`title-alt`, `alt-title`, `title`, `alt`, `filename`, `none`])
+    .optional()
+    .default(`alt`)
+    .describe(`Image caption format. Use list_legend_formats for options.`),
+  isMacCodeBlock: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(`Whether to render code blocks with a macOS-style title bar.`),
+  isShowLineNumber: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(`Whether to show line numbers in code blocks.`),
+  citeStatus: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(`Whether to render links as bottom citations (footnote style).`),
+  countStatus: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(`Whether to prepend a reading-time estimate to the document.`),
+  themeMode: z
+    .enum([`light`, `dark`])
+    .optional()
+    .default(`light`)
+    .describe(`Colour mode used by diagram extensions (e.g. Mermaid, infographic).`),
+  isUseIndent: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(`Whether to indent paragraph first lines (text-indent: 2em).`),
+  isUseJustify: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(`Whether to justify paragraph text (text-align: justify).`),
+  headingStyles: z
+    .object({
+      h1: headingStyleEnum.optional(),
+      h2: headingStyleEnum.optional(),
+      h3: headingStyleEnum.optional(),
+      h4: headingStyleEnum.optional(),
+      h5: headingStyleEnum.optional(),
+      h6: headingStyleEnum.optional(),
+    })
+    .optional()
+    .describe(`Per-level heading style presets. Use list_heading_styles for options.`),
+  codeBlockTheme: z
+    .string()
+    .url()
+    .optional()
+    .describe(
+      `URL of a highlight.js theme stylesheet for code blocks. `
+      + `Use list_code_block_themes for presets. Defaults to the GitHub theme.`,
+    ),
+  customCSS: z
+    .string()
+    .optional()
+    .describe(`Additional custom CSS appended after theme styles (highest priority).`),
 }
 
-const baseCSSContent = loadCSSFile(`base.css`)
-const themeMap: Record<string, string> = {
-  default: loadCSSFile(`default.css`),
-  grace: loadCSSFile(`grace.css`),
-  simple: loadCSSFile(`simple.css`),
+function jsonText(data: unknown) {
+  return {
+    content: [{ type: `text` as const, text: JSON.stringify(data) }],
+  }
 }
-
-// ---------------------------------------------------------------------------
-// Server initialisation
-// ---------------------------------------------------------------------------
 
 const server = new McpServer({
   name: `md-mcp-server`,
-  version: `2.1.0`,
+  version: `2.1.1`,
 })
-
-// ---------------------------------------------------------------------------
-// Tool: render_markdown
-// ---------------------------------------------------------------------------
 
 server.registerTool(
   `render_markdown`,
@@ -92,94 +128,13 @@ server.registerTool(
       + `The output is ready to be used in WeChat Official Accounts (公众号) and other platforms. `
       + `Supports standard Markdown plus: KaTeX math, Mermaid diagrams, PlantUML, footnotes, alerts, `
       + `ruby annotations, sliders, and table-of-contents.`,
-    inputSchema: {
-      markdown: z.string().describe(`The Markdown source text to render.`),
-      theme: z
-        .enum([`default`, `grace`, `simple`])
-        .optional()
-        .default(`default`)
-        .describe(`Visual theme to apply. One of: default (经典), grace (优雅), simple (简洁).`),
-      primaryColor: z
-        .string()
-        .regex(/^#[0-9A-F]{6}$/i, `Must be a valid 6-digit hex color`)
-        .optional()
-        .default(`#0F4C81`)
-        .describe(
-          `Primary accent color (hex). Use list_colors to see presets. Default: #0F4C81 (经典蓝). `
-          + `This color is applied via CSS variable --md-primary-color and affects headings, links, alerts, etc.`,
-        ),
-      isMacCodeBlock: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(`Whether to render code blocks with a macOS-style title bar.`),
-      isShowLineNumber: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(`Whether to show line numbers in code blocks.`),
-      citeStatus: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(`Whether to render links as bottom citations (footnote style).`),
-      countStatus: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(`Whether to prepend a reading-time estimate to the document.`),
-      themeMode: z
-        .enum([`light`, `dark`])
-        .optional()
-        .default(`light`)
-        .describe(`Colour mode used by diagram extensions (e.g. Mermaid, infographic).`),
-    },
+    inputSchema: renderMarkdownInputSchema,
   },
-  (args) => {
-    const renderer = initRenderer({
-      isMacCodeBlock: args.isMacCodeBlock,
-      isShowLineNumber: args.isShowLineNumber,
-      citeStatus: args.citeStatus,
-      countStatus: args.countStatus,
-      themeMode: args.themeMode,
-    })
-
-    const { html: baseHtml, readingTime } = renderMarkdown(args.markdown, renderer)
-    let processedHtml = postProcessHtml(baseHtml, readingTime, renderer)
-
-    // Inject theme CSS + primaryColor CSS variable into the output
-    const themeCSS = themeMap[args.theme as ThemeName] || themeMap.default
-    const variablesCSS = generateCSSVariables({
-      primaryColor: args.primaryColor,
-      fontFamily: `-apple-system-font,BlinkMacSystemFont,Helvetica Neue,PingFang SC,Hiragino Sans GB,Microsoft YaHei UI,Microsoft YaHei,Arial,sans-serif`,
-      fontSize: `16px`,
-    })
-    processedHtml = `<style>\n${variablesCSS}\n\n${baseCSSContent}\n\n${themeCSS}\n</style>\n${processedHtml}`
-
-    const containerHtml = renderer.createContainer(processedHtml)
-    const { yamlData } = renderer.parseFrontMatterAndContent(args.markdown)
-
-    return {
-      content: [
-        {
-          type: `text`,
-          text: JSON.stringify({
-            html: containerHtml,
-            frontMatter: yamlData,
-            readingTime: {
-              words: readingTime.words,
-              minutes: readingTime.minutes,
-            },
-          }),
-        },
-      ],
-    }
+  async (args) => {
+    const result = await buildRenderedOutput(args)
+    return jsonText(result)
   },
 )
-
-// ---------------------------------------------------------------------------
-// Tool: list_themes
-// ---------------------------------------------------------------------------
 
 server.registerTool(
   `list_themes`,
@@ -188,27 +143,14 @@ server.registerTool(
       `List all available visual themes for the doocs/md Markdown editor. `
       + `Each theme changes colours, typography, and spacing of the rendered output.`,
   },
-  () => {
-    const themes = themeOptions.map(t => ({
+  () => jsonText({
+    themes: themeOptions.map(t => ({
       value: t.value,
       label: t.label,
       author: t.desc || `official`,
-    }))
-
-    return {
-      content: [
-        {
-          type: `text`,
-          text: JSON.stringify({ themes }),
-        },
-      ],
-    }
-  },
+    })),
+  }),
 )
-
-// ---------------------------------------------------------------------------
-// Tool: list_colors
-// ---------------------------------------------------------------------------
 
 server.registerTool(
   `list_colors`,
@@ -218,27 +160,85 @@ server.registerTool(
       + `Each color is applied via CSS variable --md-primary-color and affects headings, links, alerts, etc. `
       + `You can also pass any custom hex color string directly to render_markdown.`,
   },
-  () => {
-    const colors = colorOptions.map(c => ({
+  () => jsonText({
+    colors: colorOptions.map(c => ({
       value: c.value,
       label: c.label,
       description: c.desc,
-    }))
-
-    return {
-      content: [
-        {
-          type: `text`,
-          text: JSON.stringify({ colors }),
-        },
-      ],
-    }
-  },
+    })),
+  }),
 )
 
-// ---------------------------------------------------------------------------
-// Tool: list_ai_services
-// ---------------------------------------------------------------------------
+server.registerTool(
+  `list_fonts`,
+  {
+    description: `List preset font family options for render_markdown.`,
+  },
+  () => jsonText({
+    fonts: fontFamilyOptions.map(f => ({
+      label: f.label,
+      value: f.value,
+      description: f.desc,
+    })),
+  }),
+)
+
+server.registerTool(
+  `list_font_sizes`,
+  {
+    description: `List preset font size options for render_markdown.`,
+  },
+  () => jsonText({
+    fontSizes: fontSizeOptions.map(f => ({
+      label: f.label,
+      value: f.value,
+      description: f.desc,
+    })),
+  }),
+)
+
+server.registerTool(
+  `list_legend_formats`,
+  {
+    description: `List image caption (legend) format options for render_markdown.`,
+  },
+  () => jsonText({
+    legendFormats: legendOptions.map(l => ({
+      label: l.label,
+      value: l.value,
+      description: l.desc,
+    })),
+  }),
+)
+
+server.registerTool(
+  `list_heading_styles`,
+  {
+    description: `List heading style presets usable in render_markdown headingStyles.`,
+  },
+  () => jsonText({
+    headingStyles: headingStyleOptions.map(h => ({
+      label: h.label,
+      value: h.value,
+      description: h.desc,
+    })),
+    levels: [`h1`, `h2`, `h3`, `h4`, `h5`, `h6`],
+  }),
+)
+
+server.registerTool(
+  `list_code_block_themes`,
+  {
+    description: `List highlight.js code block theme URLs for render_markdown.`,
+  },
+  () => jsonText({
+    codeBlockThemes: codeBlockThemeOptions.map(t => ({
+      label: t.label,
+      value: t.value,
+      description: t.desc,
+    })),
+  }),
+)
 
 server.registerTool(
   `list_ai_services`,
@@ -248,28 +248,15 @@ server.registerTool(
       + `Each entry includes the provider name, OpenAI-compatible endpoint URL, and available models. `
       + `Use this to help users pick the right AI service and model.`,
   },
-  () => {
-    const services = serviceOptions.map(svc => ({
+  () => jsonText({
+    services: serviceOptions.map(svc => ({
       value: svc.value,
       label: svc.label,
       endpoint: svc.endpoint,
       models: svc.models,
-    }))
-
-    return {
-      content: [
-        {
-          type: `text`,
-          text: JSON.stringify({ services }),
-        },
-      ],
-    }
-  },
+    })),
+  }),
 )
-
-// ---------------------------------------------------------------------------
-// Tool: explain_extensions
-// ---------------------------------------------------------------------------
 
 server.registerTool(
   `explain_extensions`,
@@ -278,8 +265,8 @@ server.registerTool(
       `Describe all Markdown extensions supported by doocs/md beyond standard CommonMark. `
       + `Returns the extension name, a description, and a usage example for each.`,
   },
-  () => {
-    const extensions = [
+  () => jsonText({
+    extensions: [
       {
         name: `KaTeX Math`,
         description: `Inline and block LaTeX math expressions rendered via KaTeX.`,
@@ -331,22 +318,9 @@ server.registerTool(
         description: `Horizontal scroll slider blocks for narrow viewports.`,
         example: `<<< slide content >>>`,
       },
-    ]
-
-    return {
-      content: [
-        {
-          type: `text`,
-          text: JSON.stringify({ extensions }),
-        },
-      ],
-    }
-  },
+    ],
+  }),
 )
-
-// ---------------------------------------------------------------------------
-// Tool: get_renderer_options
-// ---------------------------------------------------------------------------
 
 server.registerTool(
   `get_renderer_options`,
@@ -355,71 +329,30 @@ server.registerTool(
       `Describe every configuration option accepted by the doocs/md renderer. `
       + `Use this to understand what parameters are available when calling render_markdown.`,
   },
-  () => {
-    const rendererOptions = [
-      {
-        name: `theme`,
-        type: `'default' | 'grace' | 'simple'`,
-        default: `default`,
-        description: `Visual theme that controls overall typography, spacing, and color palette.`,
-      },
-      {
-        name: `primaryColor`,
-        type: `string (hex)`,
-        default: `#0F4C81`,
-        description: `Primary accent color applied via --md-primary-color. Affects headings, links, alert accents, etc. Use list_colors to see presets, or pass any hex value.`,
-      },
-      {
-        name: `isMacCodeBlock`,
-        type: `boolean`,
-        default: false,
-        description: `Render code blocks with a macOS-style traffic-light title bar.`,
-      },
-      {
-        name: `isShowLineNumber`,
-        type: `boolean`,
-        default: false,
-        description: `Show line numbers inside code blocks.`,
-      },
-      {
-        name: `citeStatus`,
-        type: `boolean`,
-        default: false,
-        description: `Convert hyperlinks to inline citations with footnote-style references at the bottom.`,
-      },
-      {
-        name: `countStatus`,
-        type: `boolean`,
-        default: false,
-        description: `Prepend a reading-time estimate (word count + minutes) before the document body.`,
-      },
-      {
-        name: `themeMode`,
-        type: `'light' | 'dark'`,
-        default: `light`,
-        description: `Colour mode used by diagram extensions (e.g. Mermaid, infographic).`,
-      },
-    ]
-
-    return {
-      content: [
-        {
-          type: `text`,
-          text: JSON.stringify({ options: rendererOptions }),
-        },
-      ],
-    }
-  },
+  () => jsonText({
+    options: [
+      { name: `theme`, type: `'default' | 'grace' | 'simple'`, default: `default`, description: `Visual theme.` },
+      { name: `primaryColor`, type: `string (hex)`, default: `#0F4C81`, description: `Primary accent color via --md-primary-color.` },
+      { name: `fontFamily`, type: `string`, default: `system sans-serif stack`, description: `CSS font-family. See list_fonts.` },
+      { name: `fontSize`, type: `string (px)`, default: `16px`, description: `Base font size. See list_font_sizes.` },
+      { name: `legend`, type: `'title-alt' | 'alt-title' | 'title' | 'alt' | 'filename' | 'none'`, default: `alt`, description: `Image caption format.` },
+      { name: `isMacCodeBlock`, type: `boolean`, default: false, description: `macOS-style code block title bar.` },
+      { name: `isShowLineNumber`, type: `boolean`, default: false, description: `Line numbers in code blocks.` },
+      { name: `citeStatus`, type: `boolean`, default: false, description: `Links as footnote-style citations.` },
+      { name: `countStatus`, type: `boolean`, default: false, description: `Prepend reading-time estimate.` },
+      { name: `themeMode`, type: `'light' | 'dark'`, default: `light`, description: `Diagram colour mode.` },
+      { name: `isUseIndent`, type: `boolean`, default: false, description: `Paragraph first-line indent.` },
+      { name: `isUseJustify`, type: `boolean`, default: false, description: `Justified paragraph text.` },
+      { name: `headingStyles`, type: `object`, default: `{}`, description: `Per-level heading styles. See list_heading_styles.` },
+      { name: `codeBlockTheme`, type: `string (url)`, default: `github.min.css`, description: `highlight.js theme URL.` },
+      { name: `customCSS`, type: `string`, default: `''`, description: `User custom CSS appended last.` },
+    ],
+  }),
 )
-
-// ---------------------------------------------------------------------------
-// Start server on stdio
-// ---------------------------------------------------------------------------
 
 async function main() {
   const transport = new StdioServerTransport()
   await server.connect(transport)
-  // MCP servers must not write anything to stdout except JSON-RPC messages.
   process.stderr.write(`[md-mcp-server] running on stdio\n`)
 }
 

--- a/packages/mcp-server/src/render-article.ts
+++ b/packages/mcp-server/src/render-article.ts
@@ -1,0 +1,137 @@
+import type { ThemeName } from '@md/shared/configs'
+import type { HeadingStyles } from '@md/shared/configs/style'
+import type { HeadingStylesInput, LegendValue } from './config-options'
+import fs from 'node:fs'
+import path from 'node:path'
+import { initRenderer } from '@md/core/renderer'
+import { processCSS } from '@md/core/theme/cssProcessor'
+import { generateCSSVariables, generateHeadingStyles } from '@md/core/theme/cssVariables'
+import { postProcessHtml, renderMarkdown } from '@md/core/utils'
+import {
+  defaultRenderOptions,
+
+} from './config-options'
+
+export interface RenderMarkdownInput {
+  markdown: string
+  theme?: ThemeName
+  primaryColor?: string
+  fontFamily?: string
+  fontSize?: string
+  legend?: LegendValue
+  isMacCodeBlock?: boolean
+  isShowLineNumber?: boolean
+  citeStatus?: boolean
+  countStatus?: boolean
+  themeMode?: 'light' | 'dark'
+  isUseIndent?: boolean
+  isUseJustify?: boolean
+  headingStyles?: HeadingStylesInput
+  codeBlockTheme?: string
+  customCSS?: string
+}
+
+const themeDir = path.resolve(import.meta.dirname, `../../shared/src/configs/theme-css`)
+
+function loadCSSFile(filename: string): string {
+  return fs.readFileSync(path.join(themeDir, filename), `utf-8`)
+}
+
+const baseCSSContent = loadCSSFile(`base.css`)
+const themeMap: Record<string, string> = {
+  default: loadCSSFile(`default.css`),
+  grace: loadCSSFile(`grace.css`),
+  simple: loadCSSFile(`simple.css`),
+}
+
+const hljsCssCache = new Map<string, string>()
+
+export async function fetchCodeBlockCSS(url: string): Promise<string> {
+  const cached = hljsCssCache.get(url)
+  if (cached)
+    return cached
+
+  const response = await fetch(url)
+  if (!response.ok)
+    throw new Error(`Failed to fetch code block theme CSS (${response.status}): ${url}`)
+
+  const css = await response.text()
+  hljsCssCache.set(url, css)
+  return css
+}
+
+function normalizeHeadingStyles(input?: HeadingStylesInput): HeadingStyles | undefined {
+  if (!input)
+    return undefined
+
+  const normalized: HeadingStyles = {}
+  for (const [level, style] of Object.entries(input)) {
+    if (style && style !== `default`)
+      normalized[level as keyof HeadingStyles] = style
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+export async function buildRenderedOutput(input: RenderMarkdownInput) {
+  const theme = input.theme ?? defaultRenderOptions.theme
+  const primaryColor = input.primaryColor ?? defaultRenderOptions.primaryColor
+  const fontFamily = input.fontFamily ?? defaultRenderOptions.fontFamily
+  const fontSize = input.fontSize ?? defaultRenderOptions.fontSize
+  const legend = input.legend ?? defaultRenderOptions.legend
+  const codeBlockTheme = input.codeBlockTheme ?? defaultRenderOptions.codeBlockTheme
+  const headingStyles = normalizeHeadingStyles(input.headingStyles)
+
+  const renderer = initRenderer({
+    isMacCodeBlock: input.isMacCodeBlock ?? defaultRenderOptions.isMacCodeBlock,
+    isShowLineNumber: input.isShowLineNumber ?? defaultRenderOptions.isShowLineNumber,
+    citeStatus: input.citeStatus ?? defaultRenderOptions.citeStatus,
+    countStatus: input.countStatus ?? defaultRenderOptions.countStatus,
+    themeMode: input.themeMode ?? defaultRenderOptions.themeMode,
+    legend,
+  })
+
+  const { html: baseHtml, readingTime } = renderMarkdown(input.markdown, renderer)
+  const processedHtml = postProcessHtml(baseHtml, readingTime, renderer)
+  const { yamlData } = renderer.parseFrontMatterAndContent(input.markdown)
+
+  const cssConfig = {
+    primaryColor,
+    fontFamily,
+    fontSize,
+    isUseIndent: input.isUseIndent ?? defaultRenderOptions.isUseIndent,
+    isUseJustify: input.isUseJustify ?? defaultRenderOptions.isUseJustify,
+    headingStyles,
+  }
+
+  const variablesCSS = generateCSSVariables(cssConfig)
+  const headingStylesCSS = generateHeadingStyles(cssConfig)
+  const themeCSS = themeMap[theme] || themeMap.default
+  const hljsCSS = codeBlockTheme ? await fetchCodeBlockCSS(codeBlockTheme) : ``
+  const customCSS = input.customCSS?.trim() ?? ``
+
+  let mergedCSS = [
+    variablesCSS,
+    baseCSSContent,
+    themeCSS,
+    headingStylesCSS,
+    hljsCSS,
+    customCSS,
+  ].filter(Boolean).join(`\n\n`)
+
+  mergedCSS = processCSS(mergedCSS)
+
+  const html = `<style>\n${mergedCSS}\n</style>\n${processedHtml}`
+
+  return {
+    html,
+    frontMatter: yamlData,
+    readingTime: {
+      words: readingTime.words,
+      minutes: readingTime.minutes,
+    },
+  }
+}
+
+export function clearHljsCssCache() {
+  hljsCssCache.clear()
+}

--- a/packages/mcp-server/src/render-article.ts
+++ b/packages/mcp-server/src/render-article.ts
@@ -8,9 +8,11 @@ import { processCSS } from '@md/core/theme/cssProcessor'
 import { generateCSSVariables, generateHeadingStyles } from '@md/core/theme/cssVariables'
 import { postProcessHtml, renderMarkdown } from '@md/core/utils'
 import {
+  assertAllowedCodeBlockThemeUrl,
   defaultRenderOptions,
-
 } from './config-options'
+
+const CODE_BLOCK_FETCH_TIMEOUT_MS = 10_000
 
 export interface RenderMarkdownInput {
   markdown: string
@@ -33,8 +35,20 @@ export interface RenderMarkdownInput {
 
 const themeDir = path.resolve(import.meta.dirname, `../../shared/src/configs/theme-css`)
 
+function escapeStyleContent(css: string): string {
+  return css.replace(/<\/style/gi, `<\\/style`)
+}
+
 function loadCSSFile(filename: string): string {
-  return fs.readFileSync(path.join(themeDir, filename), `utf-8`)
+  try {
+    return fs.readFileSync(path.join(themeDir, filename), `utf-8`)
+  }
+  catch (err) {
+    throw new Error(
+      `[md-mcp-server] Failed to load CSS file: ${filename}. Ensure the monorepo source structure is intact.`,
+      { cause: err },
+    )
+  }
 }
 
 const baseCSSContent = loadCSSFile(`base.css`)
@@ -47,17 +61,32 @@ const themeMap: Record<string, string> = {
 const hljsCssCache = new Map<string, string>()
 
 export async function fetchCodeBlockCSS(url: string): Promise<string> {
+  assertAllowedCodeBlockThemeUrl(url)
+
   const cached = hljsCssCache.get(url)
   if (cached)
     return cached
 
-  const response = await fetch(url)
-  if (!response.ok)
-    throw new Error(`Failed to fetch code block theme CSS (${response.status}): ${url}`)
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(CODE_BLOCK_FETCH_TIMEOUT_MS),
+    })
+    if (!response.ok)
+      throw new Error(`Failed to fetch code block theme CSS (${response.status}): ${url}`)
 
-  const css = await response.text()
-  hljsCssCache.set(url, css)
-  return css
+    const css = escapeStyleContent(await response.text())
+    hljsCssCache.set(url, css)
+    return css
+  }
+  catch (err) {
+    if (err instanceof Error && err.name === `TimeoutError`) {
+      throw new Error(
+        `Timed out fetching code block theme CSS after ${CODE_BLOCK_FETCH_TIMEOUT_MS}ms: ${url}`,
+        { cause: err },
+      )
+    }
+    throw err
+  }
 }
 
 function normalizeHeadingStyles(input?: HeadingStylesInput): HeadingStyles | undefined {
@@ -107,7 +136,7 @@ export async function buildRenderedOutput(input: RenderMarkdownInput) {
   const headingStylesCSS = generateHeadingStyles(cssConfig)
   const themeCSS = themeMap[theme] || themeMap.default
   const hljsCSS = codeBlockTheme ? await fetchCodeBlockCSS(codeBlockTheme) : ``
-  const customCSS = input.customCSS?.trim() ?? ``
+  const customCSS = escapeStyleContent(input.customCSS?.trim() ?? ``)
 
   let mergedCSS = [
     variablesCSS,


### PR DESCRIPTION
## Summary

- Expand `render_markdown` with web-editor parity options: font family/size, legend, paragraph indent/justify, heading styles, code block theme (hljs CSS inlined), and custom CSS
- Refactor MCP server into `config-options.ts` and `render-article.ts`; fix double container wrapping in HTML output
- Add five discovery tools: `list_fonts`, `list_font_sizes`, `list_legend_formats`, `list_heading_styles`, `list_code_block_themes`
- Ship `.cursor/mcp.json` for Cursor IDE integration and update docs (`README.md`, `AGENTS.md`)
- Bump `@md/mcp-server` version to `2.1.1`

## Related Issue

Closes #880

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] Manually verified MCP stdio connection and tool calls (`list_themes`, `render_markdown`, `get_renderer_options`)
- [x] Verified rendered HTML includes theme CSS, typography options, and inlined hljs styles
- [x] ESLint passed via pre-commit hook

## Pre-flight Checklist

- [x] Changes are focused on MCP server enhancements
- [x] No secrets committed
- [x] Documentation updated for new tools and Cursor setup
