### PR TITLE
feat(share): add Pro-only share management and revoke

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -25,7 +25,9 @@ doocs/md 的后端 API，基于 **Cloudflare Workers + Hono + D1**，提供 GitH
 - `GET  /sync/pull?since=<ms>` 拉取游标之后的变更
 - `POST /sync/push` 推送本地变更（LWW 合并）
 - `POST /sync/activate` 用爱发电订单号激活 Pro（需登录）
+- `GET  /share` 列出当前用户的分享（需登录 + Pro；不含 HTML 快照）
 - `POST /share` 创建/更新预览分享（需登录；按 `user_id + post_id` 去重）
+- `DELETE /share/:id` 取消分享（需登录 + Pro；链接立即失效）
 - `GET  /s/:shareId` 只读分享页（有密码时需先解锁）
 - `POST /s/:shareId/unlock` 校验分享密码并写入访问 Cookie
 - `POST /webhooks/afdian` 爱发电订单 Webhook
@@ -113,12 +115,13 @@ VITE_AFDIAN_ORDER_BASE=https://ifdian.net
 
 ## 套餐说明
 
-| 能力              | 免费       | Pro           |
-| ----------------- | ---------- | ------------- |
-| 手动同步          | ✅         | ✅            |
-| 自动同步          | —          | 编辑后约 3 秒 |
-| 同步频率上限      | 30 次/小时 | 300 次/小时   |
-| 分享（新建/更新） | 2 次/天    | 不限          |
+| 能力                  | 免费       | Pro           |
+| --------------------- | ---------- | ------------- |
+| 手动同步              | ✅         | ✅            |
+| 自动同步              | —          | 编辑后约 3 秒 |
+| 同步频率上限          | 30 次/小时 | 300 次/小时   |
+| 分享（新建/更新）     | 2 次/天    | 不限          |
+| 我的分享（管理/取消） | —          | ✅            |
 
 爱发电每赞助 1 个月 = **31 天** Pro 有效期。
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ import { cors } from 'hono/cors'
 import { activateHandler } from './activate'
 import { authMiddleware, authRoutes, meHandler } from './auth'
 import { isAllowedOrigin } from './origin'
-import { createShareHandler, unlockShareHandler, viewShareHandler } from './share'
+import { createShareHandler, deleteShareHandler, listSharesHandler, unlockShareHandler, viewShareHandler } from './share'
 import { SHARE_FAVICON_PATH } from './share-head'
 import { pullHandler, pushHandler } from './sync'
 import { afdianWebhookHandler } from './webhook'
