### PR TITLE
feat(sync): add cloud sync with worker backend and status UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,18 @@
 
 ## Monorepo 结构
 
-| 工作区           | 路径                  | 说明                                              |
-| ---------------- | --------------------- | ------------------------------------------------- |
-| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox） |
-| (无名)           | `apps/vscode`         | VSCode 扩展（webpack 构建）                       |
-| (无名)           | `apps/utools`         | uTools 插件打包                                   |
-| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）     |
-| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置              |
-| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                           |
-| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）              |
-| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                    |
-| (无名)           | `packages/example`    | Cloudflare Workers 示例                           |
+| 工作区            | 路径                  | 说明                                              |
+| ----------------- | --------------------- | ------------------------------------------------- |
+| `@md/web`         | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox） |
+| (无名)            | `apps/vscode`         | VSCode 扩展（webpack 构建）                       |
+| (无名)            | `apps/utools`         | uTools 插件打包                                   |
+| `@md/core`        | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）     |
+| `@md/shared`      | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置              |
+| `@md/config`      | `packages/config`     | TypeScript 配置基础文件                           |
+| `@doocs/md-cli`   | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）              |
+| `@md/mcp-server`  | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                    |
+| `@md/sync-worker` | `apps/sync-worker`    | 云同步后端（Cloudflare Workers + Hono + D1）      |
+| (无名)            | `packages/example`    | Cloudflare Workers 示例                           |
 
 ## 常用命令
 

--- a/apps/sync-worker/README.md
+++ b/apps/sync-worker/README.md
@@ -1,0 +1,81 @@
+# @md/sync-worker
+
+doocs/md 的云同步后端，基于 **Cloudflare Workers + Hono + D1**，提供 GitHub 登录与文章/偏好的增量同步。
+
+## 能力
+
+- GitHub OAuth 登录，签发自有 JWT（HS256，有效期 30 天）
+- 文章与偏好设置的增量同步（`/sync/pull`、`/sync/push`）
+- 冲突策略：**last-write-wins**（按 `updateDatetime`），软删除墓碑保证删除可传播
+- 数据范围：文章（含 history）+ 偏好白名单；**不包含图床密钥、AI 密钥**
+
+## 数据流
+
+```
+前端 ──Bearer JWT──> Worker ──> D1 (users / documents / settings)
+```
+
+- `GET  /auth/github` 跳转 GitHub 授权
+- `GET  /auth/github/callback` 回调，签发 JWT 后回跳前端（token 在 URL fragment）
+- `GET  /me` 当前用户
+- `GET  /sync/pull?since=<ms>` 拉取游标之后的变更
+- `POST /sync/push` 推送本地变更（LWW 合并）
+
+## 部署步骤
+
+### 1. 创建 D1 数据库
+
+```bash
+pnpm sync exec wrangler d1 create md-sync
+```
+
+把输出的 `database_id` 填入 [`wrangler.toml`](./wrangler.toml) 的 `database_id`。
+
+### 2. 执行迁移
+
+```bash
+pnpm sync db:migrate:local    # 本地开发库
+pnpm sync db:migrate:remote   # 生产库
+```
+
+### 3. 配置 GitHub OAuth App
+
+在 GitHub → Settings → Developer settings → OAuth Apps 新建应用：
+
+- **Authorization callback URL**：`https://<your-worker-domain>/auth/github/callback`
+  （本地开发：`http://localhost:8787/auth/github/callback`）
+
+### 4. 设置密钥与变量
+
+```bash
+pnpm sync exec wrangler secret put GITHUB_CLIENT_ID
+pnpm sync exec wrangler secret put GITHUB_CLIENT_SECRET
+pnpm sync exec wrangler secret put JWT_SECRET     # 任意高强度随机串
+```
+
+`APP_URL`（前端地址，CORS 白名单 + 登录回跳，多个用英文逗号分隔）在
+[`wrangler.toml`](./wrangler.toml) 的 `[vars]` 中配置，例如 `https://md.doocs.org`。
+
+### 5. 本地运行 / 部署
+
+```bash
+pnpm sync dev      # 本地 http://localhost:8787
+pnpm sync deploy   # 部署到 Cloudflare
+```
+
+### 6. 前端接入
+
+在 `apps/web/.env`（参考 [`apps/web/.env.example`](../web/.env.example)）设置：
+
+```
+VITE_SYNC_API_URL=https://<your-worker-domain>
+```
+
+前端顶栏会出现云图标入口；登录后即可手动 / 自动同步。
+
+## 说明与限制
+
+- 前端约定「先 pull 再 push」，`push` 仅返回本次被接受的记录与新游标。
+- 偏好设置应用到本地后需刷新页面生效（前端会给出提示），文章为即时生效。
+- 同步白名单见 `apps/web/src/services/sync/settings.ts`，新增可同步项请在此维护，
+  切勿加入任何密钥类字段。

