### PR TITLE
fix(web): improve post slider mobile and desktop UX

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Wechat Markdown Editor | 一款高度简洁的微信 Markdown 编辑器" />
     <meta
       name="viewport"
-      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, viewport-fit=cover"
     />
     <title>微信 Markdown 编辑器 | Doocs 开源社区</title>
     <link rel="shortcut icon" href="/favicon.png" />

--- a/apps/web/src/components/editor/CodemirrorEditor.vue
+++ b/apps/web/src/components/editor/CodemirrorEditor.vue
@@ -102,6 +102,7 @@ const previewPanelConfig = computed(() => {
 
 const editorResizablePanelRef = ref<InstanceType<typeof ResizablePanel> | null>(null)
 const previewResizablePanelRef = ref<InstanceType<typeof ResizablePanel> | null>(null)
+const postSliderPanelRef = ref<InstanceType<typeof ResizablePanel> | null>(null)
 const cssEditorPanelRef = ref<InstanceType<typeof ResizablePanel> | null>(null)
 const rightSliderPanelRef = ref<InstanceType<typeof ResizablePanel> | null>(null)
 
@@ -141,8 +142,27 @@ watch(isOpenRightSlider, () => {
   nextTick(redistributePanelSizes)
 })
 
+watch(isOpenPostSlider, (open) => {
+  if (isMobile.value)
+    return
+  nextTick(() => {
+    postSliderPanelRef.value?.resize(open ? 20 : 0)
+  })
+})
+
+watch(isMobile, (mobile) => {
+  if (mobile)
+    postSliderPanelRef.value?.resize(0)
+  else if (isOpenPostSlider.value)
+    nextTick(() => postSliderPanelRef.value?.resize(20))
+})
+
 onMounted(() => {
-  nextTick(redistributePanelSizes)
+  nextTick(() => {
+    redistributePanelSizes()
+    if (!isMobile.value && isOpenPostSlider.value)
+      postSliderPanelRef.value?.resize(20)
+  })
 })
 
 // --- 进度条 ---
@@ -163,10 +183,11 @@ const progressValue = computed(() => editorPanelCompRef.value?.progressValue ?? 
       >
         <ResizablePanelGroup direction="horizontal">
           <ResizablePanel
+            ref="postSliderPanelRef"
             class="post-slider-panel"
-            :default-size="isMobile ? 0 : 15"
-            :max-size="!isMobile && isOpenPostSlider ? 20 : 0"
-            :min-size="!isMobile && isOpenPostSlider ? 10 : 0"
+            :default-size="!isMobile && isOpenPostSlider ? 20 : 0"
+            :max-size="!isMobile && isOpenPostSlider ? 30 : 0"
+            :min-size="!isMobile && isOpenPostSlider ? 18 : 0"
           >
             <PostSlider />
           </ResizablePanel>

--- a/apps/web/src/components/editor/post-slider/PostItem.vue
+++ b/apps/web/src/components/editor/post-slider/PostItem.vue
@@ -16,6 +16,11 @@ import { usePostStore } from '@/stores/post'
 import { useTemplateStore } from '@/stores/template'
 import { useUIStore } from '@/stores/ui'
 import { downloadMD } from '@/utils'
+import {
+  getPostSliderDropdownContentProps,
+  updatePostSliderMenuOpen,
+  usePostSliderMenu,
+} from './postSliderMenu'
 
 const props = defineProps<PostItemProps>()
 
@@ -23,12 +28,32 @@ const postStore = usePostStore()
 const templateStore = useTemplateStore()
 const uiStore = useUIStore()
 const { posts, currentPostId } = storeToRefs(postStore)
+const { isMobile } = storeToRefs(uiStore)
 const { toggleShowTemplateDialog } = uiStore
+const postSliderMenu = usePostSliderMenu()
+const { openMenuKey } = postSliderMenu
+
+const postDropdownProps = computed(() => getPostSliderDropdownContentProps(isMobile.value))
+
+function onPostMenuOpenChange(postId: string, open: boolean) {
+  updatePostSliderMenuOpen(postSliderMenu, postId, open)
+}
+
+function closePostMenu() {
+  postSliderMenu.closeMenu()
+}
 
 const { drag, actions } = props
 const isSelectMode = computed(() => props.select?.isSelectMode ?? false)
 const selectedIds = computed(() => props.select?.selectedIds ?? [])
 const onToggleSelect = computed(() => props.select?.onToggleSelect)
+
+function handleRowClick(postId: string) {
+  if (isSelectMode.value)
+    onToggleSelect.value?.(postId)
+  else
+    currentPostId.value = postId
+}
 
 function handleDragStart(id: string, e: DragEvent) {
   drag.setDragSourceId(id)
@@ -57,6 +82,7 @@ function saveAsTemplate(postId: string) {
     content: post.content,
     description: `从「${post.title}」创建于 ${new Date().toLocaleString('zh-CN')}`,
   })
+  closePostMenu()
 }
 
 function duplicateSingle(postId: string) {
@@ -66,10 +92,12 @@ function duplicateSingle(postId: string) {
   postStore.addPost(`${p.title} 副本`, p.parentId ?? null)
   const newPost = posts.value[posts.value.length - 1]
   postStore.updatePostContent(newPost.id, p.content)
+  closePostMenu()
 }
 
 function applyTemplate(postId: string) {
   currentPostId.value = postId
+  closePostMenu()
   toggleShowTemplateDialog(true)
 }
 
@@ -113,85 +141,99 @@ function cancelInlineRename() {
 
 <template>
   <div v-for="post in props.sortedPosts.filter(p => (props.parentId == null && p.parentId == null) || p.parentId === props.parentId)" :key="post.id">
-    <a
-      class="post-item group relative flex w-full cursor-pointer items-center gap-1 rounded-lg px-2 py-[7px] text-[13px] leading-snug transition-all duration-150 ease-out"
+    <div
+      class="post-item group relative flex w-full items-center gap-1 rounded-lg px-2 py-[7px] text-[13px] leading-snug transition-all duration-150 ease-out"
       :class="{
         'bg-accent text-accent-foreground font-medium active-item': !isSelectMode && currentPostId === post.id,
         'text-foreground/70 hover:text-foreground hover:bg-accent/50': isSelectMode ? true : currentPostId !== post.id,
         'opacity-30': drag.dragSourceId === post.id,
         'ring-1 ring-primary/40 ring-inset bg-primary/5': drag.dropTargetId === post.id,
       }"
-      :draggable="!isSelectMode && inlineEditId !== post.id"
-      @dragstart="!isSelectMode && handleDragStart(post.id, $event)"
-      @dragend="drag.handleDragEnd"
       @drop.prevent="!isSelectMode && drag.handleDrop(post.id)"
       @dragover.stop.prevent="!isSelectMode && drag.setDropTargetId(post.id)"
       @dragleave.prevent="drag.setDropTargetId(null)"
-      @click="isSelectMode ? onToggleSelect?.(post.id) : (currentPostId = post.id)"
     >
       <span
         v-if="!isSelectMode && currentPostId === post.id"
         class="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-4 rounded-r-full bg-primary"
       />
 
-      <span
-        v-if="isSelectMode"
-        class="flex shrink-0 items-center justify-center size-5"
-        @click.stop="onToggleSelect?.(post.id)"
+      <div
+        class="flex min-w-0 flex-1 cursor-pointer items-center gap-1"
+        :draggable="!isSelectMode && inlineEditId !== post.id"
+        @dragstart="!isSelectMode && handleDragStart(post.id, $event)"
+        @dragend="drag.handleDragEnd"
+        @click="handleRowClick(post.id)"
       >
         <span
-          class="flex items-center justify-center size-4 rounded border transition-colors duration-150"
-          :class="selectedIds?.includes(post.id)
-            ? 'bg-primary border-primary text-primary-foreground'
-            : 'border-border bg-background'"
+          v-if="isSelectMode"
+          class="flex shrink-0 items-center justify-center size-5"
+          @click.stop="onToggleSelect?.(post.id)"
         >
-          <svg v-if="selectedIds?.includes(post.id)" class="size-2.5" viewBox="0 0 10 10" fill="none">
-            <path d="M1.5 5L4 7.5L8.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
+          <span
+            class="flex items-center justify-center size-4 rounded border transition-colors duration-150"
+            :class="selectedIds?.includes(post.id)
+              ? 'bg-primary border-primary text-primary-foreground'
+              : 'border-border bg-background'"
+          >
+            <svg v-if="selectedIds?.includes(post.id)" class="size-2.5" viewBox="0 0 10 10" fill="none">
+              <path d="M1.5 5L4 7.5L8.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </span>
         </span>
-      </span>
 
-      <button
+        <button
+          v-if="!isSelectMode"
+          type="button"
+          class="flex shrink-0 items-center justify-center size-5 rounded text-muted-foreground/50 transition-colors duration-150"
+          :class="{
+            'hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5': isHasChild(post.id),
+            'invisible': !isHasChild(post.id),
+          }"
+          @click.stop="isHasChild(post.id) && togglePostExpanded(post.id)"
+        >
+          <ChevronRight
+            class="size-3.5 transition-transform duration-200 ease-out"
+            :class="{ 'rotate-90': !post.collapsed }"
+          />
+        </button>
+
+        <input
+          v-if="inlineEditId === post.id"
+          :ref="setInlineInputRef"
+          v-model="inlineEditVal"
+          class="flex-1 min-w-0 bg-transparent outline-none border-b border-primary text-[13px] leading-snug"
+          @click.stop
+          @keyup.enter="commitInlineRename"
+          @keyup.escape="cancelInlineRename"
+          @blur="commitInlineRename"
+        >
+        <span
+          v-else
+          class="flex-1 truncate select-none"
+          @dblclick.stop="startInlineRename(post)"
+        >{{ post.title }}</span>
+      </div>
+
+      <DropdownMenu
         v-if="!isSelectMode"
-        class="flex shrink-0 items-center justify-center size-5 rounded text-muted-foreground/50 transition-colors duration-150"
-        :class="{
-          'hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5': isHasChild(post.id),
-          'invisible': !isHasChild(post.id),
-        }"
-        @click.stop="isHasChild(post.id) && togglePostExpanded(post.id)"
+        :open="openMenuKey === post.id"
+        @update:open="(open) => onPostMenuOpenChange(post.id, open)"
       >
-        <ChevronRight
-          class="size-3.5 transition-transform duration-200 ease-out"
-          :class="{ 'rotate-90': !post.collapsed }"
-        />
-      </button>
-
-      <input
-        v-if="inlineEditId === post.id"
-        :ref="setInlineInputRef"
-        v-model="inlineEditVal"
-        class="flex-1 min-w-0 bg-transparent outline-none border-b border-primary text-[13px] leading-snug"
-        @click.stop
-        @keyup.enter="commitInlineRename"
-        @keyup.escape="cancelInlineRename"
-        @blur="commitInlineRename"
-      >
-      <span
-        v-else
-        class="flex-1 truncate select-none"
-        @dblclick.stop="startInlineRename(post)"
-      >{{ post.title }}</span>
-
-      <DropdownMenu v-if="!isSelectMode">
         <DropdownMenuTrigger as-child>
           <button
-            class="ml-auto flex shrink-0 items-center justify-center size-6 rounded-md text-muted-foreground/40 opacity-0 transition-all duration-150 group-hover:opacity-100 hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 data-[state=open]:opacity-100 data-[state=open]:text-foreground"
+            type="button"
+            class="flex shrink-0 items-center justify-center size-6 rounded-md text-muted-foreground/40 transition-all duration-150 hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 data-[state=open]:opacity-100 data-[state=open]:text-foreground"
+            :class="isMobile ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
             @click.stop
           >
             <Ellipsis class="size-4" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" class="w-40">
+        <DropdownMenuContent
+          :align="isMobile ? 'end' : 'start'"
+          v-bind="postDropdownProps"
+        >
           <DropdownMenuItem @click.stop="actions.openAddPostDialog(post.id)">
             <PlusSquare class="mr-2 size-4" /> 新增内容
           </DropdownMenuItem>
@@ -205,7 +247,7 @@ function cancelInlineRename() {
             <History class="mr-2 size-4" /> 历史记录
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem @click.stop="downloadMD(post.content, post.title)">
+          <DropdownMenuItem @click.stop="downloadMD(post.content, post.title); closePostMenu()">
             <FileDown class="mr-2 size-4" /> 导出 .md
           </DropdownMenuItem>
           <DropdownMenuSeparator />
@@ -225,7 +267,7 @@ function cancelInlineRename() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-    </a>
+    </div>
 
     <div
       v-if="isHasChild(post.id) && !post.collapsed"

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -6,11 +6,26 @@ import { usePostStore } from '@/stores/post'
 import { useUIStore } from '@/stores/ui'
 import { addPrefix, downloadMD, exportPostsAsZip } from '@/utils'
 import { store } from '@/utils/storage'
+import {
+  getPostSliderDropdownContentProps,
+  providePostSliderMenu,
+  updatePostSliderMenuOpen,
+} from './postSliderMenu'
 
 const confirmStore = useConfirmStore()
 const uiStore = useUIStore()
 const { isMobile, isOpenPostSlider } = storeToRefs(uiStore)
 const { toggleShowImportMdDialog } = uiStore
+
+const postSliderMenu = providePostSliderMenu()
+const { openMenuKey } = postSliderMenu
+
+const headerMenuOpen = computed(() => openMenuKey.value === `header`)
+function onHeaderMenuOpenChange(open: boolean) {
+  updatePostSliderMenuOpen(postSliderMenu, `header`, open)
+}
+
+const headerDropdownProps = computed(() => getPostSliderDropdownContentProps(isMobile.value, `w-48`))
 
 const postStore = usePostStore()
 const { posts } = storeToRefs(postStore)
@@ -22,16 +37,17 @@ const { editor } = storeToRefs(editorStore)
 const enableAnimation = ref(false)
 
 // 监听 PostSlider 开关状态变化
-watch(isOpenPostSlider, () => {
-  if (isMobile.value) {
-    // 在移动端，用户操作时启用动画
+watch(isOpenPostSlider, (open) => {
+  if (!open)
+    postSliderMenu.closeMenu()
+  if (isMobile.value)
     enableAnimation.value = true
-  }
 })
 
 // 监听设备类型变化，重置动画状态
 watch(isMobile, () => {
   enableAnimation.value = false
+  postSliderMenu.closeMenu()
 })
 
 /* ============ 新增内容 ============ */
@@ -39,17 +55,14 @@ const parentId = ref<string | null>(null)
 const isOpenAddDialog = ref(false)
 const addPostInputVal = ref(``)
 watch(isOpenAddDialog, (o) => {
-  if (o) {
+  if (o)
     addPostInputVal.value = ``
-    parentId.value = null
-  }
 })
 
 function openAddPostDialog(id: string) {
+  postSliderMenu.closeMenu()
+  parentId.value = id
   isOpenAddDialog.value = true
-  nextTick(() => {
-    parentId.value = id
-  })
 }
 
 function addPost() {
@@ -60,12 +73,19 @@ function addPost() {
   toast.success(`内容新增成功`)
 }
 
+function openCreatePostDialog() {
+  postSliderMenu.closeMenu()
+  parentId.value = null
+  isOpenAddDialog.value = true
+}
+
 /* ============ 重命名 / 删除 / 历史 对象 ============ */
 const editId = ref<string | null>(null)
 const isOpenEditDialog = ref(false)
 const renamePostInputVal = ref(``)
 
 function startRenamePost(id: string) {
+  postSliderMenu.closeMenu()
   editId.value = id
   renamePostInputVal.value = postStore.getPostById(id)!.title
   isOpenEditDialog.value = true
@@ -102,6 +122,7 @@ const hasSubPosts = computed(() => {
 })
 
 function startDelPost(id: string) {
+  postSliderMenu.closeMenu()
   delId.value = id
   delRecursive.value = false
   isOpenDelPostConfirmDialog.value = true
@@ -120,6 +141,7 @@ const historyViewMode = ref<'content' | 'diff'>(`content`)
 const compareTargetIndex = ref(`1`)
 
 function openHistoryDialog(id: string) {
+  postSliderMenu.closeMenu()
   currentPostId.value = id
   currentHistoryIndex.value = 0
   historyViewMode.value = `content`
@@ -175,6 +197,7 @@ const isRegex = ref(false)
 const isCaseSensitive = ref(false)
 
 function toggleSearch() {
+  postSliderMenu.closeMenu()
   isSearching.value = !isSearching.value
   if (isSearching.value) {
     nextTick(() => searchInputRef.value?.focus())
@@ -416,6 +439,7 @@ const selectProps = computed(() => ({
 }))
 
 function toggleSelectMode() {
+  postSliderMenu.closeMenu()
   isSelectMode.value = !isSelectMode.value
   selectedPostIds.value = []
 }
@@ -455,12 +479,14 @@ async function exportSelected() {
 
 /* ============ 批量导入 / 导出全部 ============ */
 function openImportDialog() {
+  postSliderMenu.closeMenu()
   toggleShowImportMdDialog(true)
 }
 
 async function exportAll() {
   if (!posts.value.length)
     return
+  postSliderMenu.closeMenu()
   const toExport = posts.value.map(p => ({ title: p.title, content: p.content }))
   if (toExport.length === 1) {
     downloadMD(toExport[0].content, toExport[0].title)
@@ -612,117 +638,140 @@ function handleDragEnd() {
   >
     <nav
       class="h-full flex flex-col overflow-hidden"
+      :aria-label="isMobile ? '内容管理' : undefined"
       @dragover="handleDragOver"
       @drop.prevent="handleDrop(null)"
     >
       <!-- 标题栏 -->
-      <div class="flex items-center h-10 px-3 shrink-0">
-        <span class="inline-flex items-center text-muted-foreground select-none">
+      <div
+        class="flex items-center shrink-0 bg-background flex-nowrap"
+        :class="isMobile
+          ? 'min-h-[calc(2.75rem+env(safe-area-inset-top,0px))] gap-0.5 border-b border-border px-3 pt-[max(0.625rem,env(safe-area-inset-top,0px))] pb-2.5'
+          : 'h-10 px-3'"
+      >
+        <span class="inline-flex shrink-0 items-center gap-1.5 text-muted-foreground select-none">
           <FileText class="size-4" />
+          <span
+            v-if="posts.length"
+            class="inline-flex items-center justify-center rounded-full bg-muted px-1.5 text-[10px] font-medium tabular-nums text-muted-foreground min-w-[18px] h-[18px]"
+          >
+            {{ posts.length }}
+          </span>
         </span>
-        <span
-          v-if="posts.length"
-          class="ml-1.5 inline-flex items-center justify-center rounded-full bg-muted px-1.5 text-[10px] font-medium tabular-nums text-muted-foreground min-w-[18px] h-[18px]"
-        >
-          {{ posts.length }}
-        </span>
-        <span class="flex-1" />
+        <span class="flex-1 min-w-0" />
 
-        <!-- 搜索 -->
-        <button
-          class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
-          :class="{ 'text-primary bg-primary/10': isSearching }"
-          @click="toggleSearch"
-        >
-          <Search class="size-4" />
-        </button>
+        <div class="flex shrink-0 items-center gap-0.5">
+          <!-- 搜索 -->
+          <button
+            class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
+            :class="[
+              isMobile ? 'size-8' : 'size-7',
+              { 'text-primary bg-primary/10': isSearching },
+            ]"
+            @click="toggleSearch"
+          >
+            <Search class="size-4" />
+          </button>
 
-        <!-- 多选 -->
-        <button
-          class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
-          :class="{ 'text-primary bg-primary/10': isSelectMode }"
-          :title="isSelectMode ? '退出选择' : '多选操作'"
-          @click="toggleSelectMode"
-        >
-          <CheckSquare class="size-4" />
-        </button>
+          <!-- 多选 -->
+          <button
+            class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
+            :class="[
+              isMobile ? 'size-8' : 'size-7',
+              { 'text-primary bg-primary/10': isSelectMode },
+            ]"
+            :title="isSelectMode ? '退出选择' : '多选操作'"
+            @click="toggleSelectMode"
+          >
+            <CheckSquare class="size-4" />
+          </button>
 
-        <!-- 批量导入 -->
-        <button
-          class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
-          title="导入 Markdown（支持批量）"
-          @click="openImportDialog"
-        >
-          <Upload class="size-4" />
-        </button>
+          <!-- 批量导入（移动端快捷入口，桌面端在更多菜单中） -->
+          <button
+            v-if="isMobile"
+            class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150 size-8"
+            title="导入 Markdown（支持批量）"
+            @click="openImportDialog"
+          >
+            <Upload class="size-4" />
+          </button>
 
-        <!-- 新增 -->
-        <button
-          class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
-          @click="isOpenAddDialog = true"
-        >
-          <Plus class="size-4" />
-        </button>
+          <!-- 新增 -->
+          <button
+            class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
+            :class="isMobile ? 'size-8' : 'size-7'"
+            @click="openCreatePostDialog"
+          >
+            <Plus class="size-4" />
+          </button>
 
-        <!-- 更多操作 -->
-        <DropdownMenu>
-          <DropdownMenuTrigger as-child>
-            <button class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150">
-              <Ellipsis class="size-4" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" class="w-48">
-            <DropdownMenuLabel class="text-xs text-muted-foreground font-normal">
-              排序方式
-            </DropdownMenuLabel>
-            <DropdownMenuRadioGroup v-model="sortMode">
-              <DropdownMenuRadioItem value="A-Z">
-                文件名（A-Z）
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="Z-A">
-                文件名（Z-A）
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="update-new-old">
-                编辑时间（新→旧）
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="update-old-new">
-                编辑时间（旧→新）
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="create-new-old">
-                创建时间（新→旧）
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="create-old-new">
-                创建时间（旧→新）
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem @click="openImportDialog">
-              <Upload class="mr-2 size-4" />
-              批量导入
-            </DropdownMenuItem>
-            <DropdownMenuItem :disabled="!posts.length" @click="exportAll">
-              <Download class="mr-2 size-4" />
-              导出全部
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem @click="postStore.collapseAllPosts">
-              <ChevronsDownUp class="mr-2 size-4" />
-              全部收起
-            </DropdownMenuItem>
-            <DropdownMenuItem @click="postStore.expandAllPosts">
-              <ChevronsUpDown class="mr-2 size-4" />
-              全部展开
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+          <!-- 更多操作 -->
+          <DropdownMenu :open="headerMenuOpen" @update:open="onHeaderMenuOpenChange">
+            <DropdownMenuTrigger as-child>
+              <button
+                class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
+                :class="isMobile ? 'size-8' : 'size-7'"
+              >
+                <Ellipsis class="size-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              v-bind="headerDropdownProps"
+            >
+              <DropdownMenuLabel class="text-xs text-muted-foreground font-normal">
+                排序方式
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup v-model="sortMode">
+                <DropdownMenuRadioItem value="A-Z">
+                  文件名（A-Z）
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="Z-A">
+                  文件名（Z-A）
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="update-new-old">
+                  编辑时间（新→旧）
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="update-old-new">
+                  编辑时间（旧→新）
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="create-new-old">
+                  创建时间（新→旧）
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="create-old-new">
+                  创建时间（旧→新）
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem @click="openImportDialog">
+                <Upload class="mr-2 size-4" />
+                批量导入
+              </DropdownMenuItem>
+              <DropdownMenuItem :disabled="!posts.length" @click="exportAll">
+                <Download class="mr-2 size-4" />
+                导出全部
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem @click="postStore.collapseAllPosts">
+                <ChevronsDownUp class="mr-2 size-4" />
+                全部收起
+              </DropdownMenuItem>
+              <DropdownMenuItem @click="postStore.expandAllPosts">
+                <ChevronsUpDown class="mr-2 size-4" />
+                全部展开
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-        <!-- 关闭 -->
-        <button
-          class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150 ml-0.5"
-          @click="isOpenPostSlider = false"
-        >
-          <X class="size-4" />
-        </button>
+          <!-- 关闭（移动端全屏抽屉） -->
+          <button
+            v-if="isMobile"
+            class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150 ml-0.5 size-8"
+            @click="isOpenPostSlider = false"
+          >
+            <X class="size-4" />
+          </button>
+        </div>
       </div>
 
       <!-- 搜索栏 -->
@@ -881,7 +930,10 @@ function handleDragEnd() {
       <Transition name="slide-up">
         <div
           v-if="isSelectMode"
-          class="shrink-0 border-t border-border bg-background px-3 pt-2 pb-3 space-y-2"
+          class="shrink-0 border-t border-border bg-background px-3 pt-2 space-y-2"
+          :class="isMobile
+            ? 'pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]'
+            : 'pb-3'"
         >
           <!-- 选中信息行 -->
           <div class="flex items-center justify-between text-xs">

--- a/apps/web/src/components/editor/post-slider/postSliderMenu.ts
+++ b/apps/web/src/components/editor/post-slider/postSliderMenu.ts
@@ -1,0 +1,60 @@
+import type { InjectionKey, Ref } from 'vue'
+
+export type PostSliderMenuKey = 'header' | string | null
+
+export interface PostSliderMenuContext {
+  openMenuKey: Ref<PostSliderMenuKey>
+  setOpenMenuKey: (key: PostSliderMenuKey) => void
+  closeMenu: () => void
+}
+
+export const postSliderMenuKey: InjectionKey<PostSliderMenuContext> = Symbol(`postSliderMenu`)
+
+export const postSliderMobileMenuClass
+  = `z-[60] w-[min(12rem,calc(100vw-2rem))] max-h-[min(60dvh,calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-5rem))] overflow-x-hidden overflow-y-auto overscroll-contain`
+
+export const postSliderMobileMenuCollisionPadding = {
+  top: 72,
+  bottom: 96,
+  left: 16,
+  right: 16,
+} as const
+
+export function getPostSliderDropdownContentProps(isMobile: boolean, desktopClass = `w-40`) {
+  return {
+    sideOffset: 8,
+    collisionPadding: isMobile ? postSliderMobileMenuCollisionPadding : 8,
+    class: isMobile ? postSliderMobileMenuClass : desktopClass,
+  } as const
+}
+
+export function providePostSliderMenu() {
+  const openMenuKey = ref<PostSliderMenuKey>(null)
+  const setOpenMenuKey = (key: PostSliderMenuKey) => {
+    openMenuKey.value = key
+  }
+  const closeMenu = () => {
+    openMenuKey.value = null
+  }
+  const ctx = { openMenuKey, setOpenMenuKey, closeMenu }
+  provide(postSliderMenuKey, ctx)
+  return ctx
+}
+
+export function usePostSliderMenu() {
+  const ctx = inject(postSliderMenuKey)
+  if (!ctx)
+    throw new Error(`usePostSliderMenu must be used within PostSlider`)
+  return ctx
+}
+
+export function updatePostSliderMenuOpen(
+  ctx: PostSliderMenuContext,
+  key: Exclude<PostSliderMenuKey, null>,
+  open: boolean,
+) {
+  if (open)
+    ctx.setOpenMenuKey(key)
+  else if (ctx.openMenuKey.value === key)
+    ctx.closeMenu()
+}


### PR DESCRIPTION
## Summary

- Improve mobile content management (post slider) layout with safe-area insets and `viewport-fit=cover`
- Fix dropdown menus being clipped or hidden behind the mobile drawer (z-index, alignment, collision padding, scroll)
- Enforce exclusive dropdown state so header and item menus cannot stay open at the same time
- Widen desktop post slider panel defaults and resize panel when toggling open state or switching device mode
- Refactor post item row structure to separate drag/click area from the action menu trigger

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] CI/workflow change

## Test Procedure

- [ ] Open **文件 → 内容管理** on desktop; verify toolbar icons are fully visible at default panel width
- [ ] On mobile (or DevTools device mode), open content management and verify header buttons respect safe area
- [ ] Tap item **...** menu near top/bottom of list; menu should be fully visible or scrollable
- [ ] Open item **...** then header **...**; only one menu should remain open
- [ ] Verify drag-and-drop still works from list rows; **...** button should not trigger drag
- [ ] Toggle desktop/mobile viewport while panel is open; layout should remain correct

## Pre-flight Checklist

- [x] Changes are limited to the post slider / content management UX
- [x] Commit message follows Conventional Commits (English)
- [x] ESLint pre-commit hook passed
- [ ] Manual mobile and desktop verification completed
