### PR TITLE
refactor(web): improve account and sync panel mobile layout

### DIFF
--- a/apps/web/src/components/editor/editor-header/AccountDialog.vue
+++ b/apps/web/src/components/editor/editor-header/AccountDialog.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { Crown, LogIn, LogOut, User } from '@lucide/vue'
+import { Crown, LogIn, LogOut, Settings2, User } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
+import { Button } from '@/components/ui/button'
 import { isProPlan } from '@/services/account/features'
 import { useAuthStore } from '@/stores/auth'
 import { useSyncStore } from '@/stores/sync'
@@ -22,10 +25,13 @@ const { user, isConfigured, isLoggedIn } = storeToRefs(authStore)
 
 const isPro = computed(() => isProPlan(user.value?.plan))
 
-function onUpdate(val: boolean) {
-  if (!val)
-    emit(`close`)
-}
+const dialogOpen = computed({
+  get: () => props.visible,
+  set: (val: boolean) => {
+    if (!val)
+      emit(`close`)
+  },
+})
 
 function handleLogin() {
   authStore.login()
@@ -38,60 +44,89 @@ function handleLogout() {
 </script>
 
 <template>
-  <Dialog :open="props.visible" @update:open="onUpdate">
-    <DialogContent class="max-w-md gap-0 p-0">
-      <DialogHeader class="space-y-1.5 border-b px-6 py-4">
-        <DialogTitle class="flex items-center gap-2">
-          <User class="size-5" />
-          账户
-        </DialogTitle>
-        <DialogDescription>
-          登录后可使用云同步等云端能力。
-        </DialogDescription>
-      </DialogHeader>
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="账户"
+    description="登录后可使用云同步、分享预览等云端能力。"
+    :icon="User"
+  >
+    <CloudPanelState
+      v-if="!isConfigured"
+      :icon="Settings2"
+      title="账户服务未配置"
+      description="部署方需配置 VITE_MD_API_URL 或 VITE_SYNC_API_URL 后，方可使用登录与云同步。"
+      compact
+    >
+      <code class="rounded-md border bg-muted/40 px-2 py-1 text-[11px] text-muted-foreground">
+        VITE_MD_API_URL
+      </code>
+    </CloudPanelState>
 
-      <div v-if="!isConfigured" class="text-muted-foreground px-6 py-8 text-center text-sm">
-        账户服务未配置（缺少 <code>VITE_MD_API_URL</code> 或 <code>VITE_SYNC_API_URL</code>）。
-      </div>
+    <CloudPanelState
+      v-else-if="!isLoggedIn"
+      :icon="User"
+      title="登录你的账户"
+      action-label="使用 GitHub 登录"
+      :action-icon="LogIn"
+      @action="handleLogin"
+    />
 
-      <div v-else-if="!isLoggedIn" class="flex flex-col items-center px-6 py-8">
-        <Button class="gap-2" @click="handleLogin">
-          <LogIn class="size-4" />
-          使用 GitHub 登录
-        </Button>
-      </div>
+    <div v-else class="space-y-4 px-4 py-4 sm:px-6">
+      <div class="flex items-center gap-3 rounded-xl border bg-muted/20 p-3.5 sm:p-4">
+        <img
+          v-if="user?.avatar"
+          :src="user.avatar"
+          :alt="user?.login"
+          class="size-12 shrink-0 rounded-full ring-2 ring-background sm:size-11"
+        >
+        <div
+          v-else
+          class="flex size-12 shrink-0 items-center justify-center rounded-full bg-muted ring-2 ring-background sm:size-11"
+        >
+          <User class="size-5 text-muted-foreground" />
+        </div>
 
-      <div v-else class="space-y-4 px-6 py-4">
-        <div class="flex items-center gap-3 rounded-lg border p-3">
-          <img
-            v-if="user?.avatar"
-            :src="user.avatar"
-            :alt="user?.login"
-            class="size-10 shrink-0 rounded-full"
-          >
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2 text-sm font-medium">
-              <span class="truncate">{{ user?.name || user?.login }}</span>
-              <span
-                v-if="isPro"
-                class="bg-primary text-primary-foreground inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs"
-              >
-                <Crown class="size-3" />
-                Pro
-              </span>
-              <span v-else class="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-xs uppercase">
-                Free
-              </span>
-            </div>
-            <div class="text-muted-foreground truncate text-xs">
-              @{{ user?.login }}
-            </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span class="truncate text-sm font-medium">
+              {{ user?.name || user?.login }}
+            </span>
+            <span
+              v-if="isPro"
+              class="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-[11px] font-medium text-primary-foreground"
+            >
+              <Crown class="size-3" />
+              Pro
+            </span>
+            <span
+              v-else
+              class="inline-flex shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium uppercase text-muted-foreground"
+            >
+              Free
+            </span>
           </div>
-          <Button variant="ghost" size="icon" class="shrink-0" title="退出登录" @click="handleLogout">
-            <LogOut class="size-4" />
-          </Button>
+          <p class="truncate text-xs text-muted-foreground">
+            @{{ user?.login }}
+          </p>
         </div>
       </div>
-    </DialogContent>
-  </Dialog>
+
+      <div class="rounded-xl border border-dashed px-3.5 py-3 text-xs leading-relaxed text-muted-foreground">
+        已登录。可在底部栏打开云同步，或使用分享预览将文章生成只读链接。
+      </div>
+    </div>
+
+    <template v-if="isConfigured && isLoggedIn" #footer>
+      <div class="border-t px-4 py-4 sm:px-6">
+        <Button
+          variant="outline"
+          class="h-10 w-full gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          @click="handleLogout"
+        >
+          <LogOut class="size-4" />
+          退出登录
+        </Button>
+      </div>
+    </template>
+  </CloudPanelDialog>
 </template>

--- a/apps/web/src/components/editor/editor-header/SyncDialog.vue
+++ b/apps/web/src/components/editor/editor-header/SyncDialog.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
-import { Cloud, Info, Loader2, LogIn, RefreshCw } from '@lucide/vue'
+import { AlertCircle, Cloud, CloudCheck, CloudOff, Info, Loader2, LogIn, RefreshCw } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 import { isSyncConfigured } from '@/services/sync/client'
 import { useAuthStore } from '@/stores/auth'
 import { useSyncStore } from '@/stores/sync'
@@ -21,18 +25,63 @@ const syncStore = useSyncStore()
 const uiStore = useUIStore()
 
 const { isLoggedIn } = storeToRefs(authStore)
-const { status, lastError, lastSyncAt, needsRefresh, isSyncing } = storeToRefs(syncStore)
+const { status, lastError, lastSyncAt, needsRefresh, isSyncing, syncState } = storeToRefs(syncStore)
+
+const dialogOpen = computed({
+  get: () => props.visible,
+  set: (val: boolean) => {
+    if (!val)
+      emit(`close`)
+  },
+})
 
 const lastSyncText = computed(() => {
   if (!lastSyncAt.value)
     return `从未同步`
-  return new Date(lastSyncAt.value).toLocaleString(`zh-cn`)
+  return new Date(lastSyncAt.value).toLocaleString(`zh-CN`, {
+    month: `short`,
+    day: `numeric`,
+    hour: `2-digit`,
+    minute: `2-digit`,
+  })
 })
 
-function onUpdate(val: boolean) {
-  if (!val)
-    emit(`close`)
-}
+const syncStatusMeta = computed(() => {
+  switch (syncState.value) {
+    case `syncing`:
+      return {
+        label: `同步中`,
+        hint: `正在与云端交换数据…`,
+        dotClass: `bg-primary animate-pulse`,
+        icon: Loader2,
+        iconClass: `text-primary animate-spin`,
+      }
+    case `synced`:
+      return {
+        label: `已同步`,
+        hint: `本地内容与云端一致`,
+        dotClass: `bg-green-500`,
+        icon: CloudCheck,
+        iconClass: `text-green-600 dark:text-green-400`,
+      }
+    case `error`:
+      return {
+        label: `同步失败`,
+        hint: lastError.value || `请稍后重试`,
+        dotClass: `bg-destructive`,
+        icon: AlertCircle,
+        iconClass: `text-destructive`,
+      }
+    default:
+      return {
+        label: `待同步`,
+        hint: `本地有未上传的更改`,
+        dotClass: `bg-amber-500`,
+        icon: CloudOff,
+        iconClass: `text-amber-600 dark:text-amber-400`,
+      }
+  }
+})
 
 function openAccountDialog() {
   emit(`close`)
@@ -53,53 +102,101 @@ function handleReload() {
 </script>
 
 <template>
-  <Dialog :open="props.visible" @update:open="onUpdate">
-    <DialogContent class="max-w-md gap-0 p-0">
-      <DialogHeader class="space-y-1.5 border-b px-6 py-4">
-        <DialogTitle class="flex items-center gap-2">
-          <Cloud class="size-5" />
-          云同步
-        </DialogTitle>
-        <DialogDescription>
-          多设备同步文章与设置，不含密钥。
-        </DialogDescription>
-      </DialogHeader>
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="云同步"
+    description="多设备同步文章与设置，不含密钥与图床凭证。"
+    :icon="Cloud"
+  >
+    <CloudPanelState
+      v-if="!isSyncConfigured()"
+      :icon="CloudOff"
+      title="云同步未启用"
+      description="当前部署未配置同步服务，请联系部署方启用后再试。"
+      compact
+    />
 
-      <div v-if="!isSyncConfigured()" class="text-muted-foreground px-6 py-8 text-center text-sm">
-        云同步服务未配置，请联系部署方启用。
+    <CloudPanelState
+      v-else-if="!isLoggedIn"
+      :icon="Cloud"
+      title="登录后开启云同步"
+      description="账户登录后，可将文章与编辑器设置安全同步到云端，并在多设备间保持一致。"
+      action-label="前往登录"
+      :action-icon="LogIn"
+      @action="openAccountDialog"
+    />
+
+    <div v-else class="space-y-4 px-4 py-4 sm:px-6">
+      <div class="flex items-start gap-3 rounded-xl border bg-muted/20 p-3.5 sm:p-4">
+        <div
+          class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-border/60"
+        >
+          <component
+            :is="syncStatusMeta.icon"
+            class="size-4"
+            :class="syncStatusMeta.iconClass"
+          />
+        </div>
+        <div class="min-w-0 flex-1 space-y-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="inline-flex items-center gap-1.5 text-sm font-medium">
+              <span class="size-2 rounded-full" :class="syncStatusMeta.dotClass" />
+              {{ syncStatusMeta.label }}
+            </span>
+          </div>
+          <p class="text-xs leading-relaxed text-muted-foreground">
+            {{ syncStatusMeta.hint }}
+          </p>
+        </div>
       </div>
 
-      <div v-else-if="!isLoggedIn" class="flex flex-col items-center gap-4 px-6 py-8">
-        <p class="text-muted-foreground text-sm">
-          请先登录账户
-        </p>
-        <Button class="gap-2" @click="openAccountDialog">
-          <LogIn class="size-4" />
-          前往登录
+      <div class="grid gap-2 rounded-xl border px-3.5 py-3 text-xs sm:px-4">
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-muted-foreground">上次同步</span>
+          <span class="font-medium tabular-nums">{{ lastSyncText }}</span>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-muted-foreground">同步范围</span>
+          <span class="text-right">文章、编辑器设置</span>
+        </div>
+      </div>
+
+      <div
+        v-if="needsRefresh"
+        class="flex flex-col gap-3 rounded-xl border bg-muted/30 p-3.5 sm:flex-row sm:items-center sm:justify-between sm:p-4"
+      >
+        <div class="flex min-w-0 items-start gap-2.5">
+          <Info class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <p class="text-xs leading-relaxed text-muted-foreground">
+            部分设置已从云端更新，刷新页面后生效
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          class="h-8 w-full shrink-0 sm:w-auto"
+          @click="handleReload"
+        >
+          刷新页面
         </Button>
       </div>
 
-      <div v-else class="space-y-4 px-6 py-4">
-        <div class="text-muted-foreground rounded-lg border px-3 py-2 text-xs">
-          上次同步：{{ lastSyncText }}
-        </div>
+      <Alert v-if="syncState === 'error' && lastError" variant="destructive" class="py-3">
+        <AlertCircle class="size-4" />
+        <AlertDescription class="text-xs leading-relaxed">
+          {{ lastError }}
+        </AlertDescription>
+      </Alert>
+    </div>
 
-        <Alert v-if="needsRefresh" class="py-2.5">
-          <Info class="size-4" />
-          <AlertDescription class="flex items-center justify-between gap-2 text-xs">
-            <span>部分设置已从云端更新，刷新后生效</span>
-            <Button size="sm" variant="outline" @click="handleReload">
-              刷新
-            </Button>
-          </AlertDescription>
-        </Alert>
-
-        <Button class="w-full gap-2" :disabled="isSyncing" @click="handleSync">
+    <template v-if="isSyncConfigured() && isLoggedIn" #footer>
+      <div class="border-t px-4 py-4 sm:px-6">
+        <Button class="h-10 w-full gap-2" :disabled="isSyncing" @click="handleSync">
           <Loader2 v-if="isSyncing" class="size-4 animate-spin" />
           <RefreshCw v-else class="size-4" />
-          {{ isSyncing ? '同步中…' : '手动同步' }}
+          {{ isSyncing ? '同步中…' : '立即同步' }}
         </Button>
       </div>
-    </DialogContent>
-  </Dialog>
+    </template>
+  </CloudPanelDialog>
 </template>

--- a/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue
+++ b/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  open: boolean
+  title: string
+  description?: string
+  icon?: Component
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const dialogContentClass = cn(
+  `flex max-h-[min(90vh,100dvh)] flex-col gap-0 overflow-hidden p-0`,
+  `max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:top-auto max-sm:w-full max-sm:max-w-none`,
+  `max-sm:max-h-[min(88dvh,100dvh)] max-sm:translate-x-0 max-sm:translate-y-0 max-sm:rounded-t-2xl max-sm:rounded-b-none`,
+  `max-sm:border-x-0 max-sm:border-b-0 max-sm:shadow-2xl`,
+  `max-sm:pb-[max(1rem,env(safe-area-inset-bottom,0px))]`,
+  `max-sm:data-[state=open]:slide-in-from-bottom-4 max-sm:data-[state=closed]:slide-out-to-bottom-4`,
+  `sm:max-w-md`,
+)
+
+function onUpdate(val: boolean) {
+  emit(`update:open`, val)
+}
+</script>
+
+<template>
+  <Dialog :open="props.open" @update:open="onUpdate">
+    <DialogContent :class="dialogContentClass">
+      <div
+        aria-hidden="true"
+        class="mx-auto mt-2 mb-1 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/25 sm:hidden"
+      />
+
+      <DialogHeader class="space-y-1.5 border-b px-4 py-4 sm:px-6">
+        <DialogTitle class="flex items-center gap-2 pr-8 text-base sm:text-lg">
+          <component :is="icon" v-if="icon" class="size-5 shrink-0 text-primary" />
+          {{ title }}
+        </DialogTitle>
+        <DialogDescription v-if="description" class="text-left text-sm">
+          {{ description }}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        <slot />
+      </div>
+
+      <slot name="footer" />
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelState.vue
+++ b/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelState.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+defineProps<{
+  icon: Component
+  title: string
+  description?: string
+  actionLabel?: string
+  actionIcon?: Component
+  compact?: boolean
+}>()
+
+const emit = defineEmits<{
+  action: []
+}>()
+</script>
+
+<template>
+  <div
+    :class="cn(
+      'flex flex-col items-center text-center',
+      compact ? 'gap-3 px-4 py-6 sm:px-6' : 'gap-4 px-4 py-8 sm:px-6 sm:py-10',
+    )"
+  >
+    <div class="flex size-14 items-center justify-center rounded-2xl bg-muted/60 ring-1 ring-border/60">
+      <component :is="icon" class="size-7 text-muted-foreground" />
+    </div>
+
+    <div class="max-w-xs space-y-1.5">
+      <p class="text-sm font-medium text-foreground">
+        {{ title }}
+      </p>
+      <p v-if="description" class="text-xs leading-relaxed text-muted-foreground sm:text-sm">
+        {{ description }}
+      </p>
+    </div>
+
+    <slot />
+
+    <Button
+      v-if="actionLabel"
+      class="h-10 w-full max-w-xs gap-2 sm:w-auto sm:min-w-[200px]"
+      @click="emit('action')"
+    >
+      <component :is="actionIcon" v-if="actionIcon" class="size-4" />
+      {{ actionLabel }}
+    </Button>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- Extract shared `CloudPanelDialog` and `CloudPanelState` components for account and cloud sync panels
- Use a mobile-friendly bottom-sheet layout with safe-area padding and scrollable content on small screens
- Refresh account login/logged-in UI and sync status cards, including a cleaner refresh-notice layout on mobile

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / UI improvement
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [ ] Open account dialog on mobile viewport: verify bottom-sheet layout, login CTA, and logged-in profile card
- [ ] Open cloud sync dialog on mobile viewport: verify status card, sync info grid, and full-width refresh button when settings need reload
- [ ] Verify desktop layout still uses centered dialog with consistent styling
- [ ] Confirm login → sync flow still works (sync dialog redirects to account dialog when logged out)

## Pre-flight Checklist

- [x] Changes are scoped to web UI components
- [x] Conventional commit message in English
- [x] No secrets or env files included
- [ ] CI checks pass after push
