### PR TITLE
feat(web): add slash command palette with edit and style actions

### DIFF
--- a/apps/web/src/components/editor/EditorContextMenu.vue
+++ b/apps/web/src/components/editor/EditorContextMenu.vue
@@ -29,13 +29,12 @@ import {
   Wand2,
 } from '@lucide/vue'
 import { altSign, headingLevels as baseHeadingLevels, ctrlKey, ctrlSign, shiftSign } from '@md/shared/configs'
-import DEFAULT_CONTENT from '@/assets/example/markdown.md?raw'
+import { useEditorDocumentActions } from '@/composables/useEditorDocumentActions'
 import { useEditorFormat } from '@/composables/useEditorFormat'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCssEditorStore } from '@/stores/cssEditor'
 import { useEditorStore } from '@/stores/editor'
 import { useExportStore } from '@/stores/export'
-import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
 import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
@@ -46,7 +45,6 @@ const confirmStore = useConfirmStore()
 const cssEditorStore = useCssEditorStore()
 const editorStore = useEditorStore()
 const exportStore = useExportStore()
-const postStore = usePostStore()
 const renderStore = useRenderStore()
 const themeStore = useThemeStore()
 const uiStore = useUIStore()
@@ -62,30 +60,13 @@ const { editor } = storeToRefs(editorStore)
 
 const { addFormat } = useEditorFormat(editor)
 
+const { formatContent, resetContent, clearContent } = useEditorDocumentActions()
+
 const headingIcons = [Heading1, Heading2, Heading3, Heading4, Heading5, Heading6]
 const headingLevels = baseHeadingLevels.map((item, index) => ({
   ...item,
   icon: headingIcons[index],
 }))