@@ -15,7 +15,7 @@ const app = new Hono<{ Bindings: Env, Variables: { userId: string } }>()
 app.use(`*`, async (c, next) => {
   const handler = cors({
     origin: origin => (isAllowedOrigin(c.env, origin) ? origin : null),
-    allowMethods: [`GET`, `POST`, `OPTIONS`],
+    allowMethods: [`GET`, `POST`, `DELETE`, `OPTIONS`],
     allowHeaders: [`Authorization`, `Content-Type`],
     credentials: true,
     maxAge: 86400,
@@ -43,7 +43,9 @@ api.get(`/me`, meHandler)
 api.get(`/sync/pull`, pullHandler)
 api.post(`/sync/push`, pushHandler)
 api.post(`/sync/activate`, activateHandler)
+api.get(`/share`, listSharesHandler)
 api.post(`/share`, createShareHandler)
+api.delete(`/share/:id`, deleteShareHandler)
 
 app.route(`/`, api)
 

--- a/apps/api/src/share-db.ts
+++ b/apps/api/src/share-db.ts
@@ -15,6 +15,43 @@ export async function getShareById(db: D1Database, id: string): Promise<ShareRow
   return db.prepare(`SELECT * FROM shares WHERE id = ?`).bind(id).first<ShareRow>()
 }
 
+export interface ShareListRow {
+  id: string
+  post_id: string
+  title: string
+  password_hash: string | null
+  created_at: number
+  expires_at: number | null
+  view_count: number
+}
+
+export async function listSharesByUserId(db: D1Database, userId: string): Promise<ShareListRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, post_id, title, password_hash, created_at, expires_at, view_count
+       FROM shares
+       WHERE user_id = ?
+       ORDER BY created_at DESC`,
+    )
+    .bind(userId)
+    .all<ShareListRow>()
+
+  return result.results ?? []
+}
+
+export async function deleteShareByUserAndId(
+  db: D1Database,
+  userId: string,
+  id: string,
+): Promise<boolean> {
+  const result = await db
+    .prepare(`DELETE FROM shares WHERE user_id = ? AND id = ?`)
+    .bind(userId, id)
+    .run()
+
+  return (result.meta.changes ?? 0) > 0
+}
+
 export async function insertShare(
   db: D1Database,
   row: {

--- a/apps/api/src/share-types.ts
+++ b/apps/api/src/share-types.ts
@@ -39,3 +39,19 @@ export interface CreateShareResponse {
   /** 仅 passwordMode=auto 时返回系统生成的明文密码 */
   password?: string
 }
+
+export interface ShareListItem {
+  id: string
+  postId: string
+  title: string
+  url: string
+  createdAt: number
+  expiresAt: number | null
+  viewCount: number
+  protected: boolean
+  expired: boolean
+}
+
+export interface ListSharesResponse {
+  shares: ShareListItem[]
+}

--- a/apps/api/src/share.ts
+++ b/apps/api/src/share.ts
@@ -9,12 +9,14 @@ import {
   peekShareCreateRateLimit,
 } from './plan'
 import {
+  deleteShareByUserAndId,
   getShareById,
   getShareByUserAndPostId,
   getShareRateLimitCount,
   incrementShareRateLimit,
   incrementShareViewCount,
   insertShare,
+  listSharesByUserId,
   shareRateLimitRetryAfterSec,
   updateShareContent,
 } from './share-db'
@@ -177,6 +179,65 @@ async function parseUnlockPassword(c: Context<{ Bindings: Env }>): Promise<strin
   }
 }
 
+const SHARE_ID_RE = /^[a-f0-9]{12}$/i
+
+type ShareManageAccess = { ok: true } | { ok: false, error: `not_found` | `pro_required` }
+
+async function requireProForShareManage(
+  c: Context<{ Bindings: Env, Variables: { userId: string } }>,
+): Promise<ShareManageAccess> {
+  const user = await getUserById(c.env.DB, c.get(`userId`))
+  if (!user)
+    return { ok: false, error: `not_found` }
+
+  const plan = getEffectivePlan(user.plan ?? `free`, user.plan_expires_at ?? null)
+  if (plan !== `pro`)
+    return { ok: false, error: `pro_required` }
+
+  return { ok: true }
+}
+
+export async function listSharesHandler(c: Context<{ Bindings: Env, Variables: { userId: string } }>) {
+  const access = await requireProForShareManage(c)
+  if (!access.ok)
+    return c.json({ error: access.error }, access.error === `pro_required` ? 403 : 404)
+
+  const userId = c.get(`userId`)
+  const rows = await listSharesByUserId(c.env.DB, userId)
+  const now = Date.now()
+
+  return c.json({
+    shares: rows.map(row => ({
+      id: row.id,
+      postId: row.post_id,
+      title: row.title,
+      url: buildShareUrl(c, row.id),
+      createdAt: row.created_at,
+      expiresAt: row.expires_at,
+      viewCount: row.view_count,
+      protected: row.password_hash != null,
+      expired: row.expires_at != null && row.expires_at <= now,
+    })),
+  })
+}
+
+export async function deleteShareHandler(c: Context<{ Bindings: Env, Variables: { userId: string } }>) {
+  const access = await requireProForShareManage(c)
+  if (!access.ok)
+    return c.json({ error: access.error }, access.error === `pro_required` ? 403 : 404)
+
+  const id = c.req.param(`id`)
+  if (!id || !SHARE_ID_RE.test(id))
+    return c.json({ error: `invalid_id` }, 400)
+
+  const userId = c.get(`userId`)
+  const deleted = await deleteShareByUserAndId(c.env.DB, userId, id)
+  if (!deleted)
+    return c.json({ error: `not_found` }, 404)
+
+  return c.json({ ok: true })
+}
+
 export async function createShareHandler(c: Context<{ Bindings: Env, Variables: { userId: string } }>) {
   let body: CreateShareRequest
   try {
@@ -277,7 +338,7 @@ export async function createShareHandler(c: Context<{ Bindings: Env, Variables: 
 
 export async function viewShareHandler(c: Context<{ Bindings: Env }>) {
   const id = c.req.param(`shareId`)
-  if (!id || !/^[a-f0-9]{12}$/i.test(id))
+  if (!id || !SHARE_ID_RE.test(id))
     return c.text(`Not Found`, 404)
 
   const share = await getShareById(c.env.DB, id)

--- a/apps/web/src/components/editor/editor-header/ShareDialog.vue
+++ b/apps/web/src/components/editor/editor-header/ShareDialog.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
-import type { SharePasswordMode } from '@/services/share/types'
-import { Check, Clock, Copy, ExternalLink, Globe, KeyRound, Loader2, LogIn, Share2, Sparkles } from '@lucide/vue'
+import type { ShareListItem, SharePasswordMode } from '@/services/share/types'
+import { Check, Clock, Copy, ExternalLink, Eye, Globe, KeyRound, Loader2, LogIn, RefreshCw, Share2, Sparkles, Trash2 } from '@lucide/vue'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { captureShareSnapshot } from '@/services/share/capture-snapshot'
 import { isShareConfigured, ShareApiError, ShareClient } from '@/services/share/client'
 import { useAuthStore } from '@/stores/auth'
+import { useConfirmStore } from '@/stores/confirm'
 import { usePostStore } from '@/stores/post'
 import { useUIStore } from '@/stores/ui'
 
@@ -49,8 +51,14 @@ const passwordOptions: PasswordOption[] = [
 const authStore = useAuthStore()
 const postStore = usePostStore()
 const uiStore = useUIStore()
+const confirmStore = useConfirmStore()
 
 const { isLoggedIn, user } = storeToRefs(authStore)
+
+const activeTab = ref<`create` | `manage`>(`create`)
+const shareList = ref<ShareListItem[]>([])
+const isLoadingList = ref(false)
+const revokingId = ref<string | null>(null)
 
 const isProUser = computed(() => {
   if (!user.value || user.value.plan !== `pro`)
@@ -98,6 +106,70 @@ function resetForm() {
   errorMessage.value = ``
   copiedLink.value = false
   copiedPassword.value = false
+}
+
+function resetDialog() {
+  activeTab.value = `create`
+  resetForm()
+}
+
+function formatShareTitle(title: string): string {
+  const trimmed = title.trim()
+  return trimmed || `无标题`
+}
+
+function formatShareExpiry(expiresAt: number | null, expired: boolean): string {
+  if (expired)
+    return `已过期`
+  if (!expiresAt)
+    return `永久有效`
+  return `${new Date(expiresAt).toLocaleString(`zh-CN`)} 过期`
+}
+
+async function loadShareList() {
+  if (!isLoggedIn.value)
+    return
+
+  isLoadingList.value = true
+  try {
+    const result = await shareClient.list()
+    shareList.value = result.shares
+  }
+  catch (err) {
+    const message = err instanceof ShareApiError && err.message === `pro_required`
+      ? `我的分享为 Pro 专属功能`
+      : err instanceof Error ? err.message : String(err)
+    toast.error(`加载分享列表失败：${message}`)
+  }
+  finally {
+    isLoadingList.value = false
+  }
+}
+
+function confirmRevokeShare(share: ShareListItem) {
+  confirmStore.confirm({
+    title: `取消分享`,
+    description: `确定取消「${formatShareTitle(share.title)}」的分享吗？链接将立即失效。`,
+    confirmText: `取消分享`,
+    destructive: true,
+    onConfirm: async () => {
+      revokingId.value = share.id
+      try {
+        await shareClient.revoke(share.id)
+        shareList.value = shareList.value.filter(item => item.id !== share.id)
+        if (shareUrl.value === share.url)
+          resetForm()
+        toast.success(`已取消分享`)
+      }
+      catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        toast.error(`取消分享失败：${message}`)
+      }
+      finally {
+        revokingId.value = null
+      }
+    },
+  })
 }
 
 function openAccountDialog() {
@@ -211,12 +283,26 @@ async function copyShareBundle() {
 
 function openSharePage() {
   if (shareUrl.value)
-    window.open(shareUrl.value, `_blank`, `noopener,noreferrer`)
+    openShareUrl(shareUrl.value)
+}
+
+function openShareUrl(url: string) {
+  window.open(url, `_blank`, `noopener,noreferrer`)
 }
 
 watch(() => props.open, (visible) => {
   if (visible)
-    resetForm()
+    resetDialog()
+})
+
+watch(activeTab, (tab) => {
+  if (tab === `manage` && props.open && isProUser.value)
+    loadShareList()
+})
+
+watch(isProUser, (pro) => {
+  if (!pro && activeTab.value === `manage`)
+    activeTab.value = `create`
 })
 </script>
 
@@ -247,138 +333,225 @@ watch(() => props.open, (visible) => {
         </Button>
       </div>
 
-      <template v-else-if="!shareUrl">
-        <div class="space-y-4 px-6 py-4">
-          <div class="flex flex-wrap gap-2">
-            <span class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground">
-              <Clock class="size-3.5" />
-              1 天后过期
-            </span>
-            <span
-              v-if="!isProUser"
-              class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground"
-            >
-              2 次/天
-            </span>
-          </div>
+      <Tabs v-else v-model="activeTab" class="gap-0">
+        <TabsList v-if="isProUser" class="mx-6 mt-4 grid w-auto grid-cols-2">
+          <TabsTrigger value="create">
+            生成分享
+          </TabsTrigger>
+          <TabsTrigger value="manage">
+            我的分享
+          </TabsTrigger>
+        </TabsList>
 
-          <div class="space-y-2">
-            <Label class="text-sm">访问密码</Label>
-            <div class="grid gap-2">
-              <button
-                v-for="option in passwordOptions"
-                :key="option.value"
-                type="button"
-                class="flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors"
-                :class="passwordMode === option.value
-                  ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
-                  : 'hover:bg-muted/50'"
-                @click="passwordMode = option.value"
-              >
-                <component :is="option.icon" class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                <span class="min-w-0 flex-1">
-                  <span class="block text-sm font-medium">{{ option.label }}</span>
-                  <span class="block text-xs text-muted-foreground">{{ option.description }}</span>
+        <TabsContent value="create" class="mt-0">
+          <template v-if="!shareUrl">
+            <div class="space-y-4 px-6 py-4">
+              <div class="flex flex-wrap gap-2">
+                <span class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground">
+                  <Clock class="size-3.5" />
+                  1 天后过期
                 </span>
                 <span
-                  class="mt-1 size-2 shrink-0 rounded-full"
-                  :class="passwordMode === option.value ? 'bg-primary' : 'bg-muted-foreground/30'"
+                  v-if="!isProUser"
+                  class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground"
+                >
+                  2 次/天
+                </span>
+              </div>
+
+              <div class="space-y-2">
+                <Label class="text-sm">访问密码</Label>
+                <div class="grid gap-2">
+                  <button
+                    v-for="option in passwordOptions"
+                    :key="option.value"
+                    type="button"
+                    class="flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors"
+                    :class="passwordMode === option.value
+                      ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
+                      : 'hover:bg-muted/50'"
+                    @click="passwordMode = option.value"
+                  >
+                    <component :is="option.icon" class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                    <span class="min-w-0 flex-1">
+                      <span class="block text-sm font-medium">{{ option.label }}</span>
+                      <span class="block text-xs text-muted-foreground">{{ option.description }}</span>
+                    </span>
+                    <span
+                      class="mt-1 size-2 shrink-0 rounded-full"
+                      :class="passwordMode === option.value ? 'bg-primary' : 'bg-muted-foreground/30'"
+                    />
+                  </button>
+                </div>
+              </div>
+
+              <div v-if="passwordMode === 'custom'" class="space-y-2 pl-1">
+                <Label for="share-custom-password" class="text-xs text-muted-foreground">
+                  输入访问密码
+                </Label>
+                <Input
+                  id="share-custom-password"
+                  v-model="customPassword"
+                  type="password"
+                  autocomplete="new-password"
+                  placeholder="4–64 个字符"
                 />
-              </button>
+              </div>
+
+              <Alert v-if="errorMessage" variant="destructive" class="py-2.5">
+                <AlertDescription class="text-xs">
+                  {{ errorMessage }}
+                </AlertDescription>
+              </Alert>
             </div>
-          </div>
 
-          <div v-if="passwordMode === 'custom'" class="space-y-2 pl-1">
-            <Label for="share-custom-password" class="text-xs text-muted-foreground">
-              输入访问密码
-            </Label>
-            <Input
-              id="share-custom-password"
-              v-model="customPassword"
-              type="password"
-              autocomplete="new-password"
-              placeholder="4–64 个字符"
-            />
-          </div>
-
-          <Alert v-if="errorMessage" variant="destructive" class="py-2.5">
-            <AlertDescription class="text-xs">
-              {{ errorMessage }}
-            </AlertDescription>
-          </Alert>
-        </div>
-
-        <div class="border-t px-6 py-4">
-          <Button class="w-full gap-2" :disabled="isSubmitting || !canSubmit" @click="createShare">
-            <Loader2 v-if="isSubmitting" class="size-4 animate-spin" />
-            <Share2 v-else class="size-4" />
-            {{ isSubmitting ? (submitStage || '正在生成…') : '生成分享链接' }}
-          </Button>
-        </div>
-      </template>
-
-      <template v-else>
-        <div class="space-y-4 px-6 py-4">
-          <Alert class="border-green-200 bg-green-50 py-2.5 text-green-900 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-100">
-            <AlertDescription class="text-xs">
-              分享链接已就绪，可直接复制或打开预览。
-            </AlertDescription>
-          </Alert>
-
-          <div class="space-y-2">
-            <Label for="share-url" class="text-xs text-muted-foreground">分享链接</Label>
-            <div class="flex gap-2">
-              <Input
-                id="share-url"
-                :model-value="shareUrl"
-                readonly
-                class="font-mono text-xs"
-              />
-              <Button variant="outline" size="icon" @click="copyText(shareUrl, 'link')">
-                <Check v-if="copiedLink" class="size-4 text-green-600" />
-                <Copy v-else class="size-4" />
-              </Button>
-              <Button variant="outline" size="icon" @click="openSharePage">
-                <ExternalLink class="size-4" />
+            <div class="border-t px-6 py-4">
+              <Button class="w-full gap-2" :disabled="isSubmitting || !canSubmit" @click="createShare">
+                <Loader2 v-if="isSubmitting" class="size-4 animate-spin" />
+                <Share2 v-else class="size-4" />
+                {{ isSubmitting ? (submitStage || '正在生成…') : '生成分享链接' }}
               </Button>
             </div>
-          </div>
+          </template>
 
-          <div v-if="isProtected && sharePassword" class="space-y-2">
-            <Label for="share-password" class="text-xs text-muted-foreground">访问密码</Label>
-            <div class="flex gap-2">
-              <Input
-                id="share-password"
-                :model-value="sharePassword"
-                readonly
-                class="font-mono text-xs"
-              />
-              <Button variant="outline" size="icon" @click="copyText(sharePassword, 'password')">
-                <Check v-if="copiedPassword" class="size-4 text-green-600" />
-                <Copy v-else class="size-4" />
+          <template v-else>
+            <div class="space-y-4 px-6 py-4">
+              <Alert class="border-green-200 bg-green-50 py-2.5 text-green-900 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-100">
+                <AlertDescription class="text-xs">
+                  分享链接已就绪，可直接复制或打开预览。
+                </AlertDescription>
+              </Alert>
+
+              <div class="space-y-2">
+                <Label for="share-url" class="text-xs text-muted-foreground">分享链接</Label>
+                <div class="flex gap-2">
+                  <Input
+                    id="share-url"
+                    :model-value="shareUrl"
+                    readonly
+                    class="font-mono text-xs"
+                  />
+                  <Button variant="outline" size="icon" @click="copyText(shareUrl, 'link')">
+                    <Check v-if="copiedLink" class="size-4 text-green-600" />
+                    <Copy v-else class="size-4" />
+                  </Button>
+                  <Button variant="outline" size="icon" @click="openSharePage">
+                    <ExternalLink class="size-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div v-if="isProtected && sharePassword" class="space-y-2">
+                <Label for="share-password" class="text-xs text-muted-foreground">访问密码</Label>
+                <div class="flex gap-2">
+                  <Input
+                    id="share-password"
+                    :model-value="sharePassword"
+                    readonly
+                    class="font-mono text-xs"
+                  />
+                  <Button variant="outline" size="icon" @click="copyText(sharePassword, 'password')">
+                    <Check v-if="copiedPassword" class="size-4 text-green-600" />
+                    <Copy v-else class="size-4" />
+                  </Button>
+                </div>
+                <Button variant="outline" class="w-full" @click="copyShareBundle">
+                  复制链接与密码
+                </Button>
+              </div>
+
+              <p v-else-if="isProtected && passwordMode === 'custom'" class="text-xs text-muted-foreground">
+                已启用密码保护，请妥善保管你设置的密码。
+              </p>
+
+              <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <span v-if="expiresLabel">过期：{{ expiresLabel }}</span>
+                <span>预览与编辑器一致</span>
+              </div>
+            </div>
+
+            <div class="border-t px-6 py-4">
+              <Button variant="outline" class="w-full" @click="resetForm">
+                重新设置并生成
               </Button>
             </div>
-            <Button variant="outline" class="w-full" @click="copyShareBundle">
-              复制链接与密码
-            </Button>
+          </template>
+        </TabsContent>
+
+        <TabsContent v-if="isProUser" value="manage" class="mt-0">
+          <div class="space-y-3 px-6 py-4">
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-xs text-muted-foreground">
+                管理已发布的分享链接，取消后链接立即失效。
+              </p>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="shrink-0"
+                title="刷新列表"
+                :disabled="isLoadingList"
+                @click="loadShareList"
+              >
+                <Loader2 v-if="isLoadingList" class="size-4 animate-spin" />
+                <RefreshCw v-else class="size-4" />
+              </Button>
+            </div>
+
+            <div v-if="isLoadingList && shareList.length === 0" class="flex items-center justify-center py-10 text-sm text-muted-foreground">
+              <Loader2 class="mr-2 size-4 animate-spin" />
+              加载中…
+            </div>
+
+            <div v-else-if="shareList.length === 0" class="rounded-lg border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+              暂无分享记录
+            </div>
+
+            <div v-else class="max-h-80 space-y-2 overflow-y-auto pr-1">
+              <div
+                v-for="share in shareList"
+                :key="share.id"
+                class="rounded-lg border p-3"
+                :class="share.expired ? 'opacity-70' : ''"
+              >
+                <div class="flex items-start justify-between gap-2">
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-medium">
+                      {{ formatShareTitle(share.title) }}
+                    </p>
+                    <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                      <span class="inline-flex items-center gap-1">
+                        <Eye class="size-3" />
+                        {{ share.viewCount }} 次阅读
+                      </span>
+                      <span>{{ formatShareExpiry(share.expiresAt, share.expired) }}</span>
+                      <span v-if="share.protected">已设密码</span>
+                    </div>
+                  </div>
+                  <div class="flex shrink-0 items-center gap-1">
+                    <Button variant="ghost" size="icon" title="复制链接" @click="copyText(share.url, 'link')">
+                      <Copy class="size-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" title="打开预览" @click="openShareUrl(share.url)">
+                      <ExternalLink class="size-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      class="text-destructive hover:text-destructive"
+                      title="取消分享"
+                      :disabled="revokingId === share.id"
+                      @click="confirmRevokeShare(share)"
+                    >
+                      <Loader2 v-if="revokingId === share.id" class="size-4 animate-spin" />
+                      <Trash2 v-else class="size-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-
-          <p v-else-if="isProtected && passwordMode === 'custom'" class="text-xs text-muted-foreground">
-            已启用密码保护，请妥善保管你设置的密码。
-          </p>
-
-          <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-            <span v-if="expiresLabel">过期：{{ expiresLabel }}</span>
-            <span>预览与编辑器一致</span>
-          </div>
-        </div>
-
-        <div class="border-t px-6 py-4">
-          <Button variant="outline" class="w-full" @click="resetForm">
-            重新设置并生成
-          </Button>
-        </div>
-      </template>
+        </TabsContent>
+      </Tabs>
     </DialogContent>
   </Dialog>
 </template>

--- a/apps/web/src/services/share/client.ts
+++ b/apps/web/src/services/share/client.ts
@@ -1,4 +1,4 @@
-import type { CreateShareRequest, CreateShareResponse } from './types'
+import type { CreateShareRequest, CreateShareResponse, ListSharesResponse } from './types'
 import { ApiError, MdApiClient } from '@/services/account/client'
 import { isAccountConfigured, MD_API_URL } from '@/services/account/config'
 
@@ -19,8 +19,16 @@ export function getSharePageUrl(id: string): string {
 }
 
 export class ShareClient extends MdApiClient {
+  list(): Promise<ListSharesResponse> {
+    return this.request<ListSharesResponse>(`GET`, `/share`)
+  }
+
   create(payload: CreateShareRequest): Promise<CreateShareResponse> {
     return this.request<CreateShareResponse>(`POST`, `/share`, payload)
+  }
+
+  revoke(id: string): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>(`DELETE`, `/share/${id}`)
   }
 }
 

--- a/apps/web/src/services/share/types.ts
+++ b/apps/web/src/services/share/types.ts
@@ -21,3 +21,19 @@ export interface CreateShareResponse {
   protected: boolean
   password?: string
 }
+
+export interface ShareListItem {
+  id: string
+  postId: string
+  title: string
+  url: string
+  createdAt: number
+  expiresAt: number | null
+  viewCount: number
+  protected: boolean
+  expired: boolean
+}
+
+export interface ListSharesResponse {
+  shares: ShareListItem[]
+}


### PR DESCRIPTION
## Summary

- Add `GET /share` and `DELETE /share/:id` API endpoints for listing and revoking preview share links
- Add a **我的分享** tab in the Share dialog (Pro users only) to view shares, copy/open links, and revoke them
- Gate list/revoke behind Pro on both frontend (tab hidden) and backend (`403 pro_required`)
- Document new endpoints and Pro capability in `apps/api/README.md`

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] `pnpm --filter @md/api run type-check` passes
- [x] Deployed `md-api` Worker to `md-api.doocs.org` and verified health check
- [x] `GET /share` without token returns `401`; non-Pro token would return `403`
- [ ] Manual: Pro user opens Share dialog → **我的分享** tab lists shares, revoke removes link
- [ ] Manual: Free user sees only **生成分享** (no manage tab)

## Pre-flight Checklist

- [x] Commit follows Conventional Commits (English)
- [x] API docs updated (`apps/api/README.md`)
- [x] No secrets committed
- [ ] CI checks pending after PR creation