--- a/apps/sync-worker/migrations/0001_init.sql
+++ b/apps/sync-worker/migrations/0001_init.sql
@@ -1,0 +1,40 @@
+-- 用户表：通过 GitHub OAuth 创建
+CREATE TABLE IF NOT EXISTS users (
+  id           TEXT PRIMARY KEY,           -- 内部用户 id（uuid）
+  github_id    INTEGER NOT NULL UNIQUE,    -- GitHub 数字 id
+  login        TEXT NOT NULL,              -- GitHub 用户名
+  name         TEXT,
+  avatar       TEXT,
+  created_at   INTEGER NOT NULL            -- epoch ms
+);
+
+-- 文档表：与前端 Post 一一对应
+CREATE TABLE IF NOT EXISTS documents (
+  user_id           TEXT NOT NULL,
+  id                TEXT NOT NULL,         -- = 前端 post.id
+  title             TEXT NOT NULL DEFAULT '',
+  content           TEXT NOT NULL DEFAULT '',
+  parent_id         TEXT,
+  history           TEXT NOT NULL DEFAULT '[]', -- JSON 数组
+  create_datetime   INTEGER NOT NULL,      -- epoch ms
+  update_datetime   INTEGER NOT NULL,      -- epoch ms，LWW 依据
+  deleted           INTEGER NOT NULL DEFAULT 0, -- 软删除
+  server_updated_at INTEGER NOT NULL,      -- epoch ms，增量同步游标
+  PRIMARY KEY (user_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_documents_cursor
+  ON documents (user_id, server_updated_at);
+
+-- 设置表：同步白名单内的偏好项（不含图床密钥）
+CREATE TABLE IF NOT EXISTS settings (
+  user_id           TEXT NOT NULL,
+  key               TEXT NOT NULL,
+  value             TEXT NOT NULL,         -- JSON 字符串
+  updated_at        INTEGER NOT NULL,      -- epoch ms，LWW 依据
+  server_updated_at INTEGER NOT NULL,      -- epoch ms，增量同步游标
+  PRIMARY KEY (user_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_settings_cursor
+  ON settings (user_id, server_updated_at);

--- a/apps/sync-worker/package.json
+++ b/apps/sync-worker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@md/sync-worker",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloud sync backend for doocs/md – Cloudflare Worker (Hono + D1) with GitHub OAuth",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy --minify",
+    "db:migrate:local": "wrangler d1 migrations apply md-sync --local",
+    "db:migrate:remote": "wrangler d1 migrations apply md-sync --remote",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "4.20260610.1",
+    "typescript": "~6.0.3",
+    "wrangler": "^4.99.0"
+  }
+}

--- a/apps/sync-worker/src/auth.ts
+++ b/apps/sync-worker/src/auth.ts
@@ -29,6 +29,8 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env, Variables: { use
 
   try {
     const payload = (await verify(token, c.env.JWT_SECRET, `HS256`)) as unknown as JwtPayload
+    if (!payload || typeof payload.sub !== `string` || !payload.sub)
+      return c.json({ error: `invalid_token` }, 401)
     c.set(`userId`, payload.sub)
     await next()
   }

--- a/apps/sync-worker/src/auth.ts
+++ b/apps/sync-worker/src/auth.ts
@@ -1,0 +1,144 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import type { Env, JwtPayload } from './types'
+import { Hono } from 'hono'
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
+import { sign, verify } from 'hono/jwt'
+import { getUserById, upsertUser } from './db'
+import { defaultOrigin, resolveRedirect } from './origin'
+
+const STATE_COOKIE = `md_oauth_state`
+const REDIRECT_COOKIE = `md_oauth_redirect`
+const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30 // 30 天
+
+function callbackUrl(c: Context): string {
+  const url = new URL(c.req.url)
+  return `${url.origin}/auth/github/callback`
+}
+
+export async function issueToken(env: Env, payload: { sub: string, login: string }): Promise<string> {
+  const exp = Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS
+  return sign({ ...payload, exp }, env.JWT_SECRET, `HS256`)
+}
+
+/** 鉴权中间件：校验 Bearer JWT，并把用户 id 写入 context */
+export const authMiddleware: MiddlewareHandler<{ Bindings: Env, Variables: { userId: string } }> = async (c, next) => {
+  const header = c.req.header(`Authorization`) ?? ``
+  const token = header.startsWith(`Bearer `) ? header.slice(7) : ``
+  if (!token)
+    return c.json({ error: `unauthorized` }, 401)
+
+  try {
+    const payload = (await verify(token, c.env.JWT_SECRET, `HS256`)) as unknown as JwtPayload
+    c.set(`userId`, payload.sub)
+    await next()
+  }
+  catch {
+    return c.json({ error: `invalid_token` }, 401)
+  }
+}
+
+export const authRoutes = new Hono<{ Bindings: Env }>()
+
+// 第一步：跳转到 GitHub 授权页
+authRoutes.get(`/github`, (c) => {
+  const state = crypto.randomUUID()
+  const isHttps = new URL(c.req.url).protocol === `https:`
+  const cookieOpts = {
+    httpOnly: true,
+    secure: isHttps,
+    sameSite: `Lax`,
+    path: `/`,
+    maxAge: 600,
+  } as const
+
+  setCookie(c, STATE_COOKIE, state, cookieOpts)
+
+  // 记录发起登录的前端来源（校验后），授权完成后跳回它
+  const redirect = resolveRedirect(c.env, c.req.query(`redirect`))
+  setCookie(c, REDIRECT_COOKIE, redirect, cookieOpts)
+
+  const authorize = new URL(`https://github.com/login/oauth/authorize`)
+  authorize.searchParams.set(`client_id`, c.env.GITHUB_CLIENT_ID)
+  authorize.searchParams.set(`redirect_uri`, callbackUrl(c))
+  authorize.searchParams.set(`scope`, `read:user`)
+  authorize.searchParams.set(`state`, state)
+  return c.redirect(authorize.toString())
+})
+
+// 第二步：GitHub 回调，换取 token 并签发自有 JWT，回跳前端
+authRoutes.get(`/github/callback`, async (c) => {
+  const code = c.req.query(`code`)
+  const state = c.req.query(`state`)
+  const savedState = getCookie(c, STATE_COOKIE)
+  const savedRedirect = getCookie(c, REDIRECT_COOKIE)
+  deleteCookie(c, STATE_COOKIE, { path: `/` })
+  deleteCookie(c, REDIRECT_COOKIE, { path: `/` })
+
+  if (!code || !state || state !== savedState)
+    return c.json({ error: `invalid_oauth_state` }, 400)
+
+  // 用 code 换 access_token
+  const tokenRes = await fetch(`https://github.com/login/oauth/access_token`, {
+    method: `POST`,
+    headers: { 'Accept': `application/json`, 'Content-Type': `application/json` },
+    body: JSON.stringify({
+      client_id: c.env.GITHUB_CLIENT_ID,
+      client_secret: c.env.GITHUB_CLIENT_SECRET,
+      code,
+      redirect_uri: callbackUrl(c),
+    }),
+  })
+  const tokenJson = await tokenRes.json<{ access_token?: string }>()
+  const accessToken = tokenJson.access_token
+  if (!accessToken)
+    return c.json({ error: `oauth_exchange_failed` }, 400)
+
+  // 拉取用户信息（GitHub 要求 User-Agent）
+  const userRes = await fetch(`https://api.github.com/user`, {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'User-Agent': `md-sync-worker`,
+      'Accept': `application/vnd.github+json`,
+    },
+  })
+  if (!userRes.ok)
+    return c.json({ error: `github_user_fetch_failed` }, 400)
+
+  const gh = await userRes.json<{ id: number, login: string, name: string | null, avatar_url: string | null }>()
+
+  // upsert 用户
+  const existing = await c.env.DB
+    .prepare(`SELECT id FROM users WHERE github_id = ?`)
+    .bind(gh.id)
+    .first<{ id: string }>()
+  const userId = existing?.id ?? crypto.randomUUID()
+
+  await upsertUser(c.env.DB, {
+    id: userId,
+    githubId: gh.id,
+    login: gh.login,
+    name: gh.name,
+    avatar: gh.avatar_url,
+  })
+
+  const token = await issueToken(c.env, { sub: userId, login: gh.login })
+
+  // 回跳到发起登录的前端来源（再次校验），token 放在 fragment，避免进入服务端日志
+  const target = resolveRedirect(c.env, savedRedirect)
+  const redirect = new URL(target || defaultOrigin(c.env))
+  redirect.hash = `sync_token=${token}`
+  return c.redirect(redirect.toString())
+})
+
+// 当前用户信息
+export async function meHandler(c: Context<{ Bindings: Env, Variables: { userId: string } }>) {
+  const user = await getUserById(c.env.DB, c.get(`userId`))
+  if (!user)
+    return c.json({ error: `not_found` }, 404)
+  return c.json({
+    id: user.id,
+    login: user.login,
+    name: user.name,
+    avatar: user.avatar,
+  })
+}

--- a/apps/sync-worker/src/db.ts
+++ b/apps/sync-worker/src/db.ts
@@ -40,9 +40,15 @@ function rowToDocument(row: DocumentRow): SyncDocument {
 }
 
 function rowToSetting(row: SettingRow): SyncSetting {
-  let value: unknown = null
+  // 与前端契约一致：value 仅可能是 string | null。
+  // DB 存的是 JSON.stringify 后的字符串，非字符串结果（异常数据）一律回退。
+  let value: string | null = null
   try {
-    value = JSON.parse(row.value)
+    const parsed = JSON.parse(row.value)
+    if (typeof parsed === `string`)
+      value = parsed
+    else if (parsed != null)
+      value = JSON.stringify(parsed)
   }
   catch {
     value = null

--- a/apps/sync-worker/src/db.ts
+++ b/apps/sync-worker/src/db.ts
@@ -1,0 +1,189 @@
+import type { Env, SyncDocument, SyncSetting, UserRow } from './types'
+
+interface DocumentRow {
+  id: string
+  title: string
+  content: string
+  parent_id: string | null
+  history: string
+  create_datetime: number
+  update_datetime: number
+  deleted: number
+  server_updated_at: number
+}
+
+interface SettingRow {
+  key: string
+  value: string
+  updated_at: number
+  server_updated_at: number
+}
+
+function rowToDocument(row: DocumentRow): SyncDocument {
+  let history: SyncDocument['history'] = []
+  try {
+    history = JSON.parse(row.history)
+  }
+  catch {
+    history = []
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    content: row.content,
+    parentId: row.parent_id,
+    history,
+    createDatetime: row.create_datetime,
+    updateDatetime: row.update_datetime,
+    deleted: row.deleted === 1,
+  }
+}
+
+function rowToSetting(row: SettingRow): SyncSetting {
+  let value: unknown = null
+  try {
+    value = JSON.parse(row.value)
+  }
+  catch {
+    value = null
+  }
+  return { key: row.key, value, updatedAt: row.updated_at }
+}
+
+export async function upsertUser(
+  db: D1Database,
+  user: { id: string, githubId: number, login: string, name: string | null, avatar: string | null },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, github_id, login, name, avatar, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(github_id) DO UPDATE SET
+         login = excluded.login,
+         name = excluded.name,
+         avatar = excluded.avatar`,
+    )
+    .bind(user.id, user.githubId, user.login, user.name, user.avatar, Date.now())
+    .run()
+}
+
+export async function getUserById(db: D1Database, id: string): Promise<UserRow | null> {
+  return db.prepare(`SELECT * FROM users WHERE id = ?`).bind(id).first<UserRow>()
+}
+
+/** 拉取 cursor 之后变更的文档与设置 */
+export async function pullChanges(
+  env: Env,
+  userId: string,
+  cursor: number,
+): Promise<{ documents: SyncDocument[], settings: SyncSetting[], maxCursor: number }> {
+  const docsResult = await env.DB
+    .prepare(
+      `SELECT id, title, content, parent_id, history, create_datetime, update_datetime, deleted, server_updated_at
+       FROM documents WHERE user_id = ? AND server_updated_at > ?
+       ORDER BY server_updated_at ASC`,
+    )
+    .bind(userId, cursor)
+    .all<DocumentRow>()
+
+  const settingsResult = await env.DB
+    .prepare(
+      `SELECT key, value, updated_at, server_updated_at
+       FROM settings WHERE user_id = ? AND server_updated_at > ?
+       ORDER BY server_updated_at ASC`,
+    )
+    .bind(userId, cursor)
+    .all<SettingRow>()
+
+  const docRows = docsResult.results ?? []
+  const settingRows = settingsResult.results ?? []
+
+  let maxCursor = cursor
+  for (const r of docRows) maxCursor = Math.max(maxCursor, r.server_updated_at)
+  for (const r of settingRows) maxCursor = Math.max(maxCursor, r.server_updated_at)
+
+  return {
+    documents: docRows.map(rowToDocument),
+    settings: settingRows.map(rowToSetting),
+    maxCursor,
+  }
+}
+
+/**
+ * 推入客户端变更，按 update_datetime 做 last-write-wins。
+ * 返回服务端最终更新过（即客户端较新）的记录，以及新游标。
+ */
+export async function pushChanges(
+  env: Env,
+  userId: string,
+  documents: SyncDocument[],
+  settings: SyncSetting[],
+): Promise<{ documents: SyncDocument[], settings: SyncSetting[], maxCursor: number }> {
+  const now = Date.now()
+
+  for (const doc of documents) {
+    const existing = await env.DB
+      .prepare(`SELECT update_datetime FROM documents WHERE user_id = ? AND id = ?`)
+      .bind(userId, doc.id)
+      .first<{ update_datetime: number }>()
+
+    // LWW：仅当客户端版本更新（或不存在）时写入
+    if (existing && existing.update_datetime >= doc.updateDatetime)
+      continue
+
+    await env.DB
+      .prepare(
+        `INSERT INTO documents
+           (user_id, id, title, content, parent_id, history, create_datetime, update_datetime, deleted, server_updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(user_id, id) DO UPDATE SET
+           title = excluded.title,
+           content = excluded.content,
+           parent_id = excluded.parent_id,
+           history = excluded.history,
+           update_datetime = excluded.update_datetime,
+           deleted = excluded.deleted,
+           server_updated_at = excluded.server_updated_at`,
+      )
+      .bind(
+        userId,
+        doc.id,
+        doc.title,
+        doc.content,
+        doc.parentId,
+        JSON.stringify(doc.history ?? []),
+        doc.createDatetime,
+        doc.updateDatetime,
+        doc.deleted ? 1 : 0,
+        now,
+      )
+      .run()
+  }
+
+  for (const setting of settings) {
+    const existing = await env.DB
+      .prepare(`SELECT updated_at FROM settings WHERE user_id = ? AND key = ?`)
+      .bind(userId, setting.key)
+      .first<{ updated_at: number }>()
+
+    if (existing && existing.updated_at >= setting.updatedAt)
+      continue
+
+    await env.DB
+      .prepare(
+        `INSERT INTO settings (user_id, key, value, updated_at, server_updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(user_id, key) DO UPDATE SET
+           value = excluded.value,
+           updated_at = excluded.updated_at,
+           server_updated_at = excluded.server_updated_at`,
+      )
+      .bind(userId, setting.key, JSON.stringify(setting.value ?? null), setting.updatedAt, now)
+      .run()
+  }
+
+  // 返回本次写入（被接受）的记录，并以服务端时钟作为新游标。
+  // 客户端约定先 pull 再 push，因此服务端较新的记录已在 pull 阶段下发。
+  const accepted = await pullChanges(env, userId, now - 1)
+  return { documents: accepted.documents, settings: accepted.settings, maxCursor: now }
+}

--- a/apps/sync-worker/src/index.ts
+++ b/apps/sync-worker/src/index.ts
@@ -1,0 +1,34 @@
+import type { Env } from './types'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { authMiddleware, authRoutes, meHandler } from './auth'
+import { isAllowedOrigin } from './origin'
+import { pullHandler, pushHandler } from './sync'
+
+const app = new Hono<{ Bindings: Env, Variables: { userId: string } }>()
+
+// CORS：允许 APP_URL 中配置的来源（支持通配符，逗号分隔）携带凭据访问
+app.use(`*`, async (c, next) => {
+  const handler = cors({
+    origin: origin => (isAllowedOrigin(c.env, origin) ? origin : null),
+    allowMethods: [`GET`, `POST`, `OPTIONS`],
+    allowHeaders: [`Authorization`, `Content-Type`],
+    credentials: true,
+    maxAge: 86400,
+  })
+  return handler(c, next)
+})
+
+app.get(`/`, c => c.json({ name: `md-sync`, ok: true }))
+
+app.route(`/auth`, authRoutes)
+
+const api = new Hono<{ Bindings: Env, Variables: { userId: string } }>()
+api.use(`*`, authMiddleware)
+api.get(`/me`, meHandler)
+api.get(`/sync/pull`, pullHandler)
+api.post(`/sync/push`, pushHandler)
+
+app.route(`/`, api)
+
+export default app

--- a/apps/sync-worker/src/origin.ts
+++ b/apps/sync-worker/src/origin.ts
@@ -39,9 +39,19 @@ export function defaultOrigin(env: Env): string {
   return patterns.find(p => !p.includes(`*`)) ?? patterns[0] ?? ``
 }
 
-/** 校验请求的回跳地址，合法则返回它，否则回退到默认地址 */
+/**
+ * 校验请求的回跳地址：解析其 origin 是否在白名单内，
+ * 合法则返回完整 URL（含 path），否则回退到默认地址。
+ * 兼容仅传 origin 的旧形式。
+ */
 export function resolveRedirect(env: Env, requested: string | undefined | null): string {
-  if (requested && isAllowedOrigin(env, requested))
-    return requested
+  if (requested) {
+    try {
+      const url = new URL(requested)
+      if (isAllowedOrigin(env, url.origin))
+        return url.toString()
+    }
+    catch { /* 非法 URL，回退默认 */ }
+  }
   return defaultOrigin(env)
 }

--- a/apps/sync-worker/src/origin.ts
+++ b/apps/sync-worker/src/origin.ts
@@ -1,0 +1,47 @@
+import type { Env } from './types'
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
+}
+
+/**
+ * 判断 origin 是否匹配某个模式。
+ * - 精确匹配：完全相等
+ * - 通配符 `*`：匹配单个主机标签（不含 `.` 与 `/`），可安全用于
+ *   预览子域名（如 `https://*--doocs-md.netlify.app`、`http://localhost:*`）
+ */
+export function matchPattern(origin: string, pattern: string): boolean {
+  if (!pattern)
+    return false
+  if (pattern === origin)
+    return true
+  if (!pattern.includes(`*`))
+    return false
+  const re = new RegExp(`^${pattern.split(`*`).map(escapeRegex).join(`[^./]+`)}$`)
+  return re.test(origin)
+}
+
+/** 解析 APP_URL（逗号分隔）为模式列表 */
+export function allowedPatterns(env: Env): string[] {
+  return env.APP_URL.split(`,`).map(s => s.trim()).filter(Boolean)
+}
+
+/** origin 是否在白名单内 */
+export function isAllowedOrigin(env: Env, origin: string | undefined | null): boolean {
+  if (!origin)
+    return false
+  return allowedPatterns(env).some(p => matchPattern(origin, p))
+}
+
+/** 默认回跳地址：取第一个不含通配符的模式，否则取第一个 */
+export function defaultOrigin(env: Env): string {
+  const patterns = allowedPatterns(env)
+  return patterns.find(p => !p.includes(`*`)) ?? patterns[0] ?? ``
+}
+
+/** 校验请求的回跳地址，合法则返回它，否则回退到默认地址 */
+export function resolveRedirect(env: Env, requested: string | undefined | null): string {
+  if (requested && isAllowedOrigin(env, requested))
+    return requested
+  return defaultOrigin(env)
+}

--- a/apps/sync-worker/src/sync.ts
+++ b/apps/sync-worker/src/sync.ts
@@ -1,0 +1,38 @@
+import type { Context } from 'hono'
+import type { Env, PushRequest } from './types'
+import { pullChanges, pushChanges } from './db'
+
+type SyncContext = Context<{ Bindings: Env, Variables: { userId: string } }>
+
+export async function pullHandler(c: SyncContext) {
+  const userId = c.get(`userId`)
+  const sinceRaw = c.req.query(`since`)
+  const since = Number.parseInt(sinceRaw ?? `0`, 10)
+  const cursor = Number.isFinite(since) && since > 0 ? since : 0
+
+  const { documents, settings, maxCursor } = await pullChanges(c.env, userId, cursor)
+  return c.json({ documents, settings, cursor: maxCursor })
+}
+
+export async function pushHandler(c: SyncContext) {
+  const userId = c.get(`userId`)
+
+  let body: PushRequest
+  try {
+    body = await c.req.json<PushRequest>()
+  }
+  catch {
+    return c.json({ error: `invalid_body` }, 400)
+  }
+
+  const documents = Array.isArray(body.documents) ? body.documents : []
+  const settings = Array.isArray(body.settings) ? body.settings : []
+
+  const { documents: mergedDocs, settings: mergedSettings, maxCursor } = await pushChanges(
+    c.env,
+    userId,
+    documents,
+    settings,
+  )
+  return c.json({ documents: mergedDocs, settings: mergedSettings, cursor: maxCursor })
+}

--- a/apps/sync-worker/src/types.ts
+++ b/apps/sync-worker/src/types.ts
@@ -1,0 +1,60 @@
+export interface Env {
+  DB: D1Database
+  GITHUB_CLIENT_ID: string
+  GITHUB_CLIENT_SECRET: string
+  JWT_SECRET: string
+  /** 前端地址，用于 OAuth 回跳与 CORS 白名单，多个用英文逗号分隔 */
+  APP_URL: string
+}
+
+export interface JwtPayload {
+  sub: string // 内部 user id
+  login: string
+  exp: number
+}
+
+export interface UserRow {
+  id: string
+  github_id: number
+  login: string
+  name: string | null
+  avatar: string | null
+  created_at: number
+}
+
+/** 同步用文档（前后端共享契约），时间字段统一为 epoch ms */
+export interface SyncDocument {
+  id: string
+  title: string
+  content: string
+  parentId: string | null
+  history: { datetime: string, content: string }[]
+  createDatetime: number
+  updateDatetime: number
+  deleted: boolean
+}
+
+/** 同步用设置项 */
+export interface SyncSetting {
+  key: string
+  value: unknown
+  updatedAt: number
+}
+
+export interface PullResponse {
+  documents: SyncDocument[]
+  settings: SyncSetting[]
+  cursor: number
+}
+
+export interface PushRequest {
+  documents?: SyncDocument[]
+  settings?: SyncSetting[]
+}
+
+export interface PushResponse {
+  /** 服务端合并后较新的文档（客户端需用其覆盖本地） */
+  documents: SyncDocument[]
+  settings: SyncSetting[]
+  cursor: number
+}

--- a/apps/sync-worker/src/types.ts
+++ b/apps/sync-worker/src/types.ts
@@ -34,10 +34,10 @@ export interface SyncDocument {
   deleted: boolean
 }
 
-/** 同步用设置项 */
+/** 同步用设置项（前后端共享契约，value 为 localStorage 原始字符串） */
 export interface SyncSetting {
   key: string
-  value: unknown
+  value: string | null
   updatedAt: number
 }
 

--- a/apps/sync-worker/tsconfig.json
+++ b/apps/sync-worker/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "ignoreDeprecations": "6.0",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/sync-worker/wrangler.toml
+++ b/apps/sync-worker/wrangler.toml
@@ -9,9 +9,9 @@ pattern = "md-api.doocs.org"
 custom_domain = true
 
 # D1 数据库绑定。
-# 首次使用前执行：
-#   wrangler d1 create md-sync
-# 然后把返回的 database_id 填入下方占位符。
+# database_id 为 doocs/md 官方部署所用实例（资源标识符，非密钥）。
+# 自行部署（fork）时请执行 `wrangler d1 create md-sync`，
+# 并把返回的 database_id 替换为你自己的实例 ID。
 [[d1_databases]]
 binding = "DB"
 database_name = "md-sync"

--- a/apps/sync-worker/wrangler.toml
+++ b/apps/sync-worker/wrangler.toml
@@ -1,0 +1,31 @@
+name = "md-sync"
+main = "./src/index.ts"
+compatibility_date = "2024-11-01"
+compatibility_flags = [ "nodejs_compat" ]
+
+# 自定义域名（zone doocs.org 需在同一 Cloudflare 账号下，部署时自动创建 DNS）
+[[routes]]
+pattern = "md-api.doocs.org"
+custom_domain = true
+
+# D1 数据库绑定。
+# 首次使用前执行：
+#   wrangler d1 create md-sync
+# 然后把返回的 database_id 填入下方占位符。
+[[d1_databases]]
+binding = "DB"
+database_name = "md-sync"
+database_id = "d7659e81-8fda-4abc-b128-f7a5975f7a7d"
+migrations_dir = "migrations"
+
+# 非敏感变量（可直接提交）。生产部署时按需覆盖。
+[vars]
+# 前端来源白名单，用于 CORS 与「登录后回跳到发起方」。
+# 支持通配符 `*`（匹配单个主机标签）。第一个非通配项作为默认回跳地址。
+# - 生产站、本地开发、Cloudflare PR 预览、Surge PR 预览
+APP_URL = "https://md.doocs.org,http://localhost:5173,https://md-pr-*.doocs.workers.dev,https://doocs-md-preview-pr-*.surge.sh"
+
+# 以下为敏感变量，请勿写入此文件，使用 `wrangler secret put` 设置：
+#   wrangler secret put GITHUB_CLIENT_ID
+#   wrangler secret put GITHUB_CLIENT_SECRET
+#   wrangler secret put JWT_SECRET

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+# 云同步后端地址（@md/sync-worker 部署后的 Worker 域名）。
+# 留空则前端不显示云同步入口。
+VITE_SYNC_API_URL=http://localhost:8787

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,5 @@
 # 云同步后端地址（@md/sync-worker 部署后的 Worker 域名）。
 # 留空则前端不显示云同步入口。
+# 本地开发把本文件复制为 .env 并按需修改；
+# 生产/预览构建使用已提交的 .env.production（指向官方后端）。
 VITE_SYNC_API_URL=http://localhost:8787

--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,0 +1,3 @@
+# 生产 / 预览构建使用的云同步后端地址（@md/sync-worker 官方部署域名）。
+# 本地开发请在 apps/web/.env 或 .env.local 中覆盖（见 .env.example）。
+VITE_SYNC_API_URL=https://md-api.doocs.org

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -3,12 +3,33 @@ import { onMounted, ref } from 'vue'
 import ConfirmDialog from '@/components/confirm-dialog/ConfirmDialog.vue'
 import CodemirrorEditor from '@/components/editor/CodemirrorEditor.vue'
 import { Toaster } from '@/components/ui/sonner'
+import { useAuthStore } from '@/stores/auth'
+import { useSyncStore } from '@/stores/sync'
 import { useUIStore } from '@/stores/ui'
 
 const uiStore = useUIStore()
 const { isDark } = storeToRefs(uiStore)
 
+const authStore = useAuthStore()
+const syncStore = useSyncStore()
+
 const isUtools = ref(false)
+
+/** 初始化云同步：捕获回跳 token、拉取用户、首次同步、开启自动同步监听 */
+async function bootstrapSync() {
+  if (!authStore.isConfigured)
+    return
+
+  authStore.captureRedirectToken()
+  syncStore.startAutoSyncWatcher()
+
+  if (!authStore.isLoggedIn)
+    return
+
+  await authStore.fetchMe()
+  if (authStore.isLoggedIn)
+    syncStore.sync()
+}
 
 onMounted(() => {
   // 检测是否为 Utools 环境
@@ -16,6 +37,8 @@ onMounted(() => {
   if (isUtools.value) {
     document.documentElement.classList.add(`is-utools`)
   }
+
+  bootstrapSync()
 
   // 若 URL 带有 open 参数（Markdown 链接），打开导入对话框并自动导入
   const params = new URLSearchParams(window.location.search)

--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { StateEffect } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { ArrowUpDown, BookOpen, ChevronRight, ChevronsUpDown, Clock, Columns2, Eye, FileText, Keyboard, ListTree, Monitor, Moon, PenLine, Pilcrow, Search, Smartphone, Sun, Type } from '@lucide/vue'
+import { ArrowUpDown, BookOpen, ChevronRight, ChevronsUpDown, Clock, Cloud, CloudAlert, CloudCheck, Columns2, Eye, FileText, Keyboard, ListTree, Loader2, Monitor, Moon, PenLine, Pilcrow, Search, Smartphone, Sun, Type } from '@lucide/vue'
 import {
   Popover,
   PopoverContent,
@@ -13,20 +13,42 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { useAuthStore } from '@/stores/auth'
 import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
+import { useSyncStore } from '@/stores/sync'
 import { useUIStore } from '@/stores/ui'
 
 const renderStore = useRenderStore()
 const editorStore = useEditorStore()
 const postStore = usePostStore()
 const uiStore = useUIStore()
+const authStore = useAuthStore()
+const syncStore = useSyncStore()
 const { readingTime } = storeToRefs(renderStore)
 const { editor } = storeToRefs(editorStore)
 const { currentPost } = storeToRefs(postStore)
 const { isDark } = storeToRefs(uiStore)
 const { isMobile, viewMode, previewDevice, enableScrollSync } = storeToRefs(uiStore)
+const { isConfigured: isSyncConfigured, isLoggedIn: isSyncLoggedIn } = storeToRefs(authStore)
+const { isSyncing, syncState } = storeToRefs(syncStore)
+
+// 云同步图标的提示文案
+const syncTooltip = computed(() => {
+  if (!isSyncLoggedIn.value)
+    return `云同步（未登录）`
+  switch (syncState.value) {
+    case `syncing`:
+      return `同步中…`
+    case `synced`:
+      return `已同步`
+    case `error`:
+      return `同步失败，点击重试`
+    default:
+      return `有未同步的更改`
+  }
+})
 
 // 相对时间格式化（复用）
 function formatRelativeTime(date: Date | string) {
@@ -613,6 +635,29 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
         </Tooltip>
 
         <span class="hidden text-border sm:block">·</span>
+
+        <!-- 云同步 -->
+        <template v-if="isSyncConfigured">
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <button
+                aria-label="云同步"
+                class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                :class="isSyncLoggedIn ? 'text-primary' : ''"
+                @click="uiStore.toggleShowSyncDialog(true)"
+              >
+                <Loader2 v-if="isSyncing" class="size-3 animate-spin" />
+                <CloudCheck v-else-if="isSyncLoggedIn && syncState === 'synced'" class="size-3 text-green-500" />
+                <CloudAlert v-else-if="isSyncLoggedIn && syncState === 'error'" class="size-3 text-destructive" />
+                <Cloud v-else class="size-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
+              <p>{{ syncTooltip }}</p>
+            </TooltipContent>
+          </Tooltip>
+          <span class="hidden text-border sm:block">·</span>
+        </template>
 
         <!-- 深浅色切换 -->
         <Tooltip>

--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Upload } from '@lucide/vue'
+import { Cloud, Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Upload } from '@lucide/vue'
 import { useEditorStore } from '@/stores/editor'
 import { useExportStore } from '@/stores/export'
 import { useUIStore } from '@/stores/ui'
@@ -19,7 +19,7 @@ const exportStore = useExportStore()
 const uiStore = useUIStore()
 
 const { isOpenPostSlider, isOpenFolderPanel } = storeToRefs(uiStore)
-const { toggleShowTemplateDialog, toggleShowImportMdDialog } = uiStore
+const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog } = uiStore
 
 function openEditorStateDialog() {
   emit(`openEditorState`)
@@ -126,6 +126,12 @@ function exportEditorContent2PDF() {
         内容管理
       </MenubarItem>
 
+      <!-- 云同步 -->
+      <MenubarItem @click="toggleShowSyncDialog(true)">
+        <Cloud class="mr-2 size-4" />
+        云同步
+      </MenubarItem>
+
       <MenubarSeparator />
 
       <!-- 项目配置 -->
@@ -208,6 +214,12 @@ function exportEditorContent2PDF() {
       <MenubarItem @click="isOpenPostSlider = !isOpenPostSlider">
         <FolderKanban class="mr-2 size-4" />
         内容管理
+      </MenubarItem>
+
+      <!-- 云同步 -->
+      <MenubarItem @click="toggleShowSyncDialog(true)">
+        <Cloud class="mr-2 size-4" />
+        云同步
       </MenubarItem>
 
       <MenubarSeparator />

--- a/apps/web/src/components/editor/editor-header/SyncDialog.vue
+++ b/apps/web/src/components/editor/editor-header/SyncDialog.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { Cloud, Loader2, LogIn, LogOut, RefreshCw } from '@lucide/vue'
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useSyncStore } from '@/stores/sync'
+
+const props = defineProps({
+  visible: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits([`close`])
+
+const authStore = useAuthStore()
+const syncStore = useSyncStore()
+
+const { user, isConfigured, isLoggedIn } = storeToRefs(authStore)
+const { status, lastError, lastSyncAt, autoSyncEnabled, needsRefresh, isSyncing } = storeToRefs(syncStore)
+
+const lastSyncText = computed(() => {
+  if (!lastSyncAt.value)
+    return `从未同步`
+  return new Date(lastSyncAt.value).toLocaleString(`zh-cn`)
+})
+
+function onUpdate(val: boolean) {
+  if (!val)
+    emit(`close`)
+}
+
+function handleLogin() {
+  authStore.login()
+}
+
+function handleLogout() {
+  authStore.logout()
+  syncStore.reset()
+}
+
+async function handleSync() {
+  await syncStore.sync()
+  if (status.value === `error`)
+    toast.error(`同步失败：${lastError.value}`)
+  else
+    toast.success(`同步完成`)
+}
+
+function handleReload() {
+  window.location.reload()
+}
+</script>
+
+<template>
+  <Dialog :open="props.visible" @update:open="onUpdate">
+    <DialogContent class="max-w-md">
+      <DialogHeader>
+        <DialogTitle class="flex items-center gap-2">
+          <Cloud class="size-5" />
+          云同步
+        </DialogTitle>
+        <DialogDescription>
+          多设备同步文章与设置，不含密钥。
+        </DialogDescription>
+      </DialogHeader>
+
+      <!-- 未配置后端 -->
+      <div v-if="!isConfigured" class="text-muted-foreground py-6 text-center text-sm">
+        云同步服务未配置（缺少 <code>VITE_SYNC_API_URL</code>），请联系部署方启用。
+      </div>
+
+      <!-- 未登录 -->
+      <div v-else-if="!isLoggedIn" class="flex flex-col items-center gap-4 py-6">
+        <p class="text-muted-foreground text-sm">
+          登录后即可开启云同步
+        </p>
+        <Button class="gap-2" @click="handleLogin">
+          <LogIn class="size-4" />
+          使用 GitHub 登录
+        </Button>
+      </div>
+
+      <!-- 已登录 -->
+      <div v-else class="space-y-4 py-2">
+        <div class="flex items-center gap-3">
+          <img
+            v-if="user?.avatar"
+            :src="user.avatar"
+            :alt="user?.login"
+            class="size-10 rounded-full"
+          >
+          <div class="flex-1">
+            <div class="text-sm font-medium">
+              {{ user?.name || user?.login }}
+            </div>
+            <div class="text-muted-foreground text-xs">
+              上次同步：{{ lastSyncText }}
+            </div>
+          </div>
+          <Button variant="ghost" size="icon" title="退出登录" @click="handleLogout">
+            <LogOut class="size-4" />
+          </Button>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <Label for="auto-sync" class="text-sm">自动同步</Label>
+          <Switch id="auto-sync" v-model="autoSyncEnabled" />
+        </div>
+
+        <div v-if="needsRefresh" class="bg-muted text-muted-foreground flex items-center justify-between gap-2 rounded-md p-2 text-xs">
+          <span>部分设置已从云端更新，刷新后生效</span>
+          <Button size="sm" variant="outline" @click="handleReload">
+            刷新
+          </Button>
+        </div>
+
+        <Button class="w-full gap-2" :disabled="isSyncing" @click="handleSync">
+          <Loader2 v-if="isSyncing" class="size-4 animate-spin" />
+          <RefreshCw v-else class="size-4" />
+          {{ isSyncing ? '同步中…' : '立即同步' }}
+        </Button>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -14,6 +14,7 @@ import HelpDropdown from './HelpDropdown.vue'
 import InsertDropdown from './InsertDropdown.vue'
 import MarkdownHelpDialog from './MarkdownHelpDialog.vue'
 import StyleDropdown from './StyleDropdown.vue'
+import SyncDialog from './SyncDialog.vue'
 
 const emit = defineEmits([`startCopy`, `endCopy`])
 
@@ -26,7 +27,7 @@ const exportStore = useExportStore()
 const { editor } = storeToRefs(editorStore)
 const { output } = storeToRefs(renderStore)
 const { primaryColor } = storeToRefs(themeStore)
-const { isOpenRightSlider } = storeToRefs(uiStore)
+const { isOpenRightSlider, isShowSyncDialog } = storeToRefs(uiStore)
 
 // Editor refresh function
 function editorRefresh() {
@@ -314,6 +315,7 @@ function copyToWeChat() {
   <FundDialog :visible="fundDialogVisible" @close="fundDialogVisible = false" />
   <EditorStateDialog :visible="editorStateDialogVisible" @close="editorStateDialogVisible = false" />
   <MarkdownHelpDialog :visible="markdownHelpDialogVisible" @close="markdownHelpDialogVisible = false" />
+  <SyncDialog :visible="isShowSyncDialog" @close="isShowSyncDialog = false" />
 </template>
 
 <style lang="less" scoped>

--- a/apps/web/src/services/sync/client.ts
+++ b/apps/web/src/services/sync/client.ts
@@ -7,9 +7,11 @@ export function isSyncConfigured(): boolean {
   return Boolean(SYNC_API_URL)
 }
 
-/** 发起 GitHub 登录：跳转到后端 OAuth 入口，并带上当前来源用于登录后回跳 */
+/** 发起 GitHub 登录：跳转到后端 OAuth 入口，并带上当前应用入口 URL 用于登录后回跳 */
 export function gotoLogin(): void {
-  const redirect = encodeURIComponent(window.location.origin)
+  // 携带完整入口（含 base path，如 `/md/`），避免回跳到站点根路径导致 404
+  const entry = `${window.location.origin}${window.location.pathname}`
+  const redirect = encodeURIComponent(entry)
   window.location.href = `${SYNC_API_URL}/auth/github?redirect=${redirect}`
 }
 

--- a/apps/web/src/services/sync/client.ts
+++ b/apps/web/src/services/sync/client.ts
@@ -1,0 +1,65 @@
+import type { PullResponse, PushRequest, PushResponse, SyncUser } from './types'
+
+/** 云同步后端地址，通过 VITE_SYNC_API_URL 注入，未配置则视为关闭云同步 */
+export const SYNC_API_URL = (import.meta.env.VITE_SYNC_API_URL ?? ``).replace(/\/$/, ``)
+
+export function isSyncConfigured(): boolean {
+  return Boolean(SYNC_API_URL)
+}
+
+/** 发起 GitHub 登录：跳转到后端 OAuth 入口，并带上当前来源用于登录后回跳 */
+export function gotoLogin(): void {
+  const redirect = encodeURIComponent(window.location.origin)
+  window.location.href = `${SYNC_API_URL}/auth/github?redirect=${redirect}`
+}
+
+export class SyncApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message)
+    this.name = `SyncApiError`
+  }
+}
+
+export class SyncClient {
+  constructor(private getToken: () => string | null) {}
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const token = this.getToken()
+    const headers: Record<string, string> = {}
+    if (body !== undefined)
+      headers[`Content-Type`] = `application/json`
+    if (token)
+      headers.Authorization = `Bearer ${token}`
+
+    const res = await fetch(`${SYNC_API_URL}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+
+    if (!res.ok) {
+      let message = res.statusText
+      try {
+        const data = await res.json() as { error?: string }
+        if (data?.error)
+          message = data.error
+      }
+      catch { /* ignore */ }
+      throw new SyncApiError(res.status, message)
+    }
+
+    return res.json() as Promise<T>
+  }
+
+  me(): Promise<SyncUser> {
+    return this.request<SyncUser>(`GET`, `/me`)
+  }
+
+  pull(since: number): Promise<PullResponse> {
+    return this.request<PullResponse>(`GET`, `/sync/pull?since=${since}`)
+  }
+
+  push(payload: PushRequest): Promise<PushResponse> {
+    return this.request<PushResponse>(`POST`, `/sync/push`, payload)
+  }
+}

--- a/apps/web/src/services/sync/merge.ts
+++ b/apps/web/src/services/sync/merge.ts
@@ -1,0 +1,106 @@
+import type { SyncDocument } from './types'
+import type { Post, PostHistory } from '@/types/post'
+
+export function toMs(value: Date | string | number | undefined): number {
+  if (value == null)
+    return 0
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime()
+  return Number.isFinite(ms) ? ms : 0
+}
+
+export function postToDoc(post: Post): SyncDocument {
+  return {
+    id: post.id,
+    title: post.title,
+    content: post.content,
+    parentId: post.parentId ?? null,
+    history: post.history ?? [],
+    createDatetime: toMs(post.createDatetime),
+    updateDatetime: toMs(post.updateDatetime),
+    deleted: false,
+  }
+}
+
+function docToPost(doc: SyncDocument): Post {
+  return {
+    id: doc.id,
+    title: doc.title,
+    content: doc.content,
+    history: doc.history ?? [],
+    createDatetime: new Date(doc.createDatetime),
+    updateDatetime: new Date(doc.updateDatetime),
+    parentId: doc.parentId ?? null,
+    collapsed: false,
+  }
+}
+
+/** 把败方内容并入胜方历史，避免数据丢失（按内容去重） */
+function mergeHistory(winner: Post, loserContent: string, loserDatetime: number): void {
+  if (!loserContent)
+    return
+  const history: PostHistory[] = winner.history ?? (winner.history = [])
+  const exists = history.some(h => h.content === loserContent)
+    || winner.content === loserContent
+  if (exists)
+    return
+  history.push({
+    datetime: new Date(loserDatetime).toLocaleString(`zh-cn`),
+    content: loserContent,
+  })
+}
+
+export interface MergeResult {
+  posts: Post[]
+  changed: boolean
+}
+
+/**
+ * 将远端文档合并进本地文章列表。
+ * - 按 updateDatetime 做 last-write-wins
+ * - 败方内容并入胜方 history 兜底
+ * - 远端软删除且更新时间较新时，从本地移除
+ */
+export function mergeRemoteIntoLocal(localPosts: Post[], remoteDocs: SyncDocument[]): MergeResult {
+  const localMap = new Map(localPosts.map(p => [p.id, p]))
+  let changed = false
+
+  for (const doc of remoteDocs) {
+    const local = localMap.get(doc.id)
+
+    if (!local) {
+      // 本地不存在
+      if (!doc.deleted) {
+        localMap.set(doc.id, docToPost(doc))
+        changed = true
+      }
+      continue
+    }
+
+    const localMs = toMs(local.updateDatetime)
+    const remoteMs = doc.updateDatetime
+
+    if (remoteMs > localMs) {
+      // 远端较新
+      if (doc.deleted) {
+        localMap.delete(doc.id)
+        changed = true
+      }
+      else {
+        const winner = docToPost(doc)
+        mergeHistory(winner, local.content, localMs)
+        winner.collapsed = local.collapsed ?? false
+        localMap.set(doc.id, winner)
+        changed = true
+      }
+    }
+    else {
+      // 本地较新（或同时）：保留本地，远端内容并入历史兜底
+      if (!doc.deleted && doc.content !== local.content) {
+        mergeHistory(local, doc.content, remoteMs)
+        changed = true
+      }
+    }
+  }
+
+  return { posts: Array.from(localMap.values()), changed }
+}

--- a/apps/web/src/services/sync/settings.ts
+++ b/apps/web/src/services/sync/settings.ts
@@ -1,0 +1,128 @@
+import type { SyncSetting } from './types'
+import { addPrefix } from '@/utils'
+
+/**
+ * 允许同步的偏好设置 key 白名单（显式枚举，避免泄露密钥）。
+ * 刻意不包含：图床配置（githubConfig/aliOSSConfig/s3Config 等）、
+ * AI 密钥（openai_key_*）、运行时/临时状态。
+ */
+export const SYNC_SETTING_KEYS: string[] = [
+  // 主题与样式
+  addPrefix(`theme`),
+  addPrefix(`themeSettings`),
+  addPrefix(`use_indent`),
+  addPrefix(`use_justify`),
+  `isCiteStatus`,
+  `isCountStatus`,
+  `legend`,
+  `previewWidth`,
+  // 编辑器 / UI 偏好
+  `isEditOnLeft`,
+  `showAIToolbox`,
+  `viewMode`,
+  `previewDevice`,
+  addPrefix(`copyMode`),
+  addPrefix(`sort_mode`),
+  addPrefix(`enableImageReupload`),
+  addPrefix(`enableScrollSync`),
+  // AI 非敏感参数（不含 key、不含 model）
+  `openai_type`,
+  `openai_temperature`,
+  `openai_max_token`,
+  // 自定义内容
+  addPrefix(`css_content_config`),
+  addPrefix(`templates`),
+  addPrefix(`custom_components`),
+  `quick_commands`,
+]
+
+const META_KEY = addPrefix(`sync_settings_meta`)
+
+interface SettingMeta {
+  value: string | null
+  updatedAt: number
+}
+
+type MetaMap = Record<string, SettingMeta>
+
+function readMeta(): MetaMap {
+  try {
+    const raw = localStorage.getItem(META_KEY)
+    return raw ? JSON.parse(raw) as MetaMap : {}
+  }
+  catch {
+    return {}
+  }
+}
+
+function writeMeta(meta: MetaMap): void {
+  try {
+    localStorage.setItem(META_KEY, JSON.stringify(meta))
+  }
+  catch { /* 配额错误，非致命 */ }
+}
+
+function readLocal(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * 收集本地发生变化的设置项（与上次同步快照比对），并刷新元数据时间戳。
+ * 返回需要推送的设置列表。
+ */
+export function collectChangedSettings(): SyncSetting[] {
+  const meta = readMeta()
+  const now = Date.now()
+  const changed: SyncSetting[] = []
+
+  for (const key of SYNC_SETTING_KEYS) {
+    const current = readLocal(key)
+    const prev = meta[key]
+    if (!prev || prev.value !== current) {
+      meta[key] = { value: current, updatedAt: now }
+      changed.push({ key, value: current, updatedAt: now })
+    }
+  }
+
+  writeMeta(meta)
+  return changed
+}
+
+/**
+ * 应用远端设置到本地（LWW，仅当远端更新时间较新时写入）。
+ * 返回实际应用的数量（>0 表示建议刷新页面以生效）。
+ */
+export function applyRemoteSettings(remote: SyncSetting[]): number {
+  const meta = readMeta()
+  let applied = 0
+
+  for (const setting of remote) {
+    if (!SYNC_SETTING_KEYS.includes(setting.key))
+      continue
+
+    const local = meta[setting.key]
+    if (local && local.updatedAt >= setting.updatedAt)
+      continue
+
+    try {
+      if (setting.value === null)
+        localStorage.removeItem(setting.key)
+      else
+        localStorage.setItem(setting.key, setting.value)
+    }
+    catch {
+      continue
+    }
+
+    meta[setting.key] = { value: setting.value, updatedAt: setting.updatedAt }
+    applied++
+  }
+
+  writeMeta(meta)
+  return applied
+}

--- a/apps/web/src/services/sync/types.ts
+++ b/apps/web/src/services/sync/types.ts
@@ -1,0 +1,46 @@
+/**
+ * 云同步前后端共享契约（与 @md/sync-worker 保持一致）。
+ * 时间字段统一为 epoch 毫秒。
+ */
+
+export interface SyncDocument {
+  id: string
+  title: string
+  content: string
+  parentId: string | null
+  history: { datetime: string, content: string }[]
+  createDatetime: number
+  updateDatetime: number
+  deleted: boolean
+}
+
+export interface SyncSetting {
+  key: string
+  /** localStorage 中的原始字符串值（保持原样回写，避免二次编解码） */
+  value: string | null
+  updatedAt: number
+}
+
+export interface SyncUser {
+  id: string
+  login: string
+  name: string | null
+  avatar: string | null
+}
+
+export interface PullResponse {
+  documents: SyncDocument[]
+  settings: SyncSetting[]
+  cursor: number
+}
+
+export interface PushRequest {
+  documents?: SyncDocument[]
+  settings?: SyncSetting[]
+}
+
+export interface PushResponse {
+  documents: SyncDocument[]
+  settings: SyncSetting[]
+  cursor: number
+}

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -1,0 +1,85 @@
+import type { SyncUser } from '@/services/sync/types'
+import { gotoLogin, isSyncConfigured, SyncApiError, SyncClient } from '@/services/sync/client'
+import { addPrefix } from '@/utils'
+import { store } from '@/utils/storage'
+
+const TOKEN_KEY = addPrefix(`sync_token`)
+
+/**
+ * 云同步账户 Store
+ * 负责管理登录态、JWT、当前用户信息
+ */
+export const useAuthStore = defineStore(`auth`, () => {
+  // 持久化的 JWT（登录后由后端签发）
+  const token = store.reactive(TOKEN_KEY, ``)
+
+  // 当前用户信息（仅内存，每次启动通过 /me 拉取）
+  const user = ref<SyncUser | null>(null)
+
+  const isConfigured = computed(() => isSyncConfigured())
+  const isLoggedIn = computed(() => Boolean(token.value))
+
+  const client = new SyncClient(() => token.value || null)
+
+  /**
+   * 从 URL fragment 中捕获后端回跳的 token（#sync_token=xxx），
+   * 捕获后清理地址栏，避免泄露。
+   */
+  function captureRedirectToken(): boolean {
+    const hash = window.location.hash.replace(/^#/, ``)
+    if (!hash.includes(`sync_token=`))
+      return false
+
+    const params = new URLSearchParams(hash)
+    const t = params.get(`sync_token`)
+    if (!t)
+      return false
+
+    token.value = t
+    // 直接写入存储：此时 store.reactive 的持久化 watch 尚未注册
+    // （它延迟到下一个微任务），仅靠赋值会导致刷新后丢失登录态。
+    store.set(TOKEN_KEY, t).catch(() => {})
+
+    params.delete(`sync_token`)
+    const rest = params.toString()
+    const newUrl = window.location.pathname + window.location.search + (rest ? `#${rest}` : ``)
+    window.history.replaceState({}, ``, newUrl)
+    return true
+  }
+
+  /** 拉取当前用户信息，仅在 token 确实失效（401/403）时登出 */
+  async function fetchMe(): Promise<void> {
+    if (!token.value)
+      return
+    try {
+      user.value = await client.me()
+    }
+    catch (e) {
+      // 仅当鉴权失败时登出；网络/临时错误不应清除登录态
+      if (e instanceof SyncApiError && (e.status === 401 || e.status === 403))
+        logout()
+    }
+  }
+
+  function login(): void {
+    gotoLogin()
+  }
+
+  function logout(): void {
+    token.value = ``
+    user.value = null
+    store.remove(TOKEN_KEY).catch(() => {})
+  }
+
+  return {
+    token,
+    user,
+    isConfigured,
+    isLoggedIn,
+    client,
+    captureRedirectToken,
+    fetchMe,
+    login,
+    logout,
+  }
+})

--- a/apps/web/src/stores/sync.ts
+++ b/apps/web/src/stores/sync.ts
@@ -1,0 +1,206 @@
+import type { SyncDocument } from '@/services/sync/types'
+import { isSyncConfigured } from '@/services/sync/client'
+import { mergeRemoteIntoLocal, postToDoc } from '@/services/sync/merge'
+import { applyRemoteSettings, collectChangedSettings } from '@/services/sync/settings'
+import { useAuthStore } from '@/stores/auth'
+import { usePostStore } from '@/stores/post'
+import { addPrefix } from '@/utils'
+import { store } from '@/utils/storage'
+
+export type SyncStatus = 'idle' | 'syncing' | 'error'
+
+const SYNCED_IDS_KEY = addPrefix(`sync_post_ids`)
+const AUTO_SYNC_DEBOUNCE = 3000
+
+function readSyncedIds(): string[] {
+  try {
+    const raw = localStorage.getItem(SYNCED_IDS_KEY)
+    return raw ? JSON.parse(raw) as string[] : []
+  }
+  catch {
+    return []
+  }
+}
+
+function writeSyncedIds(ids: string[]): void {
+  try {
+    localStorage.setItem(SYNCED_IDS_KEY, JSON.stringify(ids))
+  }
+  catch { /* 配额错误，非致命 */ }
+}
+
+/**
+ * 云同步 Store
+ * 负责同步状态机、手动/自动同步编排、上次同步时间
+ */
+export const useSyncStore = defineStore(`sync`, () => {
+  const authStore = useAuthStore()
+  const postStore = usePostStore()
+
+  const status = ref<SyncStatus>(`idle`)
+  const lastError = ref<string>(``)
+  // 上次同步成功时间（持久化展示）
+  const lastSyncAt = store.reactive<number>(addPrefix(`sync_last_at`), 0)
+  // 是否开启自动同步
+  const autoSyncEnabled = store.reactive(addPrefix(`sync_auto`), true)
+  // 应用了远端设置、建议刷新生效
+  const needsRefresh = ref(false)
+
+  // 会话内增量游标（每次启动从 0 全量拉取，避免账号切换错乱）
+  let cursor = 0
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  const isAvailable = computed(() => isSyncConfigured() && authStore.isLoggedIn)
+  const isSyncing = computed(() => status.value === `syncing`)
+
+  // 本地最近一次编辑时间（取所有文章 updateDatetime 的最大值）
+  const lastLocalEditAt = computed(() => {
+    let max = 0
+    for (const p of postStore.posts) {
+      const t = new Date(p.updateDatetime).getTime()
+      if (Number.isFinite(t) && t > max)
+        max = t
+    }
+    return max
+  })
+
+  // 是否存在尚未同步到云端的本地改动
+  const hasPendingChanges = computed(() => lastSyncAt.value === 0 || lastLocalEditAt.value > lastSyncAt.value)
+
+  /**
+   * 同步图标状态：
+   * - syncing：正在同步（loading）
+   * - synced：已与云端一致（绿色对勾）
+   * - error：上次同步失败
+   * - pending：有本地改动待同步（普通云朵）
+   */
+  const syncState = computed<'syncing' | 'synced' | 'error' | 'pending'>(() => {
+    if (status.value === `syncing`)
+      return `syncing`
+    if (status.value === `error`)
+      return `error`
+    if (lastSyncAt.value > 0 && !hasPendingChanges.value)
+      return `synced`
+    return `pending`
+  })
+
+  /** 收集本地待推送的文档（含本地删除的墓碑） */
+  function collectLocalDocuments(): SyncDocument[] {
+    const now = Date.now()
+    const currentDocs = postStore.posts.map(postToDoc)
+    const currentIds = new Set(postStore.posts.map(p => p.id))
+
+    // 上次同步存在、本地已不存在 ➜ 视为本地删除，下发墓碑
+    const tombstones: SyncDocument[] = readSyncedIds()
+      .filter(id => !currentIds.has(id))
+      .map(id => ({
+        id,
+        title: ``,
+        content: ``,
+        parentId: null,
+        history: [],
+        createDatetime: now,
+        updateDatetime: now,
+        deleted: true,
+      }))
+
+    return [...currentDocs, ...tombstones]
+  }
+
+  /** 执行一次完整同步：pull ➜ 合并 ➜ push */
+  async function sync(): Promise<void> {
+    if (!isAvailable.value || status.value === `syncing`)
+      return
+
+    status.value = `syncing`
+    lastError.value = ``
+
+    try {
+      // 1. 拉取远端变更
+      const pulled = await authStore.client.pull(cursor)
+
+      // 2. 合并文档（LWW，败方进 history）
+      if (pulled.documents.length) {
+        const { posts, changed } = mergeRemoteIntoLocal(postStore.posts, pulled.documents)
+        if (changed)
+          postStore.posts = posts
+      }
+
+      // 3. 应用远端设置
+      if (pulled.settings.length) {
+        const applied = applyRemoteSettings(pulled.settings)
+        if (applied > 0)
+          needsRefresh.value = true
+      }
+
+      cursor = Math.max(cursor, pulled.cursor)
+
+      // 4. 收集并推送本地变更
+      const documents = collectLocalDocuments()
+      const settings = collectChangedSettings()
+      if (documents.length || settings.length) {
+        const pushed = await authStore.client.push({ documents, settings })
+        cursor = Math.max(cursor, pushed.cursor)
+      }
+
+      // 5. 记录已同步快照
+      writeSyncedIds(postStore.posts.map(p => p.id))
+      lastSyncAt.value = Date.now()
+      status.value = `idle`
+    }
+    catch (e) {
+      status.value = `error`
+      lastError.value = e instanceof Error ? e.message : String(e)
+    }
+  }
+
+  /** 自动同步（防抖触发） */
+  function scheduleAutoSync(): void {
+    if (!autoSyncEnabled.value || !isAvailable.value)
+      return
+    if (debounceTimer)
+      clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      sync()
+    }, AUTO_SYNC_DEBOUNCE)
+  }
+
+  /** 监听本地文章变化，触发防抖自动同步 */
+  function startAutoSyncWatcher(): void {
+    watch(
+      () => postStore.posts,
+      () => scheduleAutoSync(),
+      { deep: true },
+    )
+  }
+
+  /** 登出时清理同步本地痕迹，防止账号间数据串味 */
+  function reset(): void {
+    cursor = 0
+    lastSyncAt.value = 0
+    needsRefresh.value = false
+    status.value = `idle`
+    try {
+      localStorage.removeItem(SYNCED_IDS_KEY)
+      localStorage.removeItem(addPrefix(`sync_settings_meta`))
+    }
+    catch { /* ignore */ }
+  }
+
+  return {
+    status,
+    lastError,
+    lastSyncAt,
+    autoSyncEnabled,
+    needsRefresh,
+    isAvailable,
+    isSyncing,
+    hasPendingChanges,
+    syncState,
+    sync,
+    scheduleAutoSync,
+    startAutoSyncWatcher,
+    reset,
+  }
+})

--- a/apps/web/src/stores/sync.ts
+++ b/apps/web/src/stores/sync.ts
@@ -1,6 +1,6 @@
 import type { SyncDocument } from '@/services/sync/types'
 import { isSyncConfigured } from '@/services/sync/client'
-import { mergeRemoteIntoLocal, postToDoc } from '@/services/sync/merge'
+import { mergeRemoteIntoLocal, postToDoc, toMs } from '@/services/sync/merge'
 import { applyRemoteSettings, collectChangedSettings } from '@/services/sync/settings'
 import { useAuthStore } from '@/stores/auth'
 import { usePostStore } from '@/stores/post'
@@ -84,13 +84,18 @@ export const useSyncStore = defineStore(`sync`, () => {
     return `pending`
   })
 
-  /** 收集本地待推送的文档（含本地删除的墓碑） */
+  /** 收集本地待推送的文档（仅增量 + 本地删除的墓碑） */
   function collectLocalDocuments(): SyncDocument[] {
     const now = Date.now()
-    const currentDocs = postStore.posts.map(postToDoc)
+    const since = lastSyncAt.value
     const currentIds = new Set(postStore.posts.map(p => p.id))
 
-    // 上次同步存在、本地已不存在 ➜ 视为本地删除，下发墓碑
+    // 仅推送自上次成功同步以来发生过变更的文档（首次同步则全量）
+    const changedDocs = postStore.posts
+      .filter(p => since === 0 || toMs(p.updateDatetime) > since)
+      .map(postToDoc)
+
+    // 上次同步存在、本地已不存在 ➜ 视为本地删除，下发墓碑（仍需全量比对）
     const tombstones: SyncDocument[] = readSyncedIds()
       .filter(id => !currentIds.has(id))
       .map(id => ({
@@ -104,7 +109,7 @@ export const useSyncStore = defineStore(`sync`, () => {
         deleted: true,
       }))
 
-    return [...currentDocs, ...tombstones]
+    return [...changedDocs, ...tombstones]
   }
 
   /** 执行一次完整同步：pull ➜ 合并 ➜ push */

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -124,6 +124,10 @@ export const useUIStore = defineStore(`ui`, () => {
   const isShowComponentDialog = ref(false)
   const toggleShowComponentDialog = useToggle(isShowComponentDialog)
 
+  // 是否展示云同步对话框
+  const isShowSyncDialog = ref(false)
+  const toggleShowSyncDialog = useToggle(isShowSyncDialog)
+
   // 组件对话框 — 打开时预展开的组件名（如 'MpProfile'）
   const componentDialogTarget = ref<string | null>(null)
 
@@ -222,6 +226,8 @@ export const useUIStore = defineStore(`ui`, () => {
     toggleShowTemplateDialog,
     isShowComponentDialog,
     toggleShowComponentDialog,
+    isShowSyncDialog,
+    toggleShowSyncDialog,
     componentDialogTarget,
     openComponentDialogWithTarget,
     aiDialogVisible,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vscode": "pnpm --prefix ./apps/vscode",
     "vscode:test": "pnpm --prefix ./apps/vscode test",
     "mcp": "pnpm --filter @md/mcp-server",
+    "sync": "pnpm --filter @md/sync-worker",
     "cli": "pnpm --filter @doocs/md-cli",
     "build:cli": "pnpm web build && npx shx rm -rf packages/md-cli/dist && npx shx rm -rf dist/**/*.map && npx shx cp -r apps/web/dist packages/md-cli/ && cd packages/md-cli && npm pack",
     "release:cli": "node ./scripts/release.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,22 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
 
+  apps/sync-worker:
+    dependencies:
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.25
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20260610.1
+        version: 4.20260610.1
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      wrangler:
+        specifier: ^4.99.0
+        version: 4.99.0(@cloudflare/workers-types@4.20260610.1)
+
   apps/utools: {}
 
   apps/vscode:


### PR DESCRIPTION
## Summary

- Add `@md/sync-worker` (Cloudflare Workers + Hono + D1) for GitHub OAuth login and document/settings sync
- Add web sync client, auth/sync stores, and SyncDialog for manual sync and auto-sync
- Show cloud sync status in the footer: loading while syncing, green check when synced, alert on error, plain cloud when pending
- Sync articles and whitelisted preferences across devices; image hosting and AI keys stay local

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [ ] Set `VITE_SYNC_API_URL` in `apps/web/.env` (see `.env.example`) and deploy/run sync-worker locally with `pnpm sync dev`
- [ ] Log in via GitHub from File → 云同步; verify token capture and user info
- [ ] Edit a document and confirm footer icon: pending → loading → green check after auto-sync
- [ ] Open sync dialog, toggle auto-sync, trigger manual sync
- [ ] Confirm image hosting and AI API keys are not included in synced settings

## Pre-flight Checklist

- [x] Changes are focused on cloud sync only
- [x] `.env` with secrets is not committed (`.env.example` included)
- [ ] CI passes (lint, type-check, build)