-
-// 格式化文档
-async function formatContent() {
-  const doc = await editorStore.formatContent()
-  if (doc && postStore.currentPost) {
-    postStore.updatePostContent(postStore.currentPostId, doc)
-  }
-}
-
-// 导入默认内容
-function importDefaultContent() {
-  editorStore.importContent(DEFAULT_CONTENT)
-  toast.success(`文档已重置`)
-}
-
-// 清空内容
-function clearContent() {
-  editorStore.clearContent()
-}
 
 function openFormulaEditor() {
   const selection = normalizeFormulaInput(editorStore.getSelection())
@@ -314,9 +295,9 @@ function downloadAsCardImage() {
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">F</kbd>
         </ContextMenuShortcut>
       </ContextMenuItem>
-      <ContextMenuItem @click="importDefaultContent()">
+      <ContextMenuItem @click="resetContent()">
         <RefreshCw class="mr-2 h-4 w-4" />
-        重置文档
+        重置
       </ContextMenuItem>
       <ContextMenuItem @click="resetStyleConfirm()">
         <RotateCcw class="mr-2 h-4 w-4" />
@@ -324,7 +305,7 @@ function downloadAsCardImage() {
       </ContextMenuItem>
       <ContextMenuItem @click="clearContent()">
         <Trash2 class="mr-2 h-4 w-4" />
-        清空内容
+        清空
       </ContextMenuItem>
 
       <ContextMenuSeparator />

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import type { ComponentPublicInstance } from 'vue'
-
 import { Compartment, EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { markdownSetup, theme } from '@md/shared/editor'
@@ -26,7 +24,27 @@ const themeStore = useThemeStore()
 const uiStore = useUIStore()
 const { upload } = useImageUploader()
 
-const slashCommand = useSlashCommand()
+const {
+  visible: slashVisible,
+  position: slashPosition,
+  filter: slashFilter,
+  activeIndex: slashActiveIndex,
+  basicCommands: slashBasicCommands,
+  commonCommands: slashCommonCommands,
+  editCommands: slashEditCommands,
+  styleCommands: slashStyleCommands,
+  filteredCommands: slashFilteredCommands,
+  closeMenu: closeSlashMenu,
+  executeCommand: executeSlashCommand,
+  createExtension: createSlashExtension,
+} = useSlashCommand()
+
+function onWrapperContextMenuCapture(e: MouseEvent) {
+  if (!slashVisible.value)
+    return
+  e.preventDefault()
+  e.stopPropagation()
+}
 
 const { editor } = storeToRefs(editorStore)
 const { isDark } = storeToRefs(uiStore)
@@ -46,7 +64,7 @@ const themeCompartment = new Compartment()
 const changeTimer = ref<ReturnType<typeof setTimeout>>()
 
 const editorRef = useTemplateRef<HTMLDivElement>(`editorRef`)
-const codeMirrorWrapper = useTemplateRef<ComponentPublicInstance<HTMLDivElement>>(`codeMirrorWrapper`)
+const codeMirrorWrapper = useTemplateRef<HTMLDivElement>(`codeMirrorWrapper`)
 
 const progressValue = ref(0)
 const isImgLoading = ref(false)
@@ -459,7 +477,7 @@ function createFormTextArea(dom: HTMLDivElement) {
       EditorView.domEventHandlers({
         paste: createPasteHandler(),
       }),
-      ...slashCommand.createExtension(() => codeMirrorView.value),
+      ...createSlashExtension(() => codeMirrorView.value),
     ],
   })
 
@@ -567,17 +585,22 @@ defineExpose({
     v-show="viewMode !== 'preview'"
     ref="codeMirrorWrapper"
     class="codeMirror-wrapper relative h-full"
+    @contextmenu.capture="onWrapperContextMenuCapture"
   >
     <SearchTab v-if="codeMirrorView" ref="searchTabRef" :editor-view="codeMirrorView as any" />
     <SlashCommandMenu
-      :visible="slashCommand.visible.value"
-      :position="slashCommand.position.value"
-      :active-index="slashCommand.activeIndex.value"
-      :basic-commands="slashCommand.basicCommands.value"
-      :common-commands="slashCommand.commonCommands.value"
-      :filtered-commands="slashCommand.filteredCommands.value"
-      @execute="(cmd) => codeMirrorView && slashCommand.executeCommand(codeMirrorView, cmd)"
-      @close="slashCommand.closeMenu()"
+      :visible="slashVisible"
+      :position="slashPosition"
+      :active-index="slashActiveIndex"
+      :filter="slashFilter"
+      :container-el="codeMirrorWrapper"
+      :basic-commands="slashBasicCommands"
+      :common-commands="slashCommonCommands"
+      :edit-commands="slashEditCommands"
+      :style-commands="slashStyleCommands"
+      :filtered-commands="slashFilteredCommands"
+      @execute="(cmd) => codeMirrorView && executeSlashCommand(codeMirrorView, cmd)"
+      @close="closeSlashMenu()"
     />
     <SidebarAIToolbar
       :is-mobile="isMobile"

--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -399,7 +399,7 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
 <template>
   <footer
-    class="flex select-none items-center overflow-hidden px-3 py-1 text-xs text-muted-foreground"
+    class="flex select-none items-center overflow-hidden px-3 py-1 text-xs text-muted-foreground max-md:px-4 max-md:py-1.5 max-md:pb-[max(0.375rem,env(safe-area-inset-bottom,0px))]"
   >
     <TooltipProvider :delay-duration="300">
       <!-- 左侧：光标位置 & 选区 -->

--- a/apps/web/src/components/editor/SlashCommandMenu.vue
+++ b/apps/web/src/components/editor/SlashCommandMenu.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
+import type { Component } from 'vue'
 import type { SlashCommandItem } from '@/composables/useSlashCommand'
 import {
+  Blocks,
+  Bold,
   Braces,
+  ChevronDown,
+  Code,
   Heading1,
   Heading2,
   Heading3,
@@ -9,21 +14,40 @@ import {
   Heading5,
   Heading6,
   Image,
+  Italic,
   Link,
   List,
   ListOrdered,
   Minus,
+  Palette,
   Quote,
+  RefreshCw,
+  Search,
   Sigma,
+  Strikethrough,
   Table,
+  Trash2,
+  WandSparkles,
 } from '@lucide/vue'
+import {
+  SLASH_BASIC_BLOCK_IDS,
+  SLASH_BASIC_FORMAT_IDS,
+  SLASH_EDIT_DOC_IDS,
+  SLASH_HEADING_IDS,
+} from '@/composables/slashCommands'
+import { useSlashMenuPosition } from '@/composables/useSlashMenuPosition'
+import { useSlashMenuScrollHint } from '@/composables/useSlashMenuScrollHint'
 
 const props = defineProps<{
   visible: boolean
-  position: { x: number, y: number }
+  position: { x: number, y: number, top: number }
   activeIndex: number
+  filter: string
+  containerEl: HTMLElement | null
   basicCommands: SlashCommandItem[]
   commonCommands: SlashCommandItem[]
+  editCommands: SlashCommandItem[]
+  styleCommands: SlashCommandItem[]
   filteredCommands: SlashCommandItem[]
 }>()
 
@@ -32,8 +56,7 @@ const emit = defineEmits<{
   close: []
 }>()
 
-// Map icon names to lucide components
-const iconMap: Record<string, any> = {
+const iconMap: Record<string, Component> = {
   'H1': Heading1,
   'H2': Heading2,
   'H3': Heading3,
@@ -44,70 +67,144 @@ const iconMap: Record<string, any> = {
   'unordered-list': List,
   'blockquote': Quote,
   'divider': Minus,
-  'link': Link,
   'code': Braces,
   'formula': Sigma,
   'image': Image,
   'table': Table,
+  'blocks': Blocks,
+  'bold': Bold,
+  'italic': Italic,
+  'strikethrough': Strikethrough,
+  'code-inline': Code,
+  'link-wrap': Link,
+  'format': WandSparkles,
+  'reset': RefreshCw,
+  'clear': Trash2,
+  'find': Search,
+  'theme': Palette,
+  'color': Palette,
 }
 
-// Heading items use text labels in the grid; others use icon + label in list
-const headingIds = [`h1`, `h2`, `h3`, `h4`, `h5`, `h6`]
-
 const menuRef = useTemplateRef<HTMLDivElement>(`menuRef`)
+const scrollRef = useTemplateRef<HTMLDivElement>(`scrollRef`)
 
-// Calculate adjusted position so the menu stays in viewport
-const adjustedPosition = computed(() => {
-  const MENU_HEIGHT = 320
-  const MENU_WIDTH = 240
-  const PADDING = 8
+const visibleRef = toRef(props, `visible`)
+const positionRef = toRef(props, `position`)
+const filterRef = toRef(props, `filter`)
+const activeIndexRef = toRef(props, `activeIndex`)
+const containerElRef = toRef(props, `containerEl`)
+const filteredCommandsLengthRef = computed(() => props.filteredCommands.length)
 
-  let { x, y } = props.position
+const isFiltering = computed(() => props.filter.trim().length > 0)
 
-  // Adjust horizontal
-  if (x + MENU_WIDTH > window.innerWidth - PADDING) {
-    x = window.innerWidth - MENU_WIDTH - PADDING
-  }
-  if (x < PADDING) {
-    x = PADDING
-  }
+const headingCommands = computed(() =>
+  props.basicCommands.filter(c => SLASH_HEADING_IDS.includes(c.id as typeof SLASH_HEADING_IDS[number])),
+)
 
-  // Adjust vertical — prefer below cursor, flip above if insufficient space
-  if (y + MENU_HEIGHT > window.innerHeight - PADDING) {
-    // Position above cursor (need cursor top, approximate with -24px offset)
-    y = y - MENU_HEIGHT - 28
-  }
+const basicBlockCommands = computed(() =>
+  props.basicCommands.filter(c => SLASH_BASIC_BLOCK_IDS.includes(c.id as typeof SLASH_BASIC_BLOCK_IDS[number])),
+)
 
-  return { x, y }
+const basicFormatCommands = computed(() =>
+  props.basicCommands.filter(c => SLASH_BASIC_FORMAT_IDS.includes(c.id as typeof SLASH_BASIC_FORMAT_IDS[number])),
+)
+
+const editDocCommands = computed(() =>
+  props.editCommands.filter(c => SLASH_EDIT_DOC_IDS.includes(c.id as typeof SLASH_EDIT_DOC_IDS[number])),
+)
+
+const styleThemeCommands = computed(() =>
+  props.styleCommands.filter(c => c.id.startsWith(`theme-`)),
+)
+
+const styleColorCommands = computed(() =>
+  props.styleCommands.filter(c => c.id.startsWith(`color-`)),
+)
+
+const {
+  adjustedPosition,
+  updateAdjustedPosition,
+  bindContainerObserver,
+  unbindContainerObserver,
+} = useSlashMenuPosition({
+  visible: visibleRef,
+  position: positionRef,
+  filter: filterRef,
+  containerEl: containerElRef,
+  menuRef,
+  isFiltering,
 })
 
-// Close on outside click
+const {
+  canScrollDown,
+  updateScrollHint,
+  scrollActiveIntoView,
+  bindScrollContentObserver,
+  unbindScrollContentObserver,
+} = useSlashMenuScrollHint({
+  visible: visibleRef,
+  scrollRef,
+  menuRef,
+  filter: filterRef,
+  filteredCommandsLength: filteredCommandsLengthRef,
+  activeIndex: activeIndexRef,
+})
+
 function handleOutsideClick(e: MouseEvent) {
-  if (menuRef.value && !menuRef.value.contains(e.target as Node)) {
+  if (menuRef.value && !menuRef.value.contains(e.target as Node))
     emit(`close`)
-  }
+}
+
+function getGlobalIndex(command: SlashCommandItem): number {
+  return props.filteredCommands.indexOf(command)
+}
+
+function isActive(command: SlashCommandItem) {
+  return getGlobalIndex(command) === props.activeIndex
+}
+
+function shortThemeLabel(label: string) {
+  return label.replace(/^主题 · /, ``)
+}
+
+function shortColorLabel(label: string) {
+  return label.replace(/^主题色 · /, ``)
 }
 
 watch(
   () => props.visible,
-  (val) => {
-    if (val) {
+  (visible) => {
+    if (visible) {
+      bindContainerObserver()
+      bindScrollContentObserver()
       nextTick(() => {
+        updateAdjustedPosition()
+        updateScrollHint()
         document.addEventListener(`mousedown`, handleOutsideClick)
         scrollActiveIntoView()
       })
     }
     else {
+      unbindContainerObserver()
+      unbindScrollContentObserver()
+      canScrollDown.value = false
       document.removeEventListener(`mousedown`, handleOutsideClick)
     }
   },
 )
 
-onUnmounted(() => {
-  document.removeEventListener(`mousedown`, handleOutsideClick)
-})
+watch(
+  () => [props.visible, props.position.x, props.position.y, props.position.top, props.filter, props.containerEl] as const,
+  () => {
+    if (!props.visible)
+      return
+    nextTick(() => {
+      updateAdjustedPosition()
+      updateScrollHint()
+    })
+  },
+)
 
-// Scroll active item into view when navigating
 watch(
   () => props.activeIndex,
   () => {
@@ -115,16 +212,11 @@ watch(
   },
 )
 
-function scrollActiveIntoView() {
-  nextTick(() => {
-    const el = menuRef.value?.querySelector(`[data-active="true"]`)
-    el?.scrollIntoView({ block: `nearest` })
-  })
-}
-
-function getGlobalIndex(command: SlashCommandItem): number {
-  return props.filteredCommands.indexOf(command)
-}
+onUnmounted(() => {
+  unbindContainerObserver()
+  unbindScrollContentObserver()
+  document.removeEventListener(`mousedown`, handleOutsideClick)
+})
 </script>
 
 <template>
@@ -132,258 +224,550 @@ function getGlobalIndex(command: SlashCommandItem): number {
     <div
       v-if="visible"
       ref="menuRef"
-      class="slash-command-menu"
+      class="slash-command-menu rounded-md shadow-md"
       :style="{
         left: `${adjustedPosition.x}px`,
         top: `${adjustedPosition.y}px`,
       }"
+      @contextmenu.capture.prevent.stop
     >
-      <!-- Basic group -->
-      <template v-if="basicCommands.length > 0">
-        <div class="slash-group-label">
-          基础
-          <span class="slash-group-count">{{ basicCommands.length }}</span>
+      <div class="slash-scroll-wrap">
+        <!-- 搜索模式：统一列表 -->
+        <div
+          v-if="isFiltering"
+          ref="scrollRef"
+          class="slash-scroll slash-scroll--filter"
+          :class="{ 'slash-scroll--has-hint': canScrollDown }"
+          @scroll="updateScrollHint"
+        >
+          <div class="slash-filter-hint">
+            匹配「{{ filter }}」
+          </div>
+          <div class="slash-list">
+            <button
+              v-for="cmd in filteredCommands"
+              :key="cmd.id"
+              class="slash-list-item"
+              :class="{ active: isActive(cmd) }"
+              :data-active="isActive(cmd)"
+              :title="cmd.label"
+              @mousedown.prevent="emit('execute', cmd)"
+            >
+              <span class="slash-list-icon">
+                <span
+                  v-if="cmd.swatch"
+                  class="slash-swatch"
+                  :style="{ backgroundColor: cmd.swatch }"
+                />
+                <template v-else-if="cmd.id === 'markdown'">
+                  <svg viewBox="0 0 24 24" class="size-3.5" fill="currentColor" aria-hidden="true">
+                    <path d="M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12C21.35 6 22 6.63 22 7.41v9.18c0 .78-.65 1.41-1.44 1.41zM7 15V9l2 2 2-2v6h2V9l2 2 2-2v6h1V9h-1l-2 2-2-2H9L7 9v6H6V9H5v6h2z" />
+                  </svg>
+                </template>
+                <component :is="iconMap[cmd.icon]" v-else-if="iconMap[cmd.icon]" class="size-3.5" />
+                <span v-else class="slash-list-fallback">{{ cmd.label.slice(0, 1) }}</span>
+              </span>
+              <span class="slash-list-text">
+                <span class="slash-list-label">{{ cmd.label }}</span>
+                <span class="slash-list-group">{{ cmd.groupLabel }}</span>
+              </span>
+            </button>
+          </div>
         </div>
-        <!-- Heading grid row -->
-        <div v-if="basicCommands.some(c => headingIds.includes(c.id))" class="slash-heading-grid">
-          <button
-            v-for="cmd in basicCommands.filter(c => headingIds.includes(c.id))"
-            :key="cmd.id"
-            class="slash-heading-btn"
-            :class="{ active: getGlobalIndex(cmd) === activeIndex }"
-            :data-active="getGlobalIndex(cmd) === activeIndex"
-            @mousedown.prevent="emit('execute', cmd)"
-          >
-            {{ cmd.label }}
-          </button>
-        </div>
-        <!-- Non-heading basic items grid -->
-        <div class="slash-misc-grid">
-          <button
-            v-for="cmd in basicCommands.filter(c => !headingIds.includes(c.id))"
-            :key="cmd.id"
-            class="slash-misc-btn"
-            :class="{ active: getGlobalIndex(cmd) === activeIndex }"
-            :data-active="getGlobalIndex(cmd) === activeIndex"
-            @mousedown.prevent="emit('execute', cmd)"
-          >
-            <span class="slash-misc-icon">
-              <component :is="iconMap[cmd.icon]" v-if="iconMap[cmd.icon]" class="w-4 h-4" />
-            </span>
-            <span class="slash-misc-label">{{ cmd.label }}</span>
-          </button>
-        </div>
-        <div v-if="commonCommands.length > 0" class="slash-separator" />
-      </template>
 
-      <!-- Common group -->
-      <template v-if="commonCommands.length > 0">
-        <div class="slash-group-label">
-          常用
-          <span class="slash-group-count">{{ commonCommands.length }}</span>
+        <!-- 默认模式：分区紧凑布局 -->
+        <div
+          v-else
+          ref="scrollRef"
+          class="slash-scroll"
+          :class="{ 'slash-scroll--has-hint': canScrollDown }"
+          @scroll="updateScrollHint"
+        >
+          <section v-if="headingCommands.length > 0 || basicBlockCommands.length > 0 || basicFormatCommands.length > 0" class="slash-section">
+            <div class="slash-section-title">
+              基础
+            </div>
+            <div v-if="headingCommands.length > 0" class="slash-heading-row">
+              <button
+                v-for="cmd in headingCommands"
+                :key="cmd.id"
+                class="slash-heading-chip"
+                :class="{ active: isActive(cmd) }"
+                :data-active="isActive(cmd)"
+                :title="cmd.label"
+                @mousedown.prevent="emit('execute', cmd)"
+              >
+                {{ cmd.label }}
+              </button>
+            </div>
+            <div class="slash-icon-row">
+              <button
+                v-for="cmd in basicBlockCommands"
+                :key="cmd.id"
+                class="slash-icon-btn"
+                :class="{ active: isActive(cmd) }"
+                :data-active="isActive(cmd)"
+                :title="cmd.label"
+                @mousedown.prevent="emit('execute', cmd)"
+              >
+                <component :is="iconMap[cmd.icon]" v-if="iconMap[cmd.icon]" class="size-3.5" />
+              </button>
+              <button
+                v-for="cmd in basicFormatCommands"
+                :key="cmd.id"
+                class="slash-icon-btn"
+                :class="{ active: isActive(cmd) }"
+                :data-active="isActive(cmd)"
+                :title="cmd.label"
+                @mousedown.prevent="emit('execute', cmd)"
+              >
+                <component :is="iconMap[cmd.icon]" v-if="iconMap[cmd.icon]" class="size-3.5" />
+              </button>
+            </div>
+          </section>
+
+          <section v-if="commonCommands.length > 0" class="slash-section">
+            <div class="slash-section-title">
+              常用
+            </div>
+            <div class="slash-grid-2">
+              <button
+                v-for="cmd in commonCommands"
+                :key="cmd.id"
+                class="slash-grid-item"
+                :class="{ active: isActive(cmd) }"
+                :data-active="isActive(cmd)"
+                @mousedown.prevent="emit('execute', cmd)"
+              >
+                <span class="slash-grid-icon">
+                  <template v-if="cmd.id === 'markdown'">
+                    <svg viewBox="0 0 24 24" class="size-3.5" fill="currentColor" aria-hidden="true">
+                      <path d="M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12C21.35 6 22 6.63 22 7.41v9.18c0 .78-.65 1.41-1.44 1.41zM7 15V9l2 2 2-2v6h2V9l2 2 2-2v6h1V9h-1l-2 2-2-2H9L7 9v6H6V9H5v6h2z" />
+                    </svg>
+                  </template>
+                  <component :is="iconMap[cmd.icon]" v-else-if="iconMap[cmd.icon]" class="size-3.5" />
+                </span>
+                <span>{{ cmd.label }}</span>
+              </button>
+            </div>
+          </section>
+
+          <section v-if="editDocCommands.length > 0" class="slash-section">
+            <div class="slash-section-title">
+              编辑
+            </div>
+            <div class="slash-chip-row slash-chip-row--compact">
+              <button
+                v-for="cmd in editDocCommands"
+                :key="cmd.id"
+                class="slash-chip slash-chip--half"
+                :class="{ active: isActive(cmd) }"
+                :data-active="isActive(cmd)"
+                @mousedown.prevent="emit('execute', cmd)"
+              >
+                <component :is="iconMap[cmd.icon]" v-if="iconMap[cmd.icon]" class="size-3.5 shrink-0" />
+                <span>{{ cmd.label }}</span>
+              </button>
+            </div>
+          </section>
+
+          <section v-if="styleCommands.length > 0" class="slash-section slash-section--last">
+            <div class="slash-section-title">
+              样式
+            </div>
+
+            <div v-if="styleThemeCommands.length > 0" class="slash-subsection">
+              <div class="slash-subsection-title">
+                主题
+              </div>
+              <div class="slash-theme-row">
+                <button
+                  v-for="cmd in styleThemeCommands"
+                  :key="cmd.id"
+                  class="slash-theme-pill"
+                  :class="{ active: isActive(cmd) }"
+                  :data-active="isActive(cmd)"
+                  :title="cmd.label"
+                  @mousedown.prevent="emit('execute', cmd)"
+                >
+                  {{ shortThemeLabel(cmd.label) }}
+                </button>
+              </div>
+            </div>
+
+            <div v-if="styleColorCommands.length > 0" class="slash-subsection">
+              <div class="slash-subsection-title">
+                主题色
+              </div>
+              <div class="slash-color-grid">
+                <button
+                  v-for="cmd in styleColorCommands"
+                  :key="cmd.id"
+                  class="slash-color-btn"
+                  :class="{ active: isActive(cmd) }"
+                  :data-active="isActive(cmd)"
+                  :title="shortColorLabel(cmd.label)"
+                  @mousedown.prevent="emit('execute', cmd)"
+                >
+                  <span
+                    class="slash-swatch slash-swatch--lg"
+                    :style="{ backgroundColor: cmd.swatch }"
+                  />
+                </button>
+              </div>
+            </div>
+          </section>
         </div>
-        <div class="slash-common-list">
-          <button
-            v-for="cmd in commonCommands"
-            :key="cmd.id"
-            class="slash-common-item"
-            :class="{ active: getGlobalIndex(cmd) === activeIndex }"
-            :data-active="getGlobalIndex(cmd) === activeIndex"
-            @mousedown.prevent="emit('execute', cmd)"
-          >
-            <span class="slash-common-icon">
-              <!-- Special icon for markdown -->
-              <template v-if="cmd.id === 'markdown'">
-                <svg viewBox="0 0 24 24" class="w-4 h-4" fill="currentColor" aria-hidden="true">
-                  <path d="M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12C21.35 6 22 6.63 22 7.41v9.18c0 .78-.65 1.41-1.44 1.41zM7 15V9l2 2 2-2v6h2V9l2 2 2-2v6h1V9h-1l-2 2-2-2H9L7 9v6H6V9H5v6h2z" />
-                </svg>
-              </template>
-              <component :is="iconMap[cmd.icon]" v-else-if="iconMap[cmd.icon]" class="w-4 h-4" />
-            </span>
-            <span class="slash-common-label">{{ cmd.label }}</span>
-          </button>
+
+        <div
+          v-if="canScrollDown"
+          class="slash-scroll-hint"
+          aria-hidden="true"
+        >
+          <ChevronDown class="size-4" />
         </div>
-      </template>
+      </div>
     </div>
   </Transition>
 </template>
 
 <style scoped>
 .slash-command-menu {
-  position: fixed;
+  position: absolute;
   z-index: 9999;
-  width: 240px;
-  border-radius: 10px;
-  border: 1px solid hsl(var(--border));
+  width: 260px;
+  border: 1px solid hsl(var(--border) / 0.8);
   background-color: hsl(var(--popover));
   color: hsl(var(--popover-foreground));
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
-  padding: 6px;
-  font-size: 13px;
+  overflow: hidden;
 }
 
-.slash-group-label {
+.slash-scroll-wrap {
+  position: relative;
+}
+
+.slash-scroll {
+  max-height: 380px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 8px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.slash-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.slash-scroll-hint {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
   display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 6px 4px;
+  height: 32px;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 4px;
+  pointer-events: none;
+  color: hsl(var(--muted-foreground));
+  background: linear-gradient(
+    to bottom,
+    hsl(var(--popover) / 0),
+    hsl(var(--popover) / 0.88) 45%,
+    hsl(var(--popover)) 100%
+  );
+}
+
+.slash-scroll--filter {
+  max-height: 320px;
+  padding: 6px;
+}
+
+.slash-scroll--has-hint {
+  padding-bottom: 28px;
+}
+
+.slash-filter-hint {
+  padding: 4px 8px 8px;
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+}
+
+.slash-section + .slash-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid hsl(var(--border) / 0.6);
+}
+
+.slash-section--last {
+  padding-bottom: 2px;
+}
+
+.slash-section-title {
+  padding: 0 4px 6px;
   font-size: 11px;
   font-weight: 600;
   color: hsl(var(--muted-foreground));
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  user-select: none;
 }
 
-.slash-group-count {
-  background: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
-  border-radius: 10px;
-  padding: 0 5px;
+.slash-subsection {
+  margin-top: 8px;
+}
+
+.slash-subsection-title {
+  padding: 0 4px 5px;
   font-size: 10px;
-  font-weight: 500;
-  line-height: 1.6;
+  color: hsl(var(--muted-foreground) / 0.85);
 }
 
-/* ── Heading grid ── */
-.slash-heading-grid {
+.slash-heading-row {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 3px;
-  padding: 2px 2px 4px;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 4px;
+  margin-bottom: 6px;
 }
 
-.slash-heading-btn {
+.slash-heading-chip {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 36px;
-  border-radius: 6px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid hsl(var(--border) / 0.5);
+  background: hsl(var(--muted) / 0.35);
+  font-size: 12px;
   font-weight: 700;
-  font-size: 13px;
   cursor: pointer;
-  background: transparent;
-  border: none;
   color: hsl(var(--foreground));
-  transition: background 0.12s;
-  outline: none;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
-.slash-heading-btn:hover,
-.slash-heading-btn.active {
-  background: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
+.slash-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
-/* ── Misc grid (ordered/unordered list, quote, divider) ── */
-.slash-misc-grid {
+.slash-chip-row--compact {
+  margin-top: 6px;
+}
+
+.slash-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: hsl(var(--muted) / 0.45);
+  font-size: 12px;
+  cursor: pointer;
+  color: hsl(var(--foreground));
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.slash-chip--half {
+  flex: 1 1 calc(50% - 2px);
+  min-width: 0;
+  justify-content: center;
+}
+
+.slash-grid-2 {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 3px;
-  padding: 2px 2px 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
 }
 
-.slash-misc-btn {
+.slash-grid-item {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 3px;
-  height: 52px;
-  border-radius: 6px;
+  gap: 7px;
+  height: 34px;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: hsl(var(--muted) / 0.35);
+  font-size: 12px;
   cursor: pointer;
-  background: transparent;
-  border: none;
   color: hsl(var(--foreground));
-  transition: background 0.12s;
-  outline: none;
+  text-align: left;
+  transition: background 0.12s, border-color 0.12s;
 }
 
-.slash-misc-btn:hover,
-.slash-misc-btn.active {
-  background: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
-}
-
-.slash-misc-icon {
+.slash-grid-icon {
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: hsl(var(--background) / 0.7);
   color: hsl(var(--foreground));
+  flex-shrink: 0;
 }
 
-.slash-misc-label {
-  font-size: 10px;
-  color: hsl(var(--muted-foreground));
-  white-space: nowrap;
+.slash-icon-row {
+  display: grid;
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+  gap: 4px;
+  padding: 4px;
+  border-radius: 10px;
+  background: hsl(var(--muted) / 0.35);
 }
 
-.slash-misc-btn:hover .slash-misc-label,
-.slash-misc-btn.active .slash-misc-label {
-  color: hsl(var(--accent-foreground));
+.slash-icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 32px;
+  border-radius: 7px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: hsl(var(--foreground));
+  transition: background 0.12s, color 0.12s;
 }
 
-.slash-separator {
-  height: 1px;
-  background: hsl(var(--border));
-  margin: 4px 4px;
+.slash-theme-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
 }
 
-/* ── Common list ── */
-.slash-common-list {
+.slash-theme-pill {
+  height: 30px;
+  border-radius: 8px;
+  border: 1px solid hsl(var(--border) / 0.5);
+  background: hsl(var(--muted) / 0.35);
+  font-size: 12px;
+  cursor: pointer;
+  color: hsl(var(--foreground));
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.slash-color-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.slash-color-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  padding: 0;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition: border-color 0.12s, transform 0.12s;
+}
+
+.slash-swatch {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: 9999px;
+  border: 1px solid rgb(0 0 0 / 0.08);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.15);
+}
+
+.slash-swatch--lg {
+  width: 22px;
+  height: 22px;
+}
+
+.slash-list {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  padding: 2px;
+  gap: 2px;
 }
 
-.slash-common-item {
+.slash-list-item {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-  background: transparent;
-  border: none;
-  color: hsl(var(--foreground));
-  text-align: left;
   width: 100%;
+  padding: 7px 8px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  color: hsl(var(--foreground));
   transition: background 0.12s;
-  outline: none;
 }
 
-.slash-common-item:hover,
-.slash-common-item.active {
-  background: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
-}
-
-.slash-common-icon {
+.slash-list-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 6px;
-  background: hsl(var(--muted));
-  color: hsl(var(--foreground));
+  border-radius: 7px;
+  background: hsl(var(--muted) / 0.55);
   flex-shrink: 0;
-  transition: background 0.12s, color 0.12s;
 }
 
-.slash-common-item:hover .slash-common-icon,
-.slash-common-item.active .slash-common-icon {
+.slash-list-fallback {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.slash-list-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.slash-list-label {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.slash-list-group {
+  font-size: 10px;
+  color: hsl(var(--muted-foreground));
+}
+
+.slash-heading-chip:hover,
+.slash-chip:hover,
+.slash-grid-item:hover,
+.slash-icon-btn:hover,
+.slash-theme-pill:hover,
+.slash-color-btn:hover,
+.slash-list-item:hover {
+  background: hsl(var(--accent) / 0.65);
+}
+
+.slash-heading-chip.active,
+.slash-chip.active,
+.slash-grid-item.active,
+.slash-icon-btn.active,
+.slash-theme-pill.active,
+.slash-list-item.active {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  border-color: hsl(var(--primary) / 0.25);
+}
+
+.slash-color-btn.active {
+  border-color: hsl(var(--primary));
+  transform: scale(1.05);
+}
+
+.slash-grid-item.active .slash-grid-icon,
+.slash-list-item.active .slash-list-icon {
   background: hsl(var(--primary));
   color: hsl(var(--primary-foreground));
 }
 
-.slash-common-label {
-  font-size: 13px;
-  font-weight: 500;
-}
-
-/* ── Transition ── */
 .slash-menu-enter-active,
 .slash-menu-leave-active {
   transition: opacity 0.12s ease, transform 0.12s ease;

--- a/apps/web/src/components/editor/editor-header/EditDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/EditDropdown.vue
@@ -4,15 +4,17 @@ import {
   ClipboardPaste,
   Copy,
   Redo2,
+  RefreshCw,
   Replace,
   Search,
+  Trash2,
   Undo2,
   WandSparkles,
 } from '@lucide/vue'
 import { altSign, ctrlSign, shiftSign } from '@md/shared/configs'
 import { redoAction, undoAction } from '@md/shared/editor'
+import { useEditorDocumentActions } from '@/composables/useEditorDocumentActions'
 import { useEditorStore } from '@/stores/editor'
-import { usePostStore } from '@/stores/post'
 import { useUIStore } from '@/stores/ui'
 import { copyPlain } from '@/utils/clipboard'
 
@@ -27,18 +29,11 @@ const emit = defineEmits(['copy'])
 const { asSub } = toRefs(props)
 
 const editorStore = useEditorStore()
-const postStore = usePostStore()
 const uiStore = useUIStore()
 
-const { editor } = storeToRefs(editorStore)
+const { formatContent, resetContent, clearContent } = useEditorDocumentActions()
 
-// Format content function
-async function formatContent() {
-  const doc = await editorStore.formatContent()
-  if (doc && postStore.currentPost) {
-    postStore.updatePostContent(postStore.currentPostId, doc)
-  }
-}
+const { editor } = storeToRefs(editorStore)
 
 // Clipboard operations
 async function copyToClipboard() {
@@ -179,15 +174,26 @@ function openReplace() {
 
       <MenubarSeparator />
 
-      <!-- 格式化文档 -->
+      <!-- 格式化 -->
       <MenubarItem @click="formatContent()">
         <WandSparkles class="mr-2 h-4 w-4" />
-        格式化文档
+        格式化
         <MenubarShortcut>
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">{{ altSign }}</kbd>
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">{{ shiftSign }}</kbd>
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">F</kbd>
         </MenubarShortcut>
+      </MenubarItem>
+
+      <MenubarSeparator />
+
+      <MenubarItem @click="resetContent()">
+        <RefreshCw class="mr-2 h-4 w-4" />
+        重置
+      </MenubarItem>
+      <MenubarItem @click="clearContent()">
+        <Trash2 class="mr-2 h-4 w-4" />
+        清空
       </MenubarItem>
 
       <MenubarSeparator />
@@ -281,15 +287,26 @@ function openReplace() {
 
       <MenubarSeparator />
 
-      <!-- 格式化文档 -->
+      <!-- 格式化 -->
       <MenubarItem @click="formatContent()">
         <WandSparkles class="mr-2 h-4 w-4" />
-        格式化文档
+        格式化
         <MenubarShortcut>
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">{{ altSign }}</kbd>
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">{{ shiftSign }}</kbd>
           <kbd class="mx-1 bg-gray-2 dark:bg-stone-9">F</kbd>
         </MenubarShortcut>
+      </MenubarItem>
+
+      <MenubarSeparator />
+
+      <MenubarItem @click="resetContent()">
+        <RefreshCw class="mr-2 h-4 w-4" />
+        重置
+      </MenubarItem>
+      <MenubarItem @click="clearContent()">
+        <Trash2 class="mr-2 h-4 w-4" />
+        清空
       </MenubarItem>
 
       <MenubarSeparator />

--- a/apps/web/src/composables/slashCommands.ts
+++ b/apps/web/src/composables/slashCommands.ts
@@ -1,0 +1,336 @@
+import type { EditorView as EditorViewType } from '@codemirror/view'
+import type { ThemeName } from '@md/shared/configs'
+import { colorOptions, themeOptions } from '@md/shared/configs'
+import {
+  formatBold,
+  formatCode,
+  formatItalic,
+  formatLink,
+  formatStrikethrough,
+} from '@md/shared/editor'
+import { useEditorDocumentActions } from '@/composables/useEditorDocumentActions'
+import { useEditorStore } from '@/stores/editor'
+import { useRenderStore } from '@/stores/render'
+import { useThemeStore } from '@/stores/theme'
+import { useUIStore } from '@/stores/ui'
+
+export type SlashCommandGroup = 'basic' | 'common' | 'edit' | 'style'
+
+export interface SlashCommandItem {
+  id: string
+  label: string
+  group: SlashCommandGroup
+  groupLabel: string
+  keywords: string[]
+  icon: string
+  swatch?: string
+  action: (view: EditorViewType) => void
+}
+
+export const SLASH_GROUP_LABELS: Record<SlashCommandGroup, string> = {
+  basic: `基础`,
+  common: `常用`,
+  edit: `编辑`,
+  style: `样式`,
+}
+
+export const SLASH_HEADING_IDS = [`h1`, `h2`, `h3`, `h4`, `h5`, `h6`] as const
+export const SLASH_BASIC_BLOCK_IDS = [`ordered-list`, `unordered-list`, `blockquote`, `divider`] as const
+export const SLASH_BASIC_FORMAT_IDS = [`bold`, `italic`, `strikethrough`, `inline-code`, `link-wrap`] as const
+export const SLASH_EDIT_DOC_IDS = [`format-doc`, `reset-content`, `clear-content`, `find`] as const
+
+const HEADING_KEYWORDS: Record<number, string[]> = {
+  1: [`h1`, `heading1`, `一级`, `标题`],
+  2: [`h2`, `heading2`, `二级`, `标题`],
+  3: [`h3`, `heading3`, `三级`, `标题`],
+  4: [`h4`, `heading4`, `四级`, `标题`],
+  5: [`h5`, `heading5`, `五级`, `标题`],
+  6: [`h6`, `heading6`, `六级`, `标题`],
+}
+
+function insertText(view: EditorViewType, text: string, cursorOffset?: number) {
+  const cursor = view.state.selection.main.head
+  const offset = cursorOffset ?? text.length
+  view.dispatch({
+    changes: { from: cursor, to: cursor, insert: text },
+    selection: { anchor: cursor + offset },
+  })
+  view.focus()
+}
+
+function insertCodeFence(view: EditorViewType, lang?: string) {
+  const fence = lang ? `\`\`\`${lang}\n\n\`\`\`` : `\`\`\`\n\n\`\`\``
+  const cursorOffset = lang ? lang.length + 4 : 4
+  insertText(view, fence, cursorOffset)
+}
+
+function applyFormat(view: EditorViewType, fn: (view: EditorViewType) => void) {
+  fn(view)
+  view.focus()
+}
+
+function createCommand(
+  partial: Omit<SlashCommandItem, 'groupLabel'> & { group: SlashCommandGroup },
+): SlashCommandItem {
+  return {
+    ...partial,
+    groupLabel: SLASH_GROUP_LABELS[partial.group],
+  }
+}
+
+export function buildSlashCommands(): SlashCommandItem[] {
+  const uiStore = useUIStore()
+  const editorStore = useEditorStore()
+  const themeStore = useThemeStore()
+  const renderStore = useRenderStore()
+  const { formatContent, resetContent, clearContent } = useEditorDocumentActions()
+
+  function refreshPreview() {
+    themeStore.updateCodeTheme()
+    renderStore.render(editorStore.getContent())
+  }
+
+  function applyTheme(theme: ThemeName) {
+    themeStore.theme = theme
+    themeStore.applyCurrentTheme()
+    refreshPreview()
+  }
+
+  function applyPrimaryColor(color: string) {
+    themeStore.primaryColor = color
+    themeStore.applyCurrentTheme()
+    refreshPreview()
+  }
+
+  const headingCommands = ([1, 2, 3, 4, 5, 6] as const).map(level =>
+    createCommand({
+      id: `h${level}`,
+      label: `H${level}`,
+      group: `basic`,
+      keywords: HEADING_KEYWORDS[level],
+      icon: `H${level}`,
+      action: view => insertText(view, `${`#`.repeat(level)} `),
+    }),
+  )
+
+  const blockCommands: SlashCommandItem[] = [
+    createCommand({
+      id: `ordered-list`,
+      label: `有序列表`,
+      group: `basic`,
+      keywords: [`ol`, `ordered`, `有序`, `列表`, `numbered`],
+      icon: `ordered-list`,
+      action: view => insertText(view, `1. `),
+    }),
+    createCommand({
+      id: `unordered-list`,
+      label: `无序列表`,
+      group: `basic`,
+      keywords: [`ul`, `unordered`, `无序`, `列表`, `bullet`],
+      icon: `unordered-list`,
+      action: view => insertText(view, `- `),
+    }),
+    createCommand({
+      id: `blockquote`,
+      label: `引用`,
+      group: `basic`,
+      keywords: [`quote`, `引用`, `blockquote`],
+      icon: `blockquote`,
+      action: view => insertText(view, `> `),
+    }),
+    createCommand({
+      id: `divider`,
+      label: `分割线`,
+      group: `basic`,
+      keywords: [`hr`, `divider`, `分割线`, `---`, `横线`],
+      icon: `divider`,
+      action: view => insertText(view, `\n---\n`),
+    }),
+  ]
+
+  const formatCommands: SlashCommandItem[] = [
+    createCommand({
+      id: `bold`,
+      label: `加粗`,
+      group: `basic`,
+      keywords: [`bold`, `加粗`, `jiacu`, `b`, `strong`],
+      icon: `bold`,
+      action: view => applyFormat(view, formatBold),
+    }),
+    createCommand({
+      id: `italic`,
+      label: `斜体`,
+      group: `basic`,
+      keywords: [`italic`, `斜体`, `xieti`, `i`, `em`],
+      icon: `italic`,
+      action: view => applyFormat(view, formatItalic),
+    }),
+    createCommand({
+      id: `strikethrough`,
+      label: `删除线`,
+      group: `basic`,
+      keywords: [`strike`, `strikethrough`, `删除线`, `shanchuxian`, `del`],
+      icon: `strikethrough`,
+      action: view => applyFormat(view, formatStrikethrough),
+    }),
+    createCommand({
+      id: `inline-code`,
+      label: `行内代码`,
+      group: `basic`,
+      keywords: [`inline-code`, `code`, `行内代码`, `inline`],
+      icon: `code-inline`,
+      action: view => applyFormat(view, formatCode),
+    }),
+    createCommand({
+      id: `link-wrap`,
+      label: `超链接`,
+      group: `basic`,
+      keywords: [`link-wrap`, `超链接`, `chaolianjie`, `wrap`],
+      icon: `link-wrap`,
+      action: view => applyFormat(view, formatLink),
+    }),
+  ]
+
+  const commonCommands: SlashCommandItem[] = [
+    createCommand({
+      id: `code-block`,
+      label: `代码块`,
+      group: `common`,
+      keywords: [`code`, `代码块`, `\`\`\``, `codeblock`, `fence`],
+      icon: `code`,
+      action: view => insertCodeFence(view),
+    }),
+    createCommand({
+      id: `markdown`,
+      label: `Markdown`,
+      group: `common`,
+      keywords: [`markdown`, `md`, `raw`],
+      icon: `markdown`,
+      action: view => insertCodeFence(view, `markdown`),
+    }),
+    createCommand({
+      id: `formula`,
+      label: `公式块`,
+      group: `common`,
+      keywords: [`formula`, `公式`, `math`, `latex`, `$$`, `katex`],
+      icon: `formula`,
+      action: () => {
+        uiStore.openFormulaEditor({ value: ``, displayMode: true })
+      },
+    }),
+    createCommand({
+      id: `image`,
+      label: `图片`,
+      group: `common`,
+      keywords: [`image`, `图片`, `img`, `photo`, `picture`],
+      icon: `image`,
+      action: () => {
+        uiStore.toggleShowUploadImgDialog()
+      },
+    }),
+    createCommand({
+      id: `table`,
+      label: `表格`,
+      group: `common`,
+      keywords: [`table`, `表格`, `grid`],
+      icon: `table`,
+      action: () => {
+        uiStore.toggleShowInsertFormDialog()
+      },
+    }),
+    createCommand({
+      id: `component`,
+      label: `组件`,
+      group: `common`,
+      keywords: [`component`, `组件`, `blocks`, `block`],
+      icon: `blocks`,
+      action: () => {
+        uiStore.toggleShowComponentDialog()
+      },
+    }),
+  ]
+
+  const editCommands: SlashCommandItem[] = [
+    createCommand({
+      id: `format-doc`,
+      label: `格式化`,
+      group: `edit`,
+      keywords: [`format`, `格式化`, `geshihua`, `prettier`],
+      icon: `format`,
+      action: async (view) => {
+        await formatContent()
+        view.focus()
+      },
+    }),
+    createCommand({
+      id: `reset-content`,
+      label: `重置`,
+      group: `edit`,
+      keywords: [`reset`, `重置`, `chongzhi`, `default`],
+      icon: `reset`,
+      action: (view) => {
+        resetContent()
+        view.focus()
+      },
+    }),
+    createCommand({
+      id: `clear-content`,
+      label: `清空`,
+      group: `edit`,
+      keywords: [`clear`, `清空`, `qingkong`, `empty`],
+      icon: `clear`,
+      action: (view) => {
+        clearContent()
+        view.focus()
+      },
+    }),
+    createCommand({
+      id: `find`,
+      label: `查找`,
+      group: `edit`,
+      keywords: [`find`, `search`, `查找`, `chazhao`],
+      icon: `find`,
+      action: (view) => {
+        const selection = view.state.selection.main
+        const selected = view.state.doc.sliceString(selection.from, selection.to).trim()
+        uiStore.openSearchTab(selected)
+        view.focus()
+      },
+    }),
+  ]
+
+  const styleCommands: SlashCommandItem[] = [
+    ...themeOptions.map(option => createCommand({
+      id: `theme-${option.value}`,
+      label: `主题 · ${option.label}`,
+      group: `style`,
+      keywords: [`theme`, `主题`, `zhuti`, option.value, option.label],
+      icon: `theme`,
+      action: (view) => {
+        applyTheme(option.value as ThemeName)
+        view.focus()
+      },
+    })),
+    ...colorOptions.map(option => createCommand({
+      id: `color-${option.value.replace('#', '')}`,
+      label: `主题色 · ${option.label}`,
+      group: `style`,
+      keywords: [`color`, `主题色`, `zhutise`, option.label, option.value],
+      icon: `color`,
+      swatch: option.value,
+      action: (view) => {
+        applyPrimaryColor(option.value)
+        view.focus()
+      },
+    })),
+  ]
+
+  return [
+    ...headingCommands,
+    ...blockCommands,
+    ...formatCommands,
+    ...commonCommands,
+    ...editCommands,
+    ...styleCommands,
+  ]
+}

--- a/apps/web/src/composables/useEditorDocumentActions.ts
+++ b/apps/web/src/composables/useEditorDocumentActions.ts
@@ -1,0 +1,30 @@
+import DEFAULT_CONTENT from '@/assets/example/markdown.md?raw'
+import { useEditorStore } from '@/stores/editor'
+import { usePostStore } from '@/stores/post'
+
+export function useEditorDocumentActions() {
+  const editorStore = useEditorStore()
+  const postStore = usePostStore()
+
+  async function formatContent() {
+    const doc = await editorStore.formatContent()
+    if (doc && postStore.currentPost)
+      postStore.updatePostContent(postStore.currentPostId, doc)
+    return doc
+  }
+
+  function resetContent() {
+    editorStore.importContent(DEFAULT_CONTENT)
+    toast.success(`内容已重置`)
+  }
+
+  function clearContent() {
+    editorStore.clearContent()
+  }
+
+  return {
+    formatContent,
+    resetContent,
+    clearContent,
+  }
+}

--- a/apps/web/src/composables/useSlashCommand.ts
+++ b/apps/web/src/composables/useSlashCommand.ts
@@ -78,7 +78,7 @@ export function useSlashCommand() {
   function createExtension(getView: () => EditorViewType | null) {
     return [
       EditorView.updateListener.of((update) => {
-        if (update.scrollChanged && visible.value) {
+        if (visible.value && update.viewportChanged && !update.docChanged) {
           closeMenu()
           return
         }

--- a/apps/web/src/composables/useSlashCommand.ts
+++ b/apps/web/src/composables/useSlashCommand.ts
@@ -1,216 +1,19 @@
 import type { EditorView as EditorViewType } from '@codemirror/view'
+import type { SlashCommandItem } from '@/composables/slashCommands'
 import { Prec } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
-import { useUIStore } from '@/stores/ui'
+import { buildSlashCommands } from '@/composables/slashCommands'
 
-export interface SlashCommandItem {
-  id: string
-  label: string
-  group: 'basic' | 'common'
-  groupLabel: string
-  keywords: string[]
-  icon: string
-  action: (view: EditorViewType) => void
-}
-
-function insertText(view: EditorViewType, text: string, cursorOffset?: number) {
-  const cursor = view.state.selection.main.head
-  const offset = cursorOffset !== undefined ? cursorOffset : text.length
-  view.dispatch({
-    changes: { from: cursor, to: cursor, insert: text },
-    selection: { anchor: cursor + offset },
-  })
-  view.focus()
-}
+export type { SlashCommandGroup, SlashCommandItem } from '@/composables/slashCommands'
 
 export function useSlashCommand() {
-  const uiStore = useUIStore()
-
   const visible = ref(false)
-  const position = ref({ x: 0, y: 0 })
+  const position = ref({ x: 0, y: 0, top: 0 })
   const filter = ref(``)
   const activeIndex = ref(0)
   const slashFrom = ref(-1)
 
-  const allCommands: SlashCommandItem[] = [
-    // ────── 基础 ──────
-    {
-      id: `h1`,
-      label: `H1`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`h1`, `heading1`, `一级`, `标题`],
-      icon: `H1`,
-      action: view => insertText(view, `# `),
-    },
-    {
-      id: `h2`,
-      label: `H2`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`h2`, `heading2`, `二级`, `标题`],
-      icon: `H2`,
-      action: view => insertText(view, `## `),
-    },
-    {
-      id: `h3`,
-      label: `H3`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`h3`, `heading3`, `三级`, `标题`],
-      icon: `H3`,
-      action: view => insertText(view, `### `),
-    },
-    {
-      id: `h4`,
-      label: `H4`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`h4`, `heading4`, `四级`, `标题`],
-      icon: `H4`,
-      action: view => insertText(view, `#### `),
-    },
-    {
-      id: `h5`,
-      label: `H5`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`h5`, `heading5`, `五级`, `标题`],
-      icon: `H5`,
-      action: view => insertText(view, `##### `),
-    },
-    {
-      id: `h6`,
-      label: `H6`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`h6`, `heading6`, `六级`, `标题`],
-      icon: `H6`,
-      action: view => insertText(view, `###### `),
-    },
-    {
-      id: `ordered-list`,
-      label: `有序列表`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`ol`, `ordered`, `有序`, `列表`, `numbered`],
-      icon: `ordered-list`,
-      action: view => insertText(view, `1. `),
-    },
-    {
-      id: `unordered-list`,
-      label: `无序列表`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`ul`, `unordered`, `无序`, `列表`, `bullet`],
-      icon: `unordered-list`,
-      action: view => insertText(view, `- `),
-    },
-    {
-      id: `blockquote`,
-      label: `引用`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`quote`, `引用`, `blockquote`],
-      icon: `blockquote`,
-      action: view => insertText(view, `> `),
-    },
-    {
-      id: `divider`,
-      label: `分割线`,
-      group: `basic`,
-      groupLabel: `基础`,
-      keywords: [`hr`, `divider`, `分割线`, `---`, `横线`],
-      icon: `divider`,
-      action: view => insertText(view, `\n---\n`),
-    },
-    // ────── 常用 ──────
-    {
-      id: `link`,
-      label: `链接`,
-      group: `common`,
-      groupLabel: `常用`,
-      keywords: [`link`, `链接`, `url`, `href`, `a`],
-      icon: `link`,
-      action: (view) => {
-        // Insert [文字](链接) with cursor selecting "文字"
-        const text = `[链接文字](https://)`
-        const cursor = view.state.selection.main.head
-        view.dispatch({
-          changes: { from: cursor, to: cursor, insert: text },
-          selection: { anchor: cursor + 1, head: cursor + 5 },
-        })
-        view.focus()
-      },
-    },
-    {
-      id: `code-block`,
-      label: `代码块`,
-      group: `common`,
-      groupLabel: `常用`,
-      keywords: [`code`, `代码块`, `\`\`\``, `codeblock`, `fence`],
-      icon: `code`,
-      action: (view) => {
-        const text = `\`\`\`\n\n\`\`\``
-        const cursor = view.state.selection.main.head
-        view.dispatch({
-          changes: { from: cursor, to: cursor, insert: text },
-          selection: { anchor: cursor + 4 },
-        })
-        view.focus()
-      },
-    },
-    {
-      id: `markdown`,
-      label: `Markdown`,
-      group: `common`,
-      groupLabel: `常用`,
-      keywords: [`markdown`, `md`, `raw`],
-      icon: `markdown`,
-      action: (view) => {
-        const text = `\`\`\`markdown\n\n\`\`\``
-        const cursor = view.state.selection.main.head
-        view.dispatch({
-          changes: { from: cursor, to: cursor, insert: text },
-          selection: { anchor: cursor + 12 },
-        })
-        view.focus()
-      },
-    },
-    {
-      id: `formula`,
-      label: `公式块`,
-      group: `common`,
-      groupLabel: `常用`,
-      keywords: [`formula`, `公式`, `math`, `latex`, `$$`, `katex`],
-      icon: `formula`,
-      action: () => {
-        uiStore.openFormulaEditor({ value: ``, displayMode: true })
-      },
-    },
-    {
-      id: `image`,
-      label: `图片`,
-      group: `common`,
-      groupLabel: `常用`,
-      keywords: [`image`, `图片`, `img`, `photo`, `picture`],
-      icon: `image`,
-      action: () => {
-        uiStore.toggleShowUploadImgDialog()
-      },
-    },
-    {
-      id: `table`,
-      label: `表格`,
-      group: `common`,
-      groupLabel: `常用`,
-      keywords: [`table`, `表格`, `grid`],
-      icon: `table`,
-      action: () => {
-        uiStore.toggleShowInsertFormDialog()
-      },
-    },
-  ]
+  const allCommands = buildSlashCommands()
 
   const filteredCommands = computed(() => {
     const f = filter.value.toLowerCase().trim()
@@ -226,6 +29,8 @@ export function useSlashCommand() {
 
   const basicCommands = computed(() => filteredCommands.value.filter(c => c.group === `basic`))
   const commonCommands = computed(() => filteredCommands.value.filter(c => c.group === `common`))
+  const editCommands = computed(() => filteredCommands.value.filter(c => c.group === `edit`))
+  const styleCommands = computed(() => filteredCommands.value.filter(c => c.group === `style`))
 
   function openMenu(view: EditorViewType, from: number) {
     const coords = view.coordsAtPos(from)
@@ -234,7 +39,7 @@ export function useSlashCommand() {
     slashFrom.value = from
     filter.value = ``
     activeIndex.value = 0
-    position.value = { x: coords.left, y: coords.bottom }
+    position.value = { x: coords.left, y: coords.bottom, top: coords.top }
     visible.value = true
   }
 
@@ -249,7 +54,6 @@ export function useSlashCommand() {
     if (from < 0)
       return
     const cursor = view.state.selection.main.head
-    // Remove the "/" + filter text before executing
     view.dispatch({
       changes: { from, to: cursor, insert: `` },
     })
@@ -274,6 +78,11 @@ export function useSlashCommand() {
   function createExtension(getView: () => EditorViewType | null) {
     return [
       EditorView.updateListener.of((update) => {
+        if (update.scrollChanged && visible.value) {
+          closeMenu()
+          return
+        }
+
         if (!update.docChanged)
           return
 
@@ -281,16 +90,12 @@ export function useSlashCommand() {
         const cursor = state.selection.main.head
 
         if (!visible.value) {
-          // Check if "/" was just typed at the cursor position
           update.changes.iterChanges((_fromA, _toA, fromB, _toB, inserted) => {
             if (inserted.length === 1 && inserted.toString() === `/`) {
-              // Only trigger slash command when:
-              // - at start of line, or
-              // - preceded by whitespace/newline
               const line = state.doc.lineAt(fromB)
               const charBefore = fromB > line.from ? state.doc.sliceString(fromB - 1, fromB) : ``
               const isAtLineStart = fromB === line.from
-              const isPrecededBySpace = charBefore === ` ` || charBefore === ``
+              const isPrecededBySpace = charBefore === ` ` || charBefore === `\t`
               if (isAtLineStart || isPrecededBySpace) {
                 const view = getView()
                 if (view)
@@ -300,7 +105,6 @@ export function useSlashCommand() {
           })
         }
         else {
-          // Menu is visible — update filter based on text between slashFrom and cursor
           const from = slashFrom.value
           if (from < 0 || cursor < from) {
             closeMenu()
@@ -318,7 +122,6 @@ export function useSlashCommand() {
         }
       }),
 
-      // High-priority keymap to intercept navigation when menu is visible
       Prec.highest(
         keymap.of([
           {
@@ -374,6 +177,8 @@ export function useSlashCommand() {
     filteredCommands,
     basicCommands,
     commonCommands,
+    editCommands,
+    styleCommands,
     allCommands,
     closeMenu,
     executeCommand,

--- a/apps/web/src/composables/useSlashMenuPosition.ts
+++ b/apps/web/src/composables/useSlashMenuPosition.ts
@@ -1,0 +1,94 @@
+import type { Ref } from 'vue'
+
+const MENU_WIDTH = 260
+const MENU_GAP = 6
+const MENU_PADDING = 8
+const MENU_HEIGHT_DEFAULT = 380
+const MENU_HEIGHT_FILTER = 320
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function useSlashMenuPosition(options: {
+  visible: Ref<boolean>
+  position: Ref<{ x: number, y: number, top: number }>
+  filter: Ref<string>
+  containerEl: Ref<HTMLElement | null>
+  menuRef: Ref<HTMLElement | null>
+  isFiltering: Ref<boolean>
+}) {
+  const adjustedPosition = ref({ x: 0, y: 0 })
+
+  let resizeObserver: ResizeObserver | null = null
+
+  function updateAdjustedPosition() {
+    const container = options.containerEl.value
+    if (!container) {
+      adjustedPosition.value = { x: options.position.value.x, y: options.position.value.y }
+      return
+    }
+
+    const bounds = container.getBoundingClientRect()
+    const menuWidth = options.menuRef.value?.offsetWidth ?? MENU_WIDTH
+    const menuHeight = options.menuRef.value?.offsetHeight
+      ?? (options.isFiltering.value ? MENU_HEIGHT_FILTER : MENU_HEIGHT_DEFAULT)
+
+    let relX = options.position.value.x - bounds.left
+    const cursorBottom = options.position.value.y - bounds.top
+    const cursorTop = options.position.value.top - bounds.top
+
+    relX = clamp(relX, MENU_PADDING, bounds.width - menuWidth - MENU_PADDING)
+
+    const spaceBelow = bounds.height - cursorBottom - MENU_PADDING
+    const spaceAbove = cursorTop - MENU_PADDING
+
+    let relY: number
+    if (spaceBelow >= menuHeight)
+      relY = cursorBottom + MENU_GAP
+    else if (spaceAbove >= menuHeight)
+      relY = cursorTop - menuHeight - MENU_GAP
+    else
+      relY = clamp(cursorBottom + MENU_GAP, MENU_PADDING, bounds.height - menuHeight - MENU_PADDING)
+
+    adjustedPosition.value = { x: relX, y: relY }
+  }
+
+  function bindContainerObserver() {
+    unbindContainerObserver()
+    if (!options.containerEl.value)
+      return
+    resizeObserver = new ResizeObserver(() => updateAdjustedPosition())
+    resizeObserver.observe(options.containerEl.value)
+  }
+
+  function unbindContainerObserver() {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+  }
+
+  watch(
+    () => [
+      options.visible.value,
+      options.position.value.x,
+      options.position.value.y,
+      options.position.value.top,
+      options.filter.value,
+      options.containerEl.value,
+    ] as const,
+    () => {
+      if (!options.visible.value)
+        return
+      nextTick(updateAdjustedPosition)
+    },
+  )
+
+  onUnmounted(unbindContainerObserver)
+
+  return {
+    adjustedPosition,
+    updateAdjustedPosition,
+    bindContainerObserver,
+    unbindContainerObserver,
+  }
+}

--- a/apps/web/src/composables/useSlashMenuScrollHint.ts
+++ b/apps/web/src/composables/useSlashMenuScrollHint.ts
@@ -1,0 +1,68 @@
+import type { Ref } from 'vue'
+
+const SCROLL_HINT_THRESHOLD = 8
+
+export function useSlashMenuScrollHint(options: {
+  visible: Ref<boolean>
+  scrollRef: Ref<HTMLElement | null>
+  menuRef: Ref<HTMLElement | null>
+  filter: Ref<string>
+  filteredCommandsLength: Ref<number>
+  activeIndex: Ref<number>
+}) {
+  const canScrollDown = ref(false)
+
+  let scrollContentObserver: ResizeObserver | null = null
+
+  function updateScrollHint() {
+    const el = options.scrollRef.value
+    if (!el) {
+      canScrollDown.value = false
+      return
+    }
+    canScrollDown.value = el.scrollHeight - el.scrollTop - el.clientHeight > SCROLL_HINT_THRESHOLD
+  }
+
+  function bindScrollContentObserver() {
+    unbindScrollContentObserver()
+    nextTick(() => {
+      const el = options.scrollRef.value
+      if (!el)
+        return
+      scrollContentObserver = new ResizeObserver(() => updateScrollHint())
+      scrollContentObserver.observe(el)
+      updateScrollHint()
+    })
+  }
+
+  function unbindScrollContentObserver() {
+    scrollContentObserver?.disconnect()
+    scrollContentObserver = null
+  }
+
+  function scrollActiveIntoView() {
+    nextTick(() => {
+      const el = options.menuRef.value?.querySelector(`[data-active="true"]`)
+      el?.scrollIntoView({ block: `nearest` })
+      updateScrollHint()
+    })
+  }
+
+  watch(
+    () => [options.filter.value, options.filteredCommandsLength.value, options.activeIndex.value] as const,
+    () => {
+      if (options.visible.value)
+        nextTick(updateScrollHint)
+    },
+  )
+
+  onUnmounted(unbindScrollContentObserver)
+
+  return {
+    canScrollDown,
+    updateScrollHint,
+    scrollActiveIntoView,
+    bindScrollContentObserver,
+    unbindScrollContentObserver,
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `/` slash command palette in the editor with grouped sections: basic (headings, blocks, inline format), common inserts, document edits, and theme/color presets.
- Extract `useEditorDocumentActions`, `useSlashMenuPosition`, and `useSlashMenuScrollHint` composables; align keyboard navigation order with the visual layout and close the menu on editor scroll.
- Unify edit menu labels (格式化 / 重置 / 清空) across the menubar, context menu, and slash palette; slightly improve mobile footer tap padding.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [x] `pnpm run type-check`
- [ ] Manual: type `/` in the editor and verify grouped menu layout, filter mode, scroll hint, and positioning mid-document
- [ ] Manual: use ↑↓ / Enter to confirm highlight order matches visual order (especially after divider → bold)
- [ ] Manual: verify 格式化 / 重置 / 清空 in Edit menu and context menu
- [ ] Manual: right-click on slash panel does not open editor context menu
- [ ] Manual: editor scroll closes the slash menu

## Pre-flight Checklist

- [x] Conventional commit message in English
- [x] Changes scoped to web editor UX
- [x] No secrets committed
- [x] Lint pre-commit hook passed
