### PR TITLE
fix(sync-worker): verify afdian orders via api to prevent webhook spoofing

### DIFF
--- a/apps/sync-worker/.dev.vars.example
+++ b/apps/sync-worker/.dev.vars.example
@@ -2,3 +2,5 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 JWT_SECRET=
 AFDIAN_API_TOKEN=
+# 可选：爱发电 Webhook 路径密钥。配置后回调地址为 /webhooks/afdian/<token>
+AFDIAN_WEBHOOK_TOKEN=

--- a/apps/sync-worker/README.md
+++ b/apps/sync-worker/README.md
@@ -57,6 +57,7 @@ pnpm sync exec wrangler secret put GITHUB_CLIENT_ID
 pnpm sync exec wrangler secret put GITHUB_CLIENT_SECRET
 pnpm sync exec wrangler secret put JWT_SECRET     # 任意高强度随机串
 pnpm sync exec wrangler secret put AFDIAN_API_TOKEN
+pnpm sync exec wrangler secret put AFDIAN_WEBHOOK_TOKEN  # 可选：Webhook 路径密钥
 ```
 
 `APP_URL`、`AFDIAN_USER_ID` 在 [`wrangler.toml`](./wrangler.toml) 的 `[vars]` 中配置。
@@ -67,8 +68,14 @@ pnpm sync exec wrangler secret put AFDIAN_API_TOKEN
 
 1. 在 [afdian.com 开发者后台](https://afdian.com/dashboard/dev) 配置 Webhook：
    `https://<your-worker-domain>/webhooks/afdian`
+   若设置了 `AFDIAN_WEBHOOK_TOKEN`，地址改为 `https://<your-worker-domain>/webhooks/afdian/<token>`
 2. 创建 Pro 赞助方案（月/季/年），引导用户在付款备注填写 **GitHub 用户名**
 3. 可选：在 `wrangler.toml` 设置 `AFDIAN_PRO_PLAN_IDS` 限定可开通的方案 ID
+
+> **安全说明**：本服务代码公开托管，Webhook 回调内容**不可信任**。Worker 收到回调后
+> 只取订单号，再用爱发电 Open API 反查真实订单（以服务端返回为准）后才开通 Pro，
+> 因此伪造回调无法骗取 Pro。建议同时设置 `AFDIAN_WEBHOOK_TOKEN` 作为路径密钥，
+> 防止公开端点被刷量、空耗爱发电 API 配额。
 
 ### 6. 本地运行 / 部署
 

--- a/apps/sync-worker/src/index.ts
+++ b/apps/sync-worker/src/index.ts
@@ -24,7 +24,10 @@ app.use(`*`, async (c, next) => {
 app.get(`/`, c => c.json({ name: `md-sync`, ok: true }))
 
 app.route(`/auth`, authRoutes)
+// 爱发电 Webhook：无密钥与带路径密钥两种形式共用同一处理器。
+// 设置 AFDIAN_WEBHOOK_TOKEN 后，仅 `/webhooks/afdian/<token>` 可通过校验。
 app.post(`/webhooks/afdian`, afdianWebhookHandler)
+app.post(`/webhooks/afdian/:token`, afdianWebhookHandler)
 
 const api = new Hono<{ Bindings: Env, Variables: { userId: string } }>()
 api.use(`*`, authMiddleware)

--- a/apps/sync-worker/src/types.ts
+++ b/apps/sync-worker/src/types.ts
@@ -13,6 +13,12 @@ export interface Env {
   AFDIAN_API_BASE?: string
   /** 可开通 Pro 的方案 plan_id，逗号分隔；留空则接受所有已付款方案 */
   AFDIAN_PRO_PLAN_IDS?: string
+  /**
+   * 爱发电 Webhook 路径密钥，通过 wrangler secret 注入。
+   * 配置后回调地址须为 `/webhooks/afdian/<token>`，缺失或不匹配则拒绝。
+   * 用于防止公开端点被任意调用 / 刷量（验单仍以爱发电 API 为准）。
+   */
+  AFDIAN_WEBHOOK_TOKEN?: string
 }
 
 export interface JwtPayload {

--- a/apps/sync-worker/src/webhook.ts
+++ b/apps/sync-worker/src/webhook.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
-import type { AfdianOrder } from './afdian'
 import type { Env } from './types'
+import { isAfdianConfigured, queryOrder } from './afdian'
 import { activateProFromOrder, parseGithubLoginFromRemark } from './plan'
 
 interface WebhookBody {
@@ -8,13 +8,33 @@ interface WebhookBody {
   em?: string
   data?: {
     type?: string
-    order?: AfdianOrder
+    order?: { out_trade_no?: string }
   }
 }
 
 type WebhookContext = Context<{ Bindings: Env }>
 
+/**
+ * 爱发电订单 Webhook。
+ *
+ * 安全要点（本服务代码公开托管，回调地址与逻辑均可被获知）：
+ * 1. 可选路径密钥 `AFDIAN_WEBHOOK_TOKEN`，防止公开端点被任意调用 / 刷量。
+ * 2. **绝不信任回调 body 中的订单内容**：仅取 `out_trade_no`，再用爱发电
+ *    Open API 反查真实订单，以服务端返回为准。这样伪造回调无法开通 Pro。
+ */
 export async function afdianWebhookHandler(c: WebhookContext) {
+  // 1. 可选共享密钥校验（通过 URL 路径段传入，配置在爱发电后台的回调地址中）
+  const expectedToken = c.env.AFDIAN_WEBHOOK_TOKEN
+  if (expectedToken) {
+    const token = c.req.param(`token`)
+    if (token !== expectedToken)
+      return c.json({ ec: 403, em: `forbidden` }, 403)
+  }
+
+  // 未配置爱发电 API 则无法验单，直接忽略（返回 200 避免平台重试）
+  if (!isAfdianConfigured(c.env))
+    return c.json({ ec: 200, em: `` })
+
   let body: WebhookBody
   try {
     body = await c.req.json<WebhookBody>()
@@ -26,8 +46,13 @@ export async function afdianWebhookHandler(c: WebhookContext) {
   if (body.data?.type !== `order` || !body.data.order)
     return c.json({ ec: 200, em: `` })
 
-  const order = body.data.order
-  if (order.status !== 2)
+  const outTradeNo = body.data.order.out_trade_no?.trim()
+  if (!outTradeNo)
+    return c.json({ ec: 200, em: `` })
+
+  // 2. 关键：以爱发电服务端查询结果为准，杜绝伪造回调
+  const order = await queryOrder(c.env, outTradeNo)
+  if (!order || order.status !== 2)
     return c.json({ ec: 200, em: `` })
 
   const githubLogin = parseGithubLoginFromRemark(order.remark ?? ``)

--- a/apps/sync-worker/wrangler.toml
+++ b/apps/sync-worker/wrangler.toml
@@ -35,3 +35,4 @@ AFDIAN_PRO_PLAN_IDS = "81efdc48655711f18b6d52540025c377,ced9acca655a11f1a7cc5254
 #   wrangler secret put GITHUB_CLIENT_SECRET
 #   wrangler secret put JWT_SECRET
 #   wrangler secret put AFDIAN_API_TOKEN
+#   wrangler secret put AFDIAN_WEBHOOK_TOKEN   # 可选：爱发电 Webhook 路径密钥


### PR DESCRIPTION
## Summary

The Afdian webhook handler (`apps/sync-worker`) previously trusted the
callback request body directly. Because the worker is open source and
publicly deployed, the endpoint URL and payload shape are known, so anyone
could forge an `order` callback and activate Pro for an arbitrary GitHub
user (the username is taken from the order `remark`).

This PR closes that bypass:

- **Verify orders against the Afdian Open API.** The handler now reads only
  `out_trade_no` from the callback and re-queries `query-order` (signed with
  `AFDIAN_API_TOKEN`) to fetch the real order. Activation uses the verified
  order's `status` / `month` / `remark`, so forged callbacks cannot grant Pro.
- **Optional path secret `AFDIAN_WEBHOOK_TOKEN`.** When set, only
  `/webhooks/afdian/<token>` is accepted (others return 403), blocking abuse
  of the public endpoint and avoiding wasted Afdian API quota.
- If Afdian API is not configured, the webhook now no-ops (cannot verify → does
  not activate).
- Idempotency via `afdian_orders.out_trade_no` is unchanged.

The manual activation path (`/sync/activate`) was already safe (it requires a
JWT and queries the Afdian API); this brings the webhook to the same standard.

## Changes

- `src/webhook.ts`: query Afdian API to verify order; optional token check; trust only `out_trade_no` from body
- `src/index.ts`: register `/webhooks/afdian/:token` alongside `/webhooks/afdian`
- `src/types.ts`: add `AFDIAN_WEBHOOK_TOKEN` to `Env`
- `README.md`, `wrangler.toml`, `.dev.vars.example`: document the new secret and security model

## Type of Change

- [x] Bug fix (security)

## Test Procedure

- `pnpm --filter @md/sync-worker type-check` passes
- `pnpm exec eslint` on changed files passes
- Forged callback (fake `out_trade_no`) → `query-order` returns nothing → no activation
- With `AFDIAN_WEBHOOK_TOKEN` set, request without/with wrong token → 403

## Deployment Notes

- Set the secret: `wrangler secret put AFDIAN_WEBHOOK_TOKEN` (recommended)
- Update the Afdian dashboard webhook URL to `/webhooks/afdian/<token>` to match
- Users can still self-activate with an order number if a callback is missed
