### PR TITLE
fix(web): restore blockquote and table styles in exported html

### DIFF
--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -42,6 +42,17 @@ export function addPrefix(str: string) {
 }
 
 /**
+ * 导出 / 分享 / 独立预览的 shell 变量。
+ * 这些变量原本由 Web App 的全局样式（index.css 的 :root）提供，主题 CSS 通过
+ * hsl(var(--foreground)) / var(--blockquote-background) 引用它们。脱离 App 后
+ * 需手动补上，否则表格边框、引用块背景等会因变量未定义而失效。
+ */
+const SHARE_SHELL_VARS_CSS = `:root {
+  --foreground: 0 0% 3.9%;
+  --blockquote-background: #f7f7f7;
+}`
+
+/**
  * 导出原始 Markdown 文档
  * @param {string} doc - 文档内容
  * @param {string} title - 文档标题
@@ -101,6 +112,7 @@ export async function exportHTML(title: string = `untitled`) {
 <head>
   <meta charset="utf-8">
   <title>${sanitizeTitle(title)}</title>
+  <style>${SHARE_SHELL_VARS_CSS}</style>
   ${stylesToAdd}
 </head>
 <body>
@@ -155,6 +167,7 @@ export async function exportPDF(title: string = `untitled`) {
 <head>
   <meta charset="utf-8">
   <title>${safeTitle}</title>
+  <style>${SHARE_SHELL_VARS_CSS}</style>
   ${stylesToAdd}
   <style>
     /* 强制打印背景颜色和图片 */
@@ -276,12 +289,6 @@ function stripOutputScope(cssContent: string): string {
   css = css.replace(/^#output\s*/gm, ``)
   return css
 }
-
-/** 分享页 shell 变量（主题 CSS 中的 hsl(var(--foreground)) 等依赖） */
-const SHARE_SHELL_VARS_CSS = `:root {
-  --foreground: 0 0% 3.9%;
-  --blockquote-background: #f7f7f7;
-}`
 
 function getThemeStyles(): string {
   const themeStyle = document.querySelector(`#md-theme`) as HTMLStyleElement

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -25,6 +25,21 @@ section,
   margin-top: 0 !important;
 }
 
+/*
+ * 兜底重置：导出 HTML / 分享页 / 独立预览等脱离 Web App 的场景
+ * 没有 Tailwind preflight，浏览器 UA 默认样式会冒出来（如
+ * blockquote 默认左右各 40px margin、table 默认 border-collapse: separate）。
+ * 这里统一重置，保证导出结果与预览一致。各主题可在其后覆盖（如 margin-bottom）。
+ */
+#output blockquote {
+  margin: 0;
+}
+
+#output table {
+  border-collapse: collapse;
+  min-width: 100%;
+}
+
 .mermaid-diagram .nodeLabel p {
   color: unset !important;
   letter-spacing: unset !important;

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -26,16 +26,19 @@ section,
 }
 
 /*
- * 兜底重置：导出 HTML / 分享页 / 独立预览等脱离 Web App 的场景
+ * 兜底重置：导出 HTML / 分享页 / VSCode 预览等脱离 Web App 的场景
  * 没有 Tailwind preflight，浏览器 UA 默认样式会冒出来（如
  * blockquote 默认左右各 40px margin、table 默认 border-collapse: separate）。
  * 这里统一重置，保证导出结果与预览一致。各主题可在其后覆盖（如 margin-bottom）。
+ * section 选择器用于 VSCode 预览（无 #output 容器，内容在 section.container 内）。
  */
-#output blockquote {
+#output blockquote,
+section blockquote {
   margin: 0;
 }
 
-#output table {
+#output table,
+section table {
   border-collapse: collapse;
   min-width: 100%;
 }


### PR DESCRIPTION
## Summary

- Add export-safe base resets for `blockquote` and `table` in theme CSS so standalone HTML no longer inherits browser UA defaults (extra blockquote indent, separated table borders).
- Inject shell CSS variables (`--foreground`, `--blockquote-background`) into exported HTML/PDF so table borders and blockquote backgrounds render correctly outside the web app.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

- [ ] Export an article containing blockquotes and tables as HTML
- [ ] Verify blockquote indentation matches in-app preview
- [ ] Verify blockquote background color is visible
- [ ] Verify table borders and collapsed layout are preserved
- [ ] Export PDF and confirm the same styling behavior

## Pre-flight Checklist

- [x] Changes are scoped to export/preview styling
- [x] No secrets or credentials included
- [ ] Manual export verification completed locally
