### PR TITLE
fix(api): allow oauth redirect for gitee and workers dev

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -22,8 +22,8 @@ migrations_dir = "migrations"
 [vars]
 # 前端来源白名单，用于 CORS 与「登录后回跳到发起方」。
 # 支持通配符 `*`（匹配单个主机标签）。第一个非通配项作为默认回跳地址。
-# - 生产站、本地开发、Cloudflare PR 预览、Surge PR 预览
-APP_URL = "https://md.doocs.org,http://localhost:5173,https://md-pr-*.doocs.workers.dev,https://doocs-md-preview-pr-*.surge.sh"
+# - 生产站、Gitee Pages、Cloudflare Workers、本地开发、PR 预览
+APP_URL = "https://md.doocs.org,https://doocs.gitee.io,https://md.doocs.workers.dev,http://localhost:5173,https://md-pr-*.doocs.workers.dev,https://doocs-md-preview-pr-*.surge.sh"
 
 # 爱发电创作者 user_id（开发者后台可见，非密钥）
 AFDIAN_USER_ID = "f001c5a8655111f18f5e52540025c377"


### PR DESCRIPTION
## Summary

- Add `https://doocs.gitee.io` and `https://md.doocs.workers.dev` to the API `APP_URL` whitelist
- Fixes OAuth login redirecting to `md.doocs.org` when users sign in from Gitee Pages or the Cloudflare Workers deployment

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI / workflow change

## Test Procedure

- [ ] Merge and deploy API with `pnpm api deploy`
- [ ] Open https://doocs.gitee.io/md and sign in via GitHub — should return to Gitee after OAuth
- [ ] Open https://md.doocs.workers.dev and sign in via GitHub — should return to Workers after OAuth
- [ ] Confirm https://md.doocs.org login still works as before

## Pre-flight Checklist

- [x] One focused change (APP_URL whitelist only)
- [x] Conventional commit message in English
- [ ] API redeploy required after merge for the fix to take effect in production
