### PR TITLE
fix: prevent inline katex matching inside numbers

### DIFF
--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -61,7 +61,10 @@ function inlineKatex(options: MarkedKatexOptions | undefined, renderer: KatexRen
         if (index === -1) {
           return
         }
-        const f = nonStandard ? index > -1 : index === 0 || indexSrc.charAt(index - 1) === ` `
+        const prevChar = index === 0 ? `` : indexSrc.charAt(index - 1)
+        const f = nonStandard
+          ? !/\d/.test(prevChar)
+          : index === 0 || prevChar === ` `
         if (f) {
           const possibleKatex = indexSrc.substring(index)
 

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -9,7 +9,45 @@ export interface MarkedKatexOptions {
 }
 
 const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:？！。，：]|$)/
-const inlineRuleNonStandard = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1/ // Non-standard, even if there are no spaces before and after $ or $$, try to parse
+// Non-standard: allow tight `$...$`; amount-like `$` is filtered in findInlineKatexStart
+const inlineRuleNonStandard = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1/
+
+/** nonStandard 模式下，跳过更像金额后缀的 `$` */
+function isAmountDollarSign(src: string, index: number): boolean {
+  if (index <= 0)
+    return false
+  const prev = src.charAt(index - 1)
+  if (/[\d,.]/.test(prev))
+    return true
+  return prev === ` ` && index >= 2 && /\d/.test(src.charAt(index - 2))
+}
+
+function isInlineKatexStart(src: string, index: number, nonStandard: boolean): boolean {
+  if (nonStandard)
+    return !isAmountDollarSign(src, index)
+  return index === 0 || src.charAt(index - 1) === ` `
+}
+
+function findInlineKatexStart(src: string, nonStandard: boolean, ruleReg: RegExp): number | undefined {
+  let indexSrc = src
+  let offset = 0
+
+  while (indexSrc) {
+    const index = indexSrc.indexOf(`$`)
+    if (index === -1)
+      return
+
+    if (isInlineKatexStart(indexSrc, index, nonStandard)) {
+      const possibleKatex = indexSrc.substring(index)
+      if (possibleKatex.match(ruleReg))
+        return offset + index
+    }
+
+    const next = indexSrc.substring(index + 1).replace(/^\$+/, ``)
+    offset += indexSrc.length - next.length
+    indexSrc = next
+  }
+}
 
 const blockRule = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
 
@@ -53,28 +91,7 @@ function inlineKatex(options: MarkedKatexOptions | undefined, renderer: KatexRen
     name: `inlineKatex`,
     level: `inline` as const,
     start(src: string) {
-      let index
-      let indexSrc = src
-
-      while (indexSrc) {
-        index = indexSrc.indexOf(`$`)
-        if (index === -1) {
-          return
-        }
-        const prevChar = index === 0 ? `` : indexSrc.charAt(index - 1)
-        const f = nonStandard
-          ? !/\d/.test(prevChar)
-          : index === 0 || prevChar === ` `
-        if (f) {
-          const possibleKatex = indexSrc.substring(index)
-
-          if (possibleKatex.match(ruleReg)) {
-            return index
-          }
-        }
-
-        indexSrc = indexSrc.substring(index + 1).replace(/^\$+/, ``)
-      }
+      return findInlineKatexStart(src, !!nonStandard, ruleReg)
     },
     tokenizer(src: string) {
       const match = src.match(ruleReg)


### PR DESCRIPTION
先做一个版本的小修复

```md
# 行内公式匹配回归测试

## A. 应命中（行内公式）

[应命中] 这是标准写法：$E=mc^2$。  
[应命中] 中文邻接写法：这是$\\alpha+\\beta$测试。  
[应命中] 非标准紧贴：a$bc$def  
[应命中] 双美元行内：这是 $$a+b$$ 的示例。  
[应命中] 含转义美元：$a\\$b$  

## B. 不应命中（金额场景）

[不应命中] 水是 10$，地铁消费 20$  
[不应命中] 测试 10$，我的钱包 10$，还有100$  
[不应命中] 午餐 35$，咖啡 18$，总计 53$

## C. 不应命中（语法不完整）

[不应命中] 只有起始符号：$x+1  
[不应命中] 只有结束符号：x+1$  
[不应命中] 孤立美元符号：今天花了 $

## D. 混合场景（同时有金额和公式）

[应仅命中公式] 价格 10$，但公式是 $x+1$，后来又花了 20$。  
[应仅命中公式] 预算 99$，计算式 $a^2+b^2=c^2$，余额 1$。

```