### PR TITLE
refactor(theme): rename md-container to container

### DIFF
--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -554,9 +554,9 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
       <div class="hidden min-w-0 flex-1 sm:block" />
 
       <!-- 右侧：统计信息 -->
-      <div class="ml-auto flex shrink-0 items-center gap-2 sm:gap-3">
+      <div class="ml-auto flex shrink-0 items-center gap-2.5 sm:gap-3.5">
         <!-- 视图模式切换 -->
-        <div class="flex items-center rounded-md border border-border/60 p-0.5">
+        <div class="flex items-center gap-0.5 rounded-md border border-border/60 p-0.5">
           <Tooltip v-for="mode in viewModes" :key="mode.key">
             <TooltipTrigger as-child>
               <button
@@ -647,72 +647,70 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
         <span class="hidden text-border sm:block">·</span>
 
-        <!-- 账户 -->
-        <template v-if="showAccountUi">
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <button
-                aria-label="账户"
-                class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
-                :class="isLoggedIn ? 'text-primary' : ''"
-                @click="uiStore.toggleShowAccountDialog(true)"
-              >
-                <img
-                  v-if="isLoggedIn && authStore.user?.avatar"
-                  :src="authStore.user.avatar"
-                  :alt="authStore.user.login"
-                  class="size-3.5 rounded-full"
+        <!-- 账户 & 同步 & 主题 -->
+        <div class="flex items-center gap-1">
+          <template v-if="showAccountUi">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  aria-label="账户"
+                  class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                  :class="isLoggedIn ? 'text-primary' : ''"
+                  @click="uiStore.toggleShowAccountDialog(true)"
                 >
-                <User v-else-if="isLoggedIn" class="size-3" />
-                <LogIn v-else class="size-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
-              <p>{{ accountTooltip }}</p>
-            </TooltipContent>
-          </Tooltip>
-          <span class="hidden text-border sm:block">·</span>
-        </template>
+                  <img
+                    v-if="isLoggedIn && authStore.user?.avatar"
+                    :src="authStore.user.avatar"
+                    :alt="authStore.user.login"
+                    class="size-3.5 rounded-full"
+                  >
+                  <User v-else-if="isLoggedIn" class="size-3" />
+                  <LogIn v-else class="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
+                <p>{{ accountTooltip }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </template>
 
-        <!-- 云同步 -->
-        <template v-if="showSyncUi">
+          <template v-if="showSyncUi">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  aria-label="云同步"
+                  class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                  :class="isLoggedIn ? 'text-primary' : ''"
+                  @click="uiStore.toggleShowSyncDialog(true)"
+                >
+                  <Loader2 v-if="isSyncing" class="size-3 animate-spin" />
+                  <CloudCheck v-else-if="isLoggedIn && syncState === 'synced'" class="size-3 text-green-500" />
+                  <CloudAlert v-else-if="isLoggedIn && syncState === 'error'" class="size-3 text-destructive" />
+                  <Cloud v-else class="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
+                <p>{{ syncTooltip }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </template>
+
           <Tooltip>
             <TooltipTrigger as-child>
               <button
-                aria-label="云同步"
                 class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
-                :class="isLoggedIn ? 'text-primary' : ''"
-                @click="uiStore.toggleShowSyncDialog(true)"
+                :class="isDark ? 'text-foreground' : ''"
+                @click="uiStore.toggleDark()"
               >
-                <Loader2 v-if="isSyncing" class="size-3 animate-spin" />
-                <CloudCheck v-else-if="isLoggedIn && syncState === 'synced'" class="size-3 text-green-500" />
-                <CloudAlert v-else-if="isLoggedIn && syncState === 'error'" class="size-3 text-destructive" />
-                <Cloud v-else class="size-3" />
+                <Moon v-if="isDark" class="size-3" />
+                <Sun v-else class="size-3" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
-              <p>{{ syncTooltip }}</p>
+              <p>{{ isDark ? '浅色模式' : '深色模式' }}</p>
             </TooltipContent>
           </Tooltip>
-          <span class="hidden text-border sm:block">·</span>
-        </template>
-
-        <!-- 深浅色切换 -->
-        <Tooltip>
-          <TooltipTrigger as-child>
-            <button
-              class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
-              :class="isDark ? 'text-foreground' : ''"
-              @click="uiStore.toggleDark()"
-            >
-              <Moon v-if="isDark" class="size-3" />
-              <Sun v-else class="size-3" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
-            <p>{{ isDark ? '浅色模式' : '深色模式' }}</p>
-          </TooltipContent>
-        </Tooltip>
+        </div>
       </div>
     </TooltipProvider>
   </footer>

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -473,7 +473,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     },
     buildReadingTime,
     createContainer(content: string) {
-      return styledContent(`container mx-auto`, content, `section`)
+      return styledContent(`container`, content, `section`)
     },
     getOpts,
   }

--- a/packages/core/src/theme/cssScopeWrapper.ts
+++ b/packages/core/src/theme/cssScopeWrapper.ts
@@ -38,6 +38,9 @@ export function wrapCSSWithScope(css: string, scope: string = `#output`): string
             return trimmed
           }
 
+          // 旧根容器类名兼容
+          trimmed = trimmed.replace(/\.md-container\b/g, `.container`)
+
           // 获取选择器的第一部分（基础选择器）
           const baseSelector = trimmed.split(/[\s>+~:[]/, 1)[0].trim()
 

--- a/packages/shared/src/assets/default-custom-theme.txt
+++ b/packages/shared/src/assets/default-custom-theme.txt
@@ -13,7 +13,7 @@
 }
 
 /* 根容器 */
-.md-container {
+.container {
 }
 
 /* 标题样式 */

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -5,7 +5,7 @@
 
 /* ==================== 容器样式 ==================== */
 section,
-container {
+#output .container {
   font-family: var(--md-font-family);
   font-size: var(--md-font-size);
   line-height: 1.75;


### PR DESCRIPTION
## Summary

- Rename the article root container from `.md-container` to `.container` so custom theme CSS matches the rendered HTML (`<section class="container">`).
- Migrate legacy `.md-container` selectors automatically in `cssScopeWrapper`.
- Scope base container typography to `#output .container` to avoid affecting app layout classes.
- Slightly adjust footer icon spacing and group account/sync/theme actions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Style/UI
- [ ] Documentation
- [ ] CI/workflow

## Test Procedure

- [ ] Open the web editor and verify custom theme `.container { padding: 0 40px; }` applies to the preview root section.
- [ ] Confirm legacy `.md-container` rules in saved custom CSS still apply after migration.
- [ ] Check footer spacing for view controls and the rightmost account/sync/theme icons.

## Pre-flight Checklist

- [x] Changes are limited in scope and focused on the described fixes
- [ ] Manually tested in the web app preview
- [x] No secrets or environment files included
- [ ] CI checks pass
