### PR TITLE
fix(web): use window.fetch and body for MinIO and R2 uploads

### DIFF
--- a/apps/web/src/utils/file.ts
+++ b/apps/web/src/utils/file.ts
@@ -303,13 +303,16 @@ async function minioFileUpload(file: File) {
     ContentType: file.type,
   })
   const presignedUrl = await getSignedUrl(s3Client, command, { expiresIn: 300 })
-  await fetch(presignedUrl, {
+  const minioResponse = await window.fetch(presignedUrl, {
     method: `PUT`,
     headers: {
       'Content-Type': file.type,
     },
-    data: file,
+    body: file,
   })
+  if (!minioResponse.ok) {
+    throw new Error(`MinIO upload failed: ${minioResponse.statusText}`)
+  }
   return `${useSSL ? `https` : `http`}://${endpoint}${port ? `:${port}` : ``}/${bucket}/${dateFilename}`
 }
 
@@ -497,13 +500,16 @@ async function r2Upload(file: File) {
     new PutObjectCommand({ Bucket: bucket, Key: filename, ContentType: file.type }),
     { expiresIn: 300 },
   )
-  await fetch(signedUrl, {
+  const r2Response = await window.fetch(signedUrl, {
     method: `PUT`,
     headers: {
       'Content-Type': file.type,
     },
-    data: file,
+    body: file,
   })
+  if (!r2Response.ok) {
+    throw new Error(`R2 upload failed: ${r2Response.statusText}`)
+  }
   return `${domain}/${filename}`
 }
 

--- a/apps/web/src/utils/file.ts
+++ b/apps/web/src/utils/file.ts
@@ -311,7 +311,7 @@ async function minioFileUpload(file: File) {
     body: file,
   })
   if (!minioResponse.ok) {
-    throw new Error(`MinIO upload failed: ${minioResponse.statusText}`)
+    throw new Error(`MinIO upload failed: ${minioResponse.status} ${minioResponse.statusText}`)
   }
   return `${useSSL ? `https` : `http`}://${endpoint}${port ? `:${port}` : ``}/${bucket}/${dateFilename}`
 }
@@ -508,7 +508,7 @@ async function r2Upload(file: File) {
     body: file,
   })
   if (!r2Response.ok) {
-    throw new Error(`R2 upload failed: ${r2Response.statusText}`)
+    throw new Error(`R2 upload failed: ${r2Response.status} ${r2Response.statusText}`)
   }
   return `${domain}/${filename}`
 }


### PR DESCRIPTION
## 问题

`minioFileUpload` 和 `r2Upload` 函数中的图片上传静默失败：前端显示上传成功，但实际图片 URL 指向空文件。

### 根因

**1. `data` vs `body`**

```typescript
// ❌ 当前代码
await fetch(presignedUrl, {
  method: `PUT`,
  data: file,    // ← Fetch API 不认识 data，这是 Axios 的属性
})
```

`fetch` API 的请求体属性是 `body`，不是 `data`。`data` 被 `fetch` 静默忽略，导致发出的 PUT 请求 body 为空。MinIO/R2 接受空 PUT（返回 200），存储了空文件。

**2. 自定义 fetch vs 原生 fetch**

```typescript
import fetch from "@md/shared/utils/fetch"  // ← 这是 Axios 封装
```

文件顶部导入的 `fetch` 是基于 Axios 的封装，不支持原生 Fetch API 的 `body` 参数，也不返回带有 `.ok` 属性的 `Response` 对象。需要使用 `window.fetch`（原生 Fetch API）。

### 对比

其他上传函数（`aliOSSFileUpload`、`s3Upload`）已正确使用 `window.fetch` + `body` + `response.ok` 检查。MinIO 和 R2 是遗漏。

## 修复

- `data: file` → `body: file`
- `fetch(...)` → `window.fetch(...)`
- 添加 `response.ok` 检查，与其他上传函数保持一致

修改范围：`apps/web/src/utils/file.ts` 中的 `minioFileUpload` 和 `r2Upload` 两个函数。

## 测试

已在自有服务器上构建测试镜像并验证：
- MinIO 上传成功，图片可通过 CDN 正常访问
- 上传失败时正确抛出错误（而非静默成功）