### PR TITLE
feat(web): unify cloud panel dialogs and footer cloud actions

### DIFF
--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { StateEffect } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { ArrowUpDown, BookOpen, ChevronRight, ChevronsUpDown, Clock, Cloud, CloudAlert, CloudCheck, Columns2, Eye, FileText, Keyboard, ListTree, Loader2, LogIn, Monitor, Moon, PenLine, Pilcrow, Search, Smartphone, Sun, Type, User } from '@lucide/vue'
+import { ArrowUpDown, BookOpen, ChevronRight, ChevronsUpDown, Clock, Cloud, CloudAlert, CloudCheck, CloudOff, Columns2, Eye, FileText, Keyboard, ListTree, Loader2, LogIn, Monitor, Moon, PenLine, Pilcrow, Search, Share2, Smartphone, Sun, Type, User } from '@lucide/vue'
 import {
   Popover,
   PopoverContent,
@@ -13,7 +13,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { useSyncStatusMeta } from '@/composables/useSyncStatusMeta'
 import { isAccountUiEnabled } from '@/services/account/config'
+import { isShareUiEnabled } from '@/services/share/client'
 import { isSyncUiEnabled } from '@/services/sync/client'
 import { useAuthStore } from '@/stores/auth'
 import { useEditorStore } from '@/stores/editor'
@@ -36,29 +38,35 @@ const { isMobile, viewMode, previewDevice, enableScrollSync } = storeToRefs(uiSt
 const { isLoggedIn } = storeToRefs(authStore)
 const showAccountUi = isAccountUiEnabled()
 const showSyncUi = isSyncUiEnabled()
+const showShareUi = isShareUiEnabled()
 const { isSyncing, syncState } = storeToRefs(syncStore)
+const { syncStatusMeta, syncTooltip } = useSyncStatusMeta()
 
-// 账户图标提示
 const accountTooltip = computed(() => {
   if (!isLoggedIn.value)
     return `登录账户`
   return `账户 @${authStore.user?.login ?? ''}`
 })
 
-// 云同步图标提示
-const syncTooltip = computed(() => {
+const syncFooterIcon = computed(() => {
   if (!isLoggedIn.value)
-    return `云同步（请先登录账户）`
+    return Cloud
+  if (isSyncing.value || syncState.value === `syncing`)
+    return Loader2
   switch (syncState.value) {
-    case `syncing`:
-      return `同步中…`
     case `synced`:
-      return `已同步`
+      return CloudCheck
     case `error`:
-      return `同步失败，点击重试`
+      return CloudAlert
     default:
-      return `有未同步的更改`
+      return CloudOff
   }
+})
+
+const syncFooterIconClass = computed(() => {
+  if (!isLoggedIn.value)
+    return ``
+  return syncStatusMeta.value.footerIconClass
 })
 
 // 相对时间格式化（复用）
@@ -647,14 +655,14 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
         <span class="hidden text-border sm:block">·</span>
 
-        <!-- 账户 & 同步 & 主题 -->
-        <div class="flex items-center gap-1">
+        <!-- 账户 & 同步 & 分享 & 主题 -->
+        <div class="flex items-center gap-0.5">
           <template v-if="showAccountUi">
             <Tooltip>
               <TooltipTrigger as-child>
                 <button
                   aria-label="账户"
-                  class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                  class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
                   :class="isLoggedIn ? 'text-primary' : ''"
                   @click="uiStore.toggleShowAccountDialog(true)"
                 >
@@ -662,10 +670,10 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
                     v-if="isLoggedIn && authStore.user?.avatar"
                     :src="authStore.user.avatar"
                     :alt="authStore.user.login"
-                    class="size-3.5 rounded-full"
+                    class="size-4 rounded-full"
                   >
-                  <User v-else-if="isLoggedIn" class="size-3" />
-                  <LogIn v-else class="size-3" />
+                  <User v-else-if="isLoggedIn" class="size-4" />
+                  <LogIn v-else class="size-4" />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
@@ -679,18 +687,36 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
               <TooltipTrigger as-child>
                 <button
                   aria-label="云同步"
-                  class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                  class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
                   :class="isLoggedIn ? 'text-primary' : ''"
                   @click="uiStore.toggleShowSyncDialog(true)"
                 >
-                  <Loader2 v-if="isSyncing" class="size-3 animate-spin" />
-                  <CloudCheck v-else-if="isLoggedIn && syncState === 'synced'" class="size-3 text-green-500" />
-                  <CloudAlert v-else-if="isLoggedIn && syncState === 'error'" class="size-3 text-destructive" />
-                  <Cloud v-else class="size-3" />
+                  <component
+                    :is="syncFooterIcon"
+                    class="size-4"
+                    :class="syncFooterIconClass"
+                  />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
-                <p>{{ syncTooltip }}</p>
+                <p>{{ isLoggedIn ? syncTooltip : '云同步（请先登录账户）' }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </template>
+
+          <template v-if="showShareUi">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  aria-label="分享预览"
+                  class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
+                  @click="uiStore.openShareDialog()"
+                >
+                  <Share2 class="size-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
+                <p>分享预览</p>
               </TooltipContent>
             </Tooltip>
           </template>
@@ -698,12 +724,12 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
           <Tooltip>
             <TooltipTrigger as-child>
               <button
-                class="flex cursor-pointer items-center rounded p-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
                 :class="isDark ? 'text-foreground' : ''"
                 @click="uiStore.toggleDark()"
               >
-                <Moon v-if="isDark" class="size-3" />
-                <Sun v-else class="size-3" />
+                <Moon v-if="isDark" class="size-4" />
+                <Sun v-else class="size-4" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">

--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -215,20 +215,23 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
       :class="{ 'pt-0': isMobile }"
     >
       <!-- 移动端标题栏 -->
-      <div v-if="isMobile" class="sticky top-0 z-10 flex items-center justify-between -mx-4 px-4 py-3 border-b mb-4 bg-background">
-        <h2 class="text-lg font-semibold">
-          样式设置
-        </h2>
-        <Button variant="ghost" size="sm" @click="isOpenRightSlider = false">
-          <X class="h-4 w-4" />
-        </Button>
+      <div v-if="isMobile" class="sticky top-0 z-10 -mx-4 mb-4 border-b bg-background px-4 pb-3 pt-[max(0.5rem,env(safe-area-inset-top,0px))]">
+        <div aria-hidden="true" class="mx-auto mb-2 h-1 w-10 rounded-full bg-muted-foreground/25" />
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold">
+            样式设置
+          </h2>
+          <Button variant="ghost" size="sm" @click="isOpenRightSlider = false">
+            <X class="h-4 w-4" />
+          </Button>
+        </div>
       </div>
       <div class="space-y-2">
         <h2>主题</h2>
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in themeOptions" :key="value" class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': theme === value,
+              'border-primary ring-1 ring-primary/20 border-2': theme === value,
             }" @click="themeChanged(value)"
           >
             {{ label }}
@@ -240,7 +243,7 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in fontFamilyOptions" :key="value" variant="outline" class="w-full"
-            :class="{ 'border-black dark:border-white border-2': fontFamily === value }" @click="fontChanged(value)"
+            :class="{ 'border-primary ring-1 ring-primary/20 border-2': fontFamily === value }" @click="fontChanged(value)"
           >
             {{ label }}
           </Button>
@@ -251,7 +254,7 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             v-for="{ value, desc } in fontSizeOptions" :key="value" variant="outline" class="w-full" :class="{
-              'border-black dark:border-white border-2': fontSize === value,
+              'border-primary ring-1 ring-primary/20 border-2': fontSize === value,
             }" @click="sizeChanged(value)"
           >
             {{ desc }}
@@ -263,7 +266,7 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in colorOptions" :key="value" class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': primaryColor === value,
+              'border-primary ring-1 ring-primary/20 border-2': primaryColor === value,
             }" @click="colorChanged(value)"
           >
             <span
@@ -330,7 +333,7 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in legendOptions" :key="value" class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': legend === value,
+              'border-primary ring-1 ring-primary/20 border-2': legend === value,
             }" @click="legendChanged(value)"
           >
             {{ label }}
@@ -343,14 +346,14 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': isMacCodeBlock,
+              'border-primary ring-1 ring-primary/20 border-2': isMacCodeBlock,
             }" @click="!isMacCodeBlock && macCodeBlockChanged()"
           >
             开启
           </Button>
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': !isMacCodeBlock,
+              'border-primary ring-1 ring-primary/20 border-2': !isMacCodeBlock,
             }" @click="isMacCodeBlock && macCodeBlockChanged()"
           >
             关闭
@@ -362,14 +365,14 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': isShowLineNumber,
+              'border-primary ring-1 ring-primary/20 border-2': isShowLineNumber,
             }" @click="!isShowLineNumber && showLineNumberChanged()"
           >
             开启
           </Button>
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': !isShowLineNumber,
+              'border-primary ring-1 ring-primary/20 border-2': !isShowLineNumber,
             }" @click="isShowLineNumber && showLineNumberChanged()"
           >
             关闭
@@ -382,14 +385,14 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': isCiteStatus,
+              'border-primary ring-1 ring-primary/20 border-2': isCiteStatus,
             }" @click="!isCiteStatus && citeStatusChanged()"
           >
             开启
           </Button>
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': !isCiteStatus,
+              'border-primary ring-1 ring-primary/20 border-2': !isCiteStatus,
             }" @click="isCiteStatus && citeStatusChanged()"
           >
             关闭
@@ -401,14 +404,14 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': isUseIndent,
+              'border-primary ring-1 ring-primary/20 border-2': isUseIndent,
             }" @click="!isUseIndent && useIndentChanged()"
           >
             开启
           </Button>
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': !isUseIndent,
+              'border-primary ring-1 ring-primary/20 border-2': !isUseIndent,
             }" @click="isUseIndent && useIndentChanged()"
           >
             关闭
@@ -420,14 +423,14 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': isUseJustify,
+              'border-primary ring-1 ring-primary/20 border-2': isUseJustify,
             }" @click="!isUseJustify && useJustifyChanged()"
           >
             开启
           </Button>
           <Button
             class="w-full" variant="outline" :class="{
-              'border-black dark:border-white border-2': !isUseJustify,
+              'border-primary ring-1 ring-primary/20 border-2': !isUseJustify,
             }" @click="isUseJustify && useJustifyChanged()"
           >
             关闭

--- a/apps/web/src/components/editor/SlashCommandMenu.vue
+++ b/apps/web/src/components/editor/SlashCommandMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
-import type { SlashCommandItem } from '@/composables/useSlashCommand'
+import type { SlashCommandItem } from '@/composables/slashCommands'
 import {
   Blocks,
   Bold,

--- a/apps/web/src/components/editor/dialogs/EditorStateDialog.vue
+++ b/apps/web/src/components/editor/dialogs/EditorStateDialog.vue
@@ -9,13 +9,12 @@ import { useUIStore } from '@/stores/ui'
 import { downloadFile } from '@/utils'
 import { copyPlain } from '@/utils/clipboard'
 
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
-})
-const emit = defineEmits([`close`])
+const props = defineProps<{
+  open: boolean
+}>()
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
 const themeStore = useThemeStore()
 const uiStore = useUIStore()
 const postStore = usePostStore()
@@ -23,7 +22,7 @@ const cssEditorStore = useCssEditorStore()
 const renderStore = useRenderStore()
 
 watch(
-  () => props.visible,
+  () => props.open,
   (val) => {
     if (val)
       fetchStoreStates()
@@ -31,9 +30,8 @@ watch(
 )
 
 function onUpdate(val: boolean) {
-  if (!val) {
-    emit(`close`)
-  }
+  if (!val)
+    emit(`update:open`, false)
 }
 
 const activeName = ref(`import`)
@@ -164,7 +162,7 @@ function exportSelectedConfig() {
   const filename = `doocs-md-config-${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}.json`
   downloadFile(JSON.stringify(selectedConfig, null, 2), filename, `application/json`)
   toast.success(`配置文件导出成功`)
-  emit(`close`)
+  emit(`update:open`, false)
 }
 
 // 处理最大化弹窗预览代码
@@ -332,12 +330,12 @@ function applyImportedConfig() {
   })
 
   toast.success(`配置应用成功，请刷新页面查看效果`)
-  emit(`close`)
+  emit(`update:open`, false)
 }
 </script>
 
 <template>
-  <Dialog :open="props.visible" @update:open="onUpdate">
+  <Dialog :open="props.open" @update:open="onUpdate">
     <DialogContent class="md:max-w-2/3">
       <DialogHeader>
         <DialogTitle>导入/导出项目配置</DialogTitle>

--- a/apps/web/src/components/editor/editor-header/AboutDialog.vue
+++ b/apps/web/src/components/editor/editor-header/AboutDialog.vue
@@ -1,18 +1,21 @@
 <script setup lang="ts">
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
+import { ExternalLink, HelpCircle } from '@lucide/vue'
+import { computed } from 'vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import { Button } from '@/components/ui/button'
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (val: boolean) => emit(`update:open`, val),
 })
-
-const emit = defineEmits([`close`])
-
-function onUpdate(val: boolean) {
-  if (!val) {
-    emit(`close`)
-  }
-}
 
 const links = [
   { label: `GitHub 仓库`, url: `https://github.com/doocs/md` },
@@ -21,35 +24,41 @@ const links = [
 ]
 
 function onRedirect(url: string) {
-  window.open(url, `_blank`)
+  window.open(url, `_blank`, `noopener,noreferrer`)
 }
 </script>
 
 <template>
-  <Dialog :open="props.visible" @update:open="onUpdate">
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>关于</DialogTitle>
-      </DialogHeader>
-      <div class="text-center">
-        <h3>一款高度简洁的微信 Markdown 编辑器</h3>
-        <p>扫码关注公众号 Doocs，原创技术内容第一时间推送！</p>
-        <img
-          class="mx-auto my-5"
-          src="https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/gh/doocs/md/images/1648303220922-7e14aefa-816e-44c1-8604-ade709ca1c69.png"
-          alt="Doocs Markdown 编辑器"
-          style="width: 40%"
-        >
-      </div>
-      <DialogFooter class="sm:justify-evenly flex flex-wrap gap-2">
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="关于"
+    description="一款高度简洁的微信 Markdown 编辑器"
+    :icon="HelpCircle"
+  >
+    <div class="space-y-4 px-4 py-6 text-center sm:px-6">
+      <p class="text-sm text-muted-foreground">
+        扫码关注公众号 Doocs，原创技术内容第一时间推送！
+      </p>
+      <img
+        class="mx-auto max-w-[200px] rounded-lg ring-1 ring-border"
+        src="https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/gh/doocs/md/images/1648303220922-7e14aefa-816e-44c1-8604-ade709ca1c69.png"
+        alt="Doocs Markdown 编辑器"
+      >
+    </div>
+
+    <template #footer>
+      <div class="flex flex-wrap gap-2 border-t px-4 py-4 sm:justify-center sm:px-6">
         <Button
           v-for="link in links"
           :key="link.url"
+          variant="outline"
+          class="h-10 flex-1 gap-2 sm:flex-none"
           @click="onRedirect(link.url)"
         >
+          <ExternalLink class="size-4" />
           {{ link.label }}
         </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
+      </div>
+    </template>
+  </CloudPanelDialog>
 </template>

--- a/apps/web/src/components/editor/editor-header/AccountDialog.vue
+++ b/apps/web/src/components/editor/editor-header/AccountDialog.vue
@@ -1,36 +1,44 @@
 <script setup lang="ts">
-import { Crown, LogIn, LogOut, Settings2, User } from '@lucide/vue'
+import { Cloud, Crown, List, LogIn, LogOut, Settings2, Share2, User } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
+import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
 import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
 import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
 import { Button } from '@/components/ui/button'
-import { isProPlan } from '@/services/account/features'
+import { isShareProUser, isShareUiEnabled } from '@/services/share/client'
+import { isSyncUiEnabled } from '@/services/sync/client'
 import { useAuthStore } from '@/stores/auth'
 import { useSyncStore } from '@/stores/sync'
+import { useUIStore } from '@/stores/ui'
 
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
-})
+const props = defineProps<{
+  open: boolean
+}>()
 
-const emit = defineEmits([`close`])
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
 
 const authStore = useAuthStore()
 const syncStore = useSyncStore()
+const uiStore = useUIStore()
 
 const { user, isConfigured, isLoggedIn } = storeToRefs(authStore)
 
-const isPro = computed(() => isProPlan(user.value?.plan))
+const isSharePro = computed(() => isShareProUser(user.value))
+const showSyncUi = isSyncUiEnabled()
+const showShareUi = isShareUiEnabled()
 
 const dialogOpen = computed({
-  get: () => props.visible,
-  set: (val: boolean) => {
-    if (!val)
-      emit(`close`)
-  },
+  get: () => props.open,
+  set: (val: boolean) => emit(`update:open`, val),
+})
+
+const dialogDescription = computed(() => {
+  if (isLoggedIn.value || !isConfigured.value)
+    return undefined
+  return `登录后可使用云同步、分享预览等云端能力。`
 })
 
 function handleLogin() {
@@ -41,13 +49,23 @@ function handleLogout() {
   authStore.logout()
   syncStore.reset()
 }
+
+function openSyncDialog() {
+  dialogOpen.value = false
+  uiStore.toggleShowSyncDialog(true)
+}
+
+function openShareDialog(tab: `create` | `manage` = `create`) {
+  dialogOpen.value = false
+  uiStore.openShareDialog({ tab })
+}
 </script>
 
 <template>
   <CloudPanelDialog
     v-model:open="dialogOpen"
     title="账户"
-    description="登录后可使用云同步、分享预览等云端能力。"
+    :description="dialogDescription"
     :icon="User"
   >
     <CloudPanelState
@@ -72,27 +90,29 @@ function handleLogout() {
     />
 
     <div v-else class="space-y-4 px-4 py-4 sm:px-6">
-      <div class="flex items-center gap-3 rounded-xl border bg-muted/20 p-3.5 sm:p-4">
-        <img
-          v-if="user?.avatar"
-          :src="user.avatar"
-          :alt="user?.login"
-          class="size-12 shrink-0 rounded-full ring-2 ring-background sm:size-11"
-        >
-        <div
-          v-else
-          class="flex size-12 shrink-0 items-center justify-center rounded-full bg-muted ring-2 ring-background sm:size-11"
-        >
-          <User class="size-5 text-muted-foreground" />
-        </div>
+      <CloudPanelCard align="center">
+        <template #leading>
+          <img
+            v-if="user?.avatar"
+            :src="user.avatar"
+            :alt="user?.login"
+            class="size-12 shrink-0 rounded-full ring-2 ring-background sm:size-11"
+          >
+          <div
+            v-else
+            class="flex size-12 shrink-0 items-center justify-center rounded-full bg-muted ring-2 ring-background sm:size-11"
+          >
+            <User class="size-5 text-muted-foreground" />
+          </div>
+        </template>
 
-        <div class="min-w-0 flex-1">
+        <div class="min-w-0 flex-1 text-left">
           <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
             <span class="truncate text-sm font-medium">
               {{ user?.name || user?.login }}
             </span>
             <span
-              v-if="isPro"
+              v-if="isSharePro"
               class="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-[11px] font-medium text-primary-foreground"
             >
               <Crown class="size-3" />
@@ -109,10 +129,36 @@ function handleLogout() {
             @{{ user?.login }}
           </p>
         </div>
-      </div>
+      </CloudPanelCard>
 
-      <div class="rounded-xl border border-dashed px-3.5 py-3 text-xs leading-relaxed text-muted-foreground">
-        已登录。可在底部栏打开云同步，或使用分享预览将文章生成只读链接。
+      <div v-if="showSyncUi || showShareUi" class="grid gap-2 sm:grid-cols-2">
+        <Button
+          v-if="showSyncUi"
+          variant="outline"
+          class="h-10 justify-start gap-2"
+          @click="openSyncDialog"
+        >
+          <Cloud class="size-4 shrink-0" />
+          云同步
+        </Button>
+        <Button
+          v-if="showShareUi"
+          variant="outline"
+          class="h-10 justify-start gap-2"
+          @click="openShareDialog('create')"
+        >
+          <Share2 class="size-4 shrink-0" />
+          分享预览
+        </Button>
+        <Button
+          v-if="showShareUi && isSharePro"
+          variant="outline"
+          class="h-10 justify-start gap-2 sm:col-span-2"
+          @click="openShareDialog('manage')"
+        >
+          <List class="size-4 shrink-0" />
+          我的分享
+        </Button>
       </div>
     </div>
 

--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -12,8 +12,6 @@ const props = withDefaults(defineProps<{
   asSub: false,
 })
 
-const emit = defineEmits([`openEditorState`, `openShare`])
-
 const { asSub } = toRefs(props)
 
 const editorStore = useEditorStore()
@@ -21,12 +19,12 @@ const exportStore = useExportStore()
 const uiStore = useUIStore()
 
 const { isOpenPostSlider, isOpenFolderPanel } = storeToRefs(uiStore)
-const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog } = uiStore
+const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog, toggleShowEditorStateDialog, openShareDialog } = uiStore
 const showSyncUi = isSyncUiEnabled()
 const showShareUi = isShareUiEnabled()
 
 function openEditorStateDialog() {
-  emit(`openEditorState`)
+  toggleShowEditorStateDialog(true)
 }
 
 function openTemplateDialog() {
@@ -138,7 +136,7 @@ function exportEditorContent2PDF() {
           云同步
         </MenubarItem>
         <!-- 分享预览 -->
-        <MenubarItem v-if="showShareUi" @click="emit('openShare')">
+        <MenubarItem v-if="showShareUi" @click="openShareDialog()">
           <Share2 class="mr-2 size-4" />
           分享预览
         </MenubarItem>
@@ -236,7 +234,7 @@ function exportEditorContent2PDF() {
           云同步
         </MenubarItem>
         <!-- 分享预览 -->
-        <MenubarItem v-if="showShareUi" @click="emit('openShare')">
+        <MenubarItem v-if="showShareUi" @click="openShareDialog()">
           <Share2 class="mr-2 size-4" />
           分享预览
         </MenubarItem>

--- a/apps/web/src/components/editor/editor-header/FundDialog.vue
+++ b/apps/web/src/components/editor/editor-header/FundDialog.vue
@@ -1,12 +1,21 @@
 <script setup lang="ts">
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
-})
+import { Heart } from '@lucide/vue'
+import { computed } from 'vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import { Button } from '@/components/ui/button'
 
-const emit = defineEmits([`close`])
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (val: boolean) => emit(`update:open`, val),
+})
 
 const contributors = [
   {
@@ -20,39 +29,33 @@ const contributors = [
     altText: `赞赏二维码 2`,
   },
 ]
-
-function onUpdate(val: boolean) {
-  if (!val) {
-    emit(`close`)
-  }
-}
 </script>
 
 <template>
-  <Dialog :open="props.visible" @update:open="onUpdate">
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>赞赏</DialogTitle>
-      </DialogHeader>
-      <div class="text-center">
-        <p>若觉得项目不错，可以通过以下方式支持我们～</p>
-        <div class="grid grid-cols-2 my-5 gap-4">
-          <div v-for="contributor in contributors" :key="contributor.name" class="text-center">
-            <img
-              :src="contributor.imageUrl"
-              :alt="contributor.altText"
-              class="mx-auto"
-              style="width: 90%; max-width: 200px;border-radius: 10%;"
-            >
-          </div>
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="赞赏"
+    description="若觉得项目不错，可以通过以下方式支持我们～"
+    :icon="Heart"
+  >
+    <div class="px-4 py-6 sm:px-6">
+      <div class="grid grid-cols-2 gap-4">
+        <div v-for="contributor in contributors" :key="contributor.name" class="text-center">
+          <img
+            :src="contributor.imageUrl"
+            :alt="contributor.altText"
+            class="mx-auto w-full max-w-[200px] rounded-xl ring-1 ring-border"
+          >
         </div>
       </div>
+    </div>
 
-      <DialogFooter class="sm:justify-evenly">
-        <Button @click="emit('close')">
+    <template #footer>
+      <div class="border-t px-4 py-4 sm:px-6">
+        <Button variant="outline" class="h-10 w-full" @click="dialogOpen = false">
           关闭
         </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
+      </div>
+    </template>
+  </CloudPanelDialog>
 </template>

--- a/apps/web/src/components/editor/editor-header/HelpDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/HelpDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { BookText, Heart, HelpCircle, MessageSquare, Tag } from '@lucide/vue'
+import { useUIStore } from '@/stores/ui'
 
 const props = withDefaults(defineProps<{
   asSub?: boolean
@@ -7,28 +8,28 @@ const props = withDefaults(defineProps<{
   asSub: false,
 })
 
-const emit = defineEmits(['openAbout', 'openFund', 'openMarkdownHelp'])
-
 const { asSub } = toRefs(props)
+const uiStore = useUIStore()
+const { toggleShowAboutDialog, toggleShowFundDialog, toggleShowMarkdownHelpDialog } = uiStore
 
 function openAboutDialog() {
-  emit('openAbout')
+  toggleShowAboutDialog(true)
 }
 
 function openFundDialog() {
-  emit('openFund')
+  toggleShowFundDialog(true)
 }
 
 function openMarkdownHelp() {
-  emit('openMarkdownHelp')
+  toggleShowMarkdownHelpDialog(true)
 }
 
 function openFeedback() {
-  window.open('https://github.com/doocs/md/issues', '_blank')
+  window.open(`https://github.com/doocs/md/issues`, `_blank`)
 }
 
 function openReleases() {
-  window.open('https://github.com/doocs/md/releases', '_blank')
+  window.open(`https://github.com/doocs/md/releases`, `_blank`)
 }
 </script>
 

--- a/apps/web/src/components/editor/editor-header/MarkdownHelpDialog.vue
+++ b/apps/web/src/components/editor/editor-header/MarkdownHelpDialog.vue
@@ -1,22 +1,25 @@
 <script setup lang="ts">
 import { BookOpen, Code2, FileText, FunctionSquare, PieChart } from '@lucide/vue'
+import { computed, ref } from 'vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (val: boolean) => emit(`update:open`, val),
 })
 
-const emit = defineEmits([`close`])
-
 const activeTab = ref(`basic`)
-
-function onUpdate(val: boolean) {
-  if (!val) {
-    emit(`close`)
-  }
-}
+const copiedSyntax = ref<string | null>(null)
 
 interface SyntaxItem {
   name: string
@@ -198,29 +201,38 @@ const syntaxCategories: SyntaxCategory[] = [
   },
 ]
 
-function copySyntax(syntax: string) {
-  navigator.clipboard.writeText(syntax)
-  toast.success(`已复制到剪贴板`)
+async function copySyntax(syntax: string) {
+  try {
+    await navigator.clipboard.writeText(syntax)
+    copiedSyntax.value = syntax
+    window.setTimeout(() => {
+      if (copiedSyntax.value === syntax)
+        copiedSyntax.value = null
+    }, 1500)
+    toast.success(`已复制到剪贴板`)
+  }
+  catch {
+    toast.error(`复制失败，请手动复制`)
+  }
 }
 </script>
 
 <template>
-  <Dialog :open="props.visible" @update:open="onUpdate">
-    <DialogContent class="sm:max-w-2xl max-h-[80vh]">
-      <DialogHeader>
-        <DialogTitle>Markdown 语法帮助</DialogTitle>
-        <DialogDescription>
-          查看支持的 Markdown 语法，点击语法可直接复制
-        </DialogDescription>
-      </DialogHeader>
-
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="Markdown 语法帮助"
+    description="查看支持的 Markdown 语法，点击语法可直接复制"
+    :icon="BookOpen"
+    size="2xl"
+  >
+    <div class="px-4 py-4 sm:px-6">
       <Tabs v-model="activeTab" class="w-full">
-        <TabsList class="grid w-full grid-cols-5">
+        <TabsList class="grid h-auto w-full grid-cols-5">
           <TabsTrigger
             v-for="cat in syntaxCategories"
             :key="cat.id"
             :value="cat.id"
-            class="!flex-col !items-center !justify-center gap-1 py-2 px-2 [&>span]:flex [&>span]:flex-col [&>span]:items-center [&>span]:justify-center"
+            class="!flex-col !items-center !justify-center gap-1 px-2 py-2 [&>span]:flex [&>span]:flex-col [&>span]:items-center [&>span]:justify-center"
           >
             <component :is="cat.icon" class="size-4" />
             <span class="text-xs whitespace-normal">{{ cat.label }}</span>
@@ -231,34 +243,39 @@ function copySyntax(syntax: string) {
           v-for="cat in syntaxCategories"
           :key="cat.id"
           :value="cat.id"
-          class="mt-4 overflow-y-auto max-h-[50vh] space-y-3"
+          class="mt-4 max-h-[min(50vh,24rem)] space-y-3 overflow-y-auto"
         >
           <div
             v-for="item in cat.items"
             :key="item.name"
-            class="rounded-lg border p-3 hover:bg-accent/50 transition-colors cursor-pointer"
+            class="cursor-pointer rounded-lg border p-3 transition-colors hover:bg-accent/50"
+            :class="copiedSyntax === item.syntax ? 'border-primary bg-primary/5 ring-1 ring-primary/20' : ''"
             @click="copySyntax(item.syntax)"
           >
-            <div class="flex items-center justify-between mb-2">
-              <span class="font-medium text-sm">{{ item.name }}</span>
-              <span class="text-xs text-muted-foreground">点击复制</span>
+            <div class="mb-2 flex items-center justify-between">
+              <span class="text-sm font-medium">{{ item.name }}</span>
+              <span class="text-xs text-muted-foreground">
+                {{ copiedSyntax === item.syntax ? '已复制' : '点击复制' }}
+              </span>
             </div>
-            <pre class="text-xs bg-muted/50 p-2 rounded overflow-x-auto font-mono">{{ item.syntax }}</pre>
+            <pre class="overflow-x-auto rounded bg-muted/50 p-2 font-mono text-xs">{{ item.syntax }}</pre>
             <div v-if="item.tip" class="mt-2 text-xs text-muted-foreground">
-              💡 {{ item.tip }}
+              {{ item.tip }}
             </div>
           </div>
         </TabsContent>
       </Tabs>
+    </div>
 
-      <DialogFooter class="sm:justify-between">
-        <span class="text-xs text-muted-foreground hidden sm:inline">
+    <template #footer>
+      <div class="flex items-center justify-between gap-3 border-t px-4 py-4 sm:px-6">
+        <span class="hidden text-xs text-muted-foreground sm:inline">
           基于 CommonMark 规范，支持多种扩展语法
         </span>
-        <Button variant="outline" @click="emit(`close`)">
+        <Button variant="outline" class="h-10 w-full sm:w-auto" @click="dialogOpen = false">
           关闭
         </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
+      </div>
+    </template>
+  </CloudPanelDialog>
 </template>

--- a/apps/web/src/components/editor/editor-header/ShareDialog.vue
+++ b/apps/web/src/components/editor/editor-header/ShareDialog.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
 import type { ShareListItem, SharePasswordMode } from '@/services/share/types'
-import { Check, Clock, Copy, ExternalLink, Eye, Globe, KeyRound, Loader2, LogIn, RefreshCw, Share2, Sparkles, Trash2 } from '@lucide/vue'
+import { Check, Clock, Copy, ExternalLink, Eye, Globe, Inbox, KeyRound, Loader2, LogIn, RefreshCw, Share2, Sparkles, Trash2 } from '@lucide/vue'
+import { storeToRefs } from 'pinia'
+import { computed, ref, watch } from 'vue'
+import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { captureShareSnapshot } from '@/services/share/capture-snapshot'
-import { isShareConfigured, ShareApiError, ShareClient } from '@/services/share/client'
+import { isShareConfigured, isShareProUser, ShareApiError, ShareClient } from '@/services/share/client'
 import { useAuthStore } from '@/stores/auth'
 import { useConfirmStore } from '@/stores/confirm'
 import { usePostStore } from '@/stores/post'
@@ -18,7 +23,9 @@ const props = defineProps<{
   open: boolean
 }>()
 
-const emit = defineEmits([`update:open`])
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
 
 interface PasswordOption {
   value: SharePasswordMode
@@ -54,21 +61,22 @@ const uiStore = useUIStore()
 const confirmStore = useConfirmStore()
 
 const { isLoggedIn, user } = storeToRefs(authStore)
+const { shareDialogInitialTab } = storeToRefs(uiStore)
 
 const activeTab = ref<`create` | `manage`>(`create`)
 const shareList = ref<ShareListItem[]>([])
 const isLoadingList = ref(false)
 const revokingId = ref<string | null>(null)
 
-const isProUser = computed(() => {
-  if (!user.value || user.value.plan !== `pro`)
-    return false
-  return user.value.planExpiresAt != null && user.value.planExpiresAt > Date.now()
-})
+const isProUser = computed(() => isShareProUser(user.value))
 
-const dialogVisible = computed({
+const dialogOpen = computed({
   get: () => props.open,
-  set: value => emit(`update:open`, value),
+  set: (value) => {
+    if (!value)
+      shareDialogInitialTab.value = `create`
+    emit(`update:open`, value)
+  },
 })
 
 const shareClient = new ShareClient(() => authStore.token)
@@ -109,7 +117,9 @@ function resetForm() {
 }
 
 function resetDialog() {
-  activeTab.value = `create`
+  activeTab.value = shareDialogInitialTab.value === `manage` && isProUser.value
+    ? `manage`
+    : `create`
   resetForm()
 }
 
@@ -173,7 +183,7 @@ function confirmRevokeShare(share: ShareListItem) {
 }
 
 function openAccountDialog() {
-  dialogVisible.value = false
+  dialogOpen.value = false
   uiStore.toggleShowAccountDialog(true)
 }
 
@@ -307,251 +317,261 @@ watch(isProUser, (pro) => {
 </script>
 
 <template>
-  <Dialog v-model:open="dialogVisible">
-    <DialogContent class="gap-0 p-0 sm:max-w-md">
-      <DialogHeader class="space-y-1.5 border-b px-6 py-4">
-        <DialogTitle class="flex items-center gap-2">
-          <Share2 class="size-5" />
-          分享预览
-        </DialogTitle>
-        <DialogDescription>
-          生成与编辑器预览一致的只读链接，便于转发给他人查看。
-        </DialogDescription>
-      </DialogHeader>
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="分享预览"
+    description="生成与编辑器预览一致的只读链接，便于转发给他人查看。"
+    :icon="Share2"
+  >
+    <CloudPanelState
+      v-if="!isShareConfigured()"
+      :icon="Share2"
+      title="分享服务未配置"
+      description="当前部署未配置分享服务，请联系部署方启用后再试。"
+      compact
+    />
 
-      <div v-if="!isShareConfigured()" class="px-6 py-8 text-center text-sm text-muted-foreground">
-        分享服务未配置，请联系部署方启用。
-      </div>
+    <CloudPanelState
+      v-else-if="!isLoggedIn"
+      :icon="Share2"
+      title="登录后分享预览"
+      description="登录账户后，可将当前文章生成与编辑器预览一致的只读链接。"
+      action-label="前往登录"
+      :action-icon="LogIn"
+      @action="openAccountDialog"
+    />
 
-      <div v-else-if="!isLoggedIn" class="flex flex-col items-center gap-4 px-6 py-8">
-        <p class="text-sm text-muted-foreground">
-          请先登录账户后再分享
-        </p>
-        <Button class="gap-2" @click="openAccountDialog">
-          <LogIn class="size-4" />
-          前往登录
-        </Button>
-      </div>
+    <Tabs v-else v-model="activeTab" class="gap-0">
+      <TabsList v-if="isProUser" class="mx-4 mt-4 grid w-auto grid-cols-2 sm:mx-6">
+        <TabsTrigger value="create">
+          生成分享
+        </TabsTrigger>
+        <TabsTrigger value="manage">
+          我的分享
+        </TabsTrigger>
+      </TabsList>
 
-      <Tabs v-else v-model="activeTab" class="gap-0">
-        <TabsList v-if="isProUser" class="mx-6 mt-4 grid w-auto grid-cols-2">
-          <TabsTrigger value="create">
-            生成分享
-          </TabsTrigger>
-          <TabsTrigger value="manage">
-            我的分享
-          </TabsTrigger>
-        </TabsList>
+      <TabsContent value="create" class="mt-0">
+        <template v-if="!shareUrl">
+          <div class="space-y-4 px-4 py-4 sm:px-6">
+            <div class="flex flex-wrap gap-2">
+              <span class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground">
+                <Clock class="size-3.5" />
+                1 天后过期
+              </span>
+              <span
+                v-if="!isProUser"
+                class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground"
+              >
+                2 次/天
+              </span>
+            </div>
 
-        <TabsContent value="create" class="mt-0">
-          <template v-if="!shareUrl">
-            <div class="space-y-4 px-6 py-4">
-              <div class="flex flex-wrap gap-2">
-                <span class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground">
-                  <Clock class="size-3.5" />
-                  1 天后过期
-                </span>
-                <span
-                  v-if="!isProUser"
-                  class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground"
+            <div class="space-y-2">
+              <Label class="text-sm">访问密码</Label>
+              <div class="grid gap-2">
+                <button
+                  v-for="option in passwordOptions"
+                  :key="option.value"
+                  type="button"
+                  class="flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors"
+                  :class="passwordMode === option.value
+                    ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
+                    : 'hover:bg-muted/50'"
+                  @click="passwordMode = option.value"
                 >
-                  2 次/天
-                </span>
+                  <component :is="option.icon" class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <span class="min-w-0 flex-1">
+                    <span class="block text-sm font-medium">{{ option.label }}</span>
+                    <span class="block text-xs text-muted-foreground">{{ option.description }}</span>
+                  </span>
+                  <span
+                    class="mt-1 size-2 shrink-0 rounded-full"
+                    :class="passwordMode === option.value ? 'bg-primary' : 'bg-muted-foreground/30'"
+                  />
+                </button>
               </div>
+            </div>
 
-              <div class="space-y-2">
-                <Label class="text-sm">访问密码</Label>
-                <div class="grid gap-2">
-                  <button
-                    v-for="option in passwordOptions"
-                    :key="option.value"
-                    type="button"
-                    class="flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors"
-                    :class="passwordMode === option.value
-                      ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
-                      : 'hover:bg-muted/50'"
-                    @click="passwordMode = option.value"
-                  >
-                    <component :is="option.icon" class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                    <span class="min-w-0 flex-1">
-                      <span class="block text-sm font-medium">{{ option.label }}</span>
-                      <span class="block text-xs text-muted-foreground">{{ option.description }}</span>
-                    </span>
-                    <span
-                      class="mt-1 size-2 shrink-0 rounded-full"
-                      :class="passwordMode === option.value ? 'bg-primary' : 'bg-muted-foreground/30'"
-                    />
-                  </button>
-                </div>
-              </div>
+            <div v-if="passwordMode === 'custom'" class="space-y-2 pl-1">
+              <Label for="share-custom-password" class="text-xs text-muted-foreground">
+                输入访问密码
+              </Label>
+              <Input
+                id="share-custom-password"
+                v-model="customPassword"
+                type="password"
+                autocomplete="new-password"
+                placeholder="4–64 个字符"
+              />
+            </div>
 
-              <div v-if="passwordMode === 'custom'" class="space-y-2 pl-1">
-                <Label for="share-custom-password" class="text-xs text-muted-foreground">
-                  输入访问密码
-                </Label>
+            <Alert v-if="errorMessage" variant="destructive" class="py-2.5">
+              <AlertDescription class="text-xs">
+                {{ errorMessage }}
+              </AlertDescription>
+            </Alert>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="space-y-4 px-4 py-4 sm:px-6">
+            <CloudPanelCard variant="success">
+              <p class="text-xs text-green-900 dark:text-green-100">
+                分享链接已就绪，可直接复制或打开预览。
+              </p>
+            </CloudPanelCard>
+
+            <div class="space-y-2">
+              <Label for="share-url" class="text-xs text-muted-foreground">分享链接</Label>
+              <div class="flex gap-2">
                 <Input
-                  id="share-custom-password"
-                  v-model="customPassword"
-                  type="password"
-                  autocomplete="new-password"
-                  placeholder="4–64 个字符"
+                  id="share-url"
+                  :model-value="shareUrl"
+                  readonly
+                  class="font-mono text-xs"
                 />
-              </div>
-
-              <Alert v-if="errorMessage" variant="destructive" class="py-2.5">
-                <AlertDescription class="text-xs">
-                  {{ errorMessage }}
-                </AlertDescription>
-              </Alert>
-            </div>
-
-            <div class="border-t px-6 py-4">
-              <Button class="w-full gap-2" :disabled="isSubmitting || !canSubmit" @click="createShare">
-                <Loader2 v-if="isSubmitting" class="size-4 animate-spin" />
-                <Share2 v-else class="size-4" />
-                {{ isSubmitting ? (submitStage || '正在生成…') : '生成分享链接' }}
-              </Button>
-            </div>
-          </template>
-
-          <template v-else>
-            <div class="space-y-4 px-6 py-4">
-              <Alert class="border-green-200 bg-green-50 py-2.5 text-green-900 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-100">
-                <AlertDescription class="text-xs">
-                  分享链接已就绪，可直接复制或打开预览。
-                </AlertDescription>
-              </Alert>
-
-              <div class="space-y-2">
-                <Label for="share-url" class="text-xs text-muted-foreground">分享链接</Label>
-                <div class="flex gap-2">
-                  <Input
-                    id="share-url"
-                    :model-value="shareUrl"
-                    readonly
-                    class="font-mono text-xs"
-                  />
-                  <Button variant="outline" size="icon" @click="copyText(shareUrl, 'link')">
-                    <Check v-if="copiedLink" class="size-4 text-green-600" />
-                    <Copy v-else class="size-4" />
-                  </Button>
-                  <Button variant="outline" size="icon" @click="openSharePage">
-                    <ExternalLink class="size-4" />
-                  </Button>
-                </div>
-              </div>
-
-              <div v-if="isProtected && sharePassword" class="space-y-2">
-                <Label for="share-password" class="text-xs text-muted-foreground">访问密码</Label>
-                <div class="flex gap-2">
-                  <Input
-                    id="share-password"
-                    :model-value="sharePassword"
-                    readonly
-                    class="font-mono text-xs"
-                  />
-                  <Button variant="outline" size="icon" @click="copyText(sharePassword, 'password')">
-                    <Check v-if="copiedPassword" class="size-4 text-green-600" />
-                    <Copy v-else class="size-4" />
-                  </Button>
-                </div>
-                <Button variant="outline" class="w-full" @click="copyShareBundle">
-                  复制链接与密码
+                <Button variant="outline" size="icon" @click="copyText(shareUrl, 'link')">
+                  <Check v-if="copiedLink" class="size-4 text-green-600" />
+                  <Copy v-else class="size-4" />
+                </Button>
+                <Button variant="outline" size="icon" @click="openSharePage">
+                  <ExternalLink class="size-4" />
                 </Button>
               </div>
+            </div>
 
-              <p v-else-if="isProtected && passwordMode === 'custom'" class="text-xs text-muted-foreground">
-                已启用密码保护，请妥善保管你设置的密码。
-              </p>
-
-              <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                <span v-if="expiresLabel">过期：{{ expiresLabel }}</span>
-                <span>预览与编辑器一致</span>
+            <div v-if="isProtected && sharePassword" class="space-y-2">
+              <Label for="share-password" class="text-xs text-muted-foreground">访问密码</Label>
+              <div class="flex gap-2">
+                <Input
+                  id="share-password"
+                  :model-value="sharePassword"
+                  readonly
+                  class="font-mono text-xs"
+                />
+                <Button variant="outline" size="icon" @click="copyText(sharePassword, 'password')">
+                  <Check v-if="copiedPassword" class="size-4 text-green-600" />
+                  <Copy v-else class="size-4" />
+                </Button>
               </div>
-            </div>
-
-            <div class="border-t px-6 py-4">
-              <Button variant="outline" class="w-full" @click="resetForm">
-                重新设置并生成
-              </Button>
-            </div>
-          </template>
-        </TabsContent>
-
-        <TabsContent v-if="isProUser" value="manage" class="mt-0">
-          <div class="space-y-3 px-6 py-4">
-            <div class="flex items-center justify-between gap-2">
-              <p class="text-xs text-muted-foreground">
-                管理已发布的分享链接，取消后链接立即失效。
-              </p>
-              <Button
-                variant="ghost"
-                size="icon"
-                class="shrink-0"
-                title="刷新列表"
-                :disabled="isLoadingList"
-                @click="loadShareList"
-              >
-                <Loader2 v-if="isLoadingList" class="size-4 animate-spin" />
-                <RefreshCw v-else class="size-4" />
+              <Button variant="outline" class="w-full" @click="copyShareBundle">
+                复制链接与密码
               </Button>
             </div>
 
-            <div v-if="isLoadingList && shareList.length === 0" class="flex items-center justify-center py-10 text-sm text-muted-foreground">
-              <Loader2 class="mr-2 size-4 animate-spin" />
-              加载中…
-            </div>
+            <p v-else-if="isProtected && passwordMode === 'custom'" class="text-xs text-muted-foreground">
+              已启用密码保护，请妥善保管你设置的密码。
+            </p>
 
-            <div v-else-if="shareList.length === 0" class="rounded-lg border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-              暂无分享记录
+            <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <span v-if="expiresLabel">过期：{{ expiresLabel }}</span>
+              <span>预览与编辑器一致</span>
             </div>
+          </div>
+        </template>
+      </TabsContent>
 
-            <div v-else class="max-h-80 space-y-2 overflow-y-auto pr-1">
-              <div
-                v-for="share in shareList"
-                :key="share.id"
-                class="rounded-lg border p-3"
-                :class="share.expired ? 'opacity-70' : ''"
-              >
-                <div class="flex items-start justify-between gap-2">
-                  <div class="min-w-0 flex-1">
-                    <p class="truncate text-sm font-medium">
-                      {{ formatShareTitle(share.title) }}
-                    </p>
-                    <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                      <span class="inline-flex items-center gap-1">
-                        <Eye class="size-3" />
-                        {{ share.viewCount }} 次阅读
-                      </span>
-                      <span>{{ formatShareExpiry(share.expiresAt, share.expired) }}</span>
-                      <span v-if="share.protected">已设密码</span>
-                    </div>
+      <TabsContent v-if="isProUser" value="manage" class="mt-0">
+        <div class="space-y-3 px-4 py-4 sm:px-6">
+          <div class="flex items-center justify-between gap-2">
+            <p class="text-xs text-muted-foreground">
+              管理已发布的分享链接，取消后链接立即失效。
+            </p>
+            <Button
+              variant="ghost"
+              size="icon"
+              class="shrink-0"
+              title="刷新列表"
+              :disabled="isLoadingList"
+              @click="loadShareList"
+            >
+              <Loader2 v-if="isLoadingList" class="size-4 animate-spin" />
+              <RefreshCw v-else class="size-4" />
+            </Button>
+          </div>
+
+          <div v-if="isLoadingList && shareList.length === 0" class="flex items-center justify-center py-10 text-sm text-muted-foreground">
+            <Loader2 class="mr-2 size-4 animate-spin" />
+            加载中…
+          </div>
+
+          <CloudPanelState
+            v-else-if="shareList.length === 0"
+            :icon="Inbox"
+            title="暂无分享记录"
+            description="生成分享后，可在此统一管理链接。"
+            compact
+          />
+
+          <div v-else class="max-h-80 space-y-2 overflow-y-auto pr-1">
+            <div
+              v-for="share in shareList"
+              :key="share.id"
+              class="rounded-lg border p-3"
+              :class="share.expired ? 'opacity-70' : ''"
+            >
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0 flex-1">
+                  <p class="truncate text-sm font-medium">
+                    {{ formatShareTitle(share.title) }}
+                  </p>
+                  <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <span class="inline-flex items-center gap-1">
+                      <Eye class="size-3" />
+                      {{ share.viewCount }} 次阅读
+                    </span>
+                    <span>{{ formatShareExpiry(share.expiresAt, share.expired) }}</span>
+                    <span v-if="share.protected">已设密码</span>
                   </div>
-                  <div class="flex shrink-0 items-center gap-1">
-                    <Button variant="ghost" size="icon" title="复制链接" @click="copyText(share.url, 'link')">
-                      <Copy class="size-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon" title="打开预览" @click="openShareUrl(share.url)">
-                      <ExternalLink class="size-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      class="text-destructive hover:text-destructive"
-                      title="取消分享"
-                      :disabled="revokingId === share.id"
-                      @click="confirmRevokeShare(share)"
-                    >
-                      <Loader2 v-if="revokingId === share.id" class="size-4 animate-spin" />
-                      <Trash2 v-else class="size-4" />
-                    </Button>
-                  </div>
+                </div>
+                <div class="flex shrink-0 items-center gap-1">
+                  <Button variant="ghost" size="icon" title="复制链接" @click="copyText(share.url, 'link')">
+                    <Copy class="size-4" />
+                  </Button>
+                  <Button variant="ghost" size="icon" title="打开预览" @click="openShareUrl(share.url)">
+                    <ExternalLink class="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="text-destructive hover:text-destructive"
+                    title="取消分享"
+                    :disabled="revokingId === share.id"
+                    @click="confirmRevokeShare(share)"
+                  >
+                    <Loader2 v-if="revokingId === share.id" class="size-4 animate-spin" />
+                    <Trash2 v-else class="size-4" />
+                  </Button>
                 </div>
               </div>
             </div>
           </div>
-        </TabsContent>
-      </Tabs>
-    </DialogContent>
-  </Dialog>
+        </div>
+      </TabsContent>
+    </Tabs>
+
+    <template v-if="isShareConfigured() && isLoggedIn && activeTab === 'create'" #footer>
+      <div class="border-t px-4 py-4 sm:px-6">
+        <Button
+          v-if="!shareUrl"
+          class="h-10 w-full gap-2"
+          :disabled="isSubmitting || !canSubmit"
+          @click="createShare"
+        >
+          <Loader2 v-if="isSubmitting" class="size-4 animate-spin" />
+          <Share2 v-else class="size-4" />
+          {{ isSubmitting ? (submitStage || '正在生成…') : '生成分享链接' }}
+        </Button>
+        <Button
+          v-else
+          variant="outline"
+          class="h-10 w-full"
+          @click="resetForm"
+        >
+          重新设置并生成
+        </Button>
+      </div>
+    </template>
+  </CloudPanelDialog>
 </template>

--- a/apps/web/src/components/editor/editor-header/SyncDialog.vue
+++ b/apps/web/src/components/editor/editor-header/SyncDialog.vue
@@ -1,24 +1,25 @@
 <script setup lang="ts">
-import { AlertCircle, Cloud, CloudCheck, CloudOff, Info, Loader2, LogIn, RefreshCw } from '@lucide/vue'
+import { AlertCircle, Cloud, CloudOff, Info, Loader2, LogIn, RefreshCw } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
+import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
 import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
 import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
+import { useSyncStatusMeta } from '@/composables/useSyncStatusMeta'
 import { isSyncConfigured } from '@/services/sync/client'
 import { useAuthStore } from '@/stores/auth'
 import { useSyncStore } from '@/stores/sync'
 import { useUIStore } from '@/stores/ui'
 
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
-})
+const props = defineProps<{
+  open: boolean
+}>()
 
-const emit = defineEmits([`close`])
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
 
 const authStore = useAuthStore()
 const syncStore = useSyncStore()
@@ -26,13 +27,11 @@ const uiStore = useUIStore()
 
 const { isLoggedIn } = storeToRefs(authStore)
 const { status, lastError, lastSyncAt, needsRefresh, isSyncing, syncState } = storeToRefs(syncStore)
+const { syncStatusMeta } = useSyncStatusMeta({ errorHint: `generic` })
 
 const dialogOpen = computed({
-  get: () => props.visible,
-  set: (val: boolean) => {
-    if (!val)
-      emit(`close`)
-  },
+  get: () => props.open,
+  set: (val: boolean) => emit(`update:open`, val),
 })
 
 const lastSyncText = computed(() => {
@@ -46,45 +45,8 @@ const lastSyncText = computed(() => {
   })
 })
 
-const syncStatusMeta = computed(() => {
-  switch (syncState.value) {
-    case `syncing`:
-      return {
-        label: `同步中`,
-        hint: `正在与云端交换数据…`,
-        dotClass: `bg-primary animate-pulse`,
-        icon: Loader2,
-        iconClass: `text-primary animate-spin`,
-      }
-    case `synced`:
-      return {
-        label: `已同步`,
-        hint: `本地内容与云端一致`,
-        dotClass: `bg-green-500`,
-        icon: CloudCheck,
-        iconClass: `text-green-600 dark:text-green-400`,
-      }
-    case `error`:
-      return {
-        label: `同步失败`,
-        hint: lastError.value || `请稍后重试`,
-        dotClass: `bg-destructive`,
-        icon: AlertCircle,
-        iconClass: `text-destructive`,
-      }
-    default:
-      return {
-        label: `待同步`,
-        hint: `本地有未上传的更改`,
-        dotClass: `bg-amber-500`,
-        icon: CloudOff,
-        iconClass: `text-amber-600 dark:text-amber-400`,
-      }
-  }
-})
-
 function openAccountDialog() {
-  emit(`close`)
+  dialogOpen.value = false
   uiStore.toggleShowAccountDialog(true)
 }
 
@@ -127,17 +89,20 @@ function handleReload() {
     />
 
     <div v-else class="space-y-4 px-4 py-4 sm:px-6">
-      <div class="flex items-start gap-3 rounded-xl border bg-muted/20 p-3.5 sm:p-4">
-        <div
-          class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-border/60"
-        >
-          <component
-            :is="syncStatusMeta.icon"
-            class="size-4"
-            :class="syncStatusMeta.iconClass"
-          />
-        </div>
-        <div class="min-w-0 flex-1 space-y-1">
+      <CloudPanelCard>
+        <template #leading>
+          <div
+            class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-border/60"
+          >
+            <component
+              :is="syncStatusMeta.icon"
+              class="size-4"
+              :class="syncStatusMeta.iconClass"
+            />
+          </div>
+        </template>
+
+        <div class="space-y-1">
           <div class="flex flex-wrap items-center gap-2">
             <span class="inline-flex items-center gap-1.5 text-sm font-medium">
               <span class="size-2 rounded-full" :class="syncStatusMeta.dotClass" />
@@ -148,7 +113,7 @@ function handleReload() {
             {{ syncStatusMeta.hint }}
           </p>
         </div>
-      </div>
+      </CloudPanelCard>
 
       <div class="grid gap-2 rounded-xl border px-3.5 py-3 text-xs sm:px-4">
         <div class="flex items-center justify-between gap-3">

--- a/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelCard.vue
+++ b/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelCard.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  align?: `center` | `start`
+  variant?: `default` | `dashed` | `success`
+  class?: string
+}>()
+</script>
+
+<template>
+  <div
+    :class="cn(
+      'rounded-xl border p-3.5 sm:p-4',
+      align === 'center' ? 'flex items-center gap-3' : 'flex items-start gap-3',
+      variant === 'dashed' && 'border-dashed bg-transparent',
+      variant === 'success' && 'border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/30',
+      (!variant || variant === 'default') && 'bg-muted/20',
+      props.class,
+    )"
+  >
+    <slot name="leading" />
+    <div class="min-w-0 flex-1">
+      <slot />
+    </div>
+    <slot name="trailing" />
+  </div>
+</template>

--- a/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue
+++ b/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
+import { computed } from 'vue'
 import {
   Dialog,
   DialogContent,
@@ -9,26 +10,37 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   open: boolean
   title: string
   description?: string
   icon?: Component
-}>()
+  size?: keyof typeof sizeClassMap
+}>(), {
+  size: `md`,
+})
 
 const emit = defineEmits<{
   'update:open': [value: boolean]
 }>()
 
-const dialogContentClass = cn(
+const sizeClassMap = {
+  'md': `sm:max-w-md`,
+  'lg': `sm:max-w-lg`,
+  'xl': `sm:max-w-xl`,
+  '2xl': `sm:max-w-2xl`,
+  '3xl': `sm:max-w-3xl`,
+} as const
+
+const dialogContentClass = computed(() => cn(
   `flex max-h-[min(90vh,100dvh)] flex-col gap-0 overflow-hidden p-0`,
   `max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:top-auto max-sm:w-full max-sm:max-w-none`,
   `max-sm:max-h-[min(88dvh,100dvh)] max-sm:translate-x-0 max-sm:translate-y-0 max-sm:rounded-t-2xl max-sm:rounded-b-none`,
   `max-sm:border-x-0 max-sm:border-b-0 max-sm:shadow-2xl`,
   `max-sm:pb-[max(1rem,env(safe-area-inset-bottom,0px))]`,
   `max-sm:data-[state=open]:slide-in-from-bottom-4 max-sm:data-[state=closed]:slide-out-to-bottom-4`,
-  `sm:max-w-md`,
-)
+  sizeClassMap[props.size],
+))
 
 function onUpdate(val: boolean) {
   emit(`update:open`, val)

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -29,7 +29,7 @@ const exportStore = useExportStore()
 const { editor } = storeToRefs(editorStore)
 const { output } = storeToRefs(renderStore)
 const { primaryColor } = storeToRefs(themeStore)
-const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog } = storeToRefs(uiStore)
+const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog } = storeToRefs(uiStore)
 
 // Editor refresh function
 function editorRefresh() {
@@ -39,31 +39,8 @@ function editorRefresh() {
   renderStore.render(raw)
 }
 
-// 对话框状态
-const aboutDialogVisible = ref(false)
-const fundDialogVisible = ref(false)
-const editorStateDialogVisible = ref(false)
-const markdownHelpDialogVisible = ref(false)
-
-function handleOpenAbout() {
-  aboutDialogVisible.value = true
-}
-
-function handleOpenFund() {
-  fundDialogVisible.value = true
-}
-
-function handleOpenEditorState() {
-  editorStateDialogVisible.value = true
-}
-
-function handleOpenMarkdownHelp() {
-  markdownHelpDialogVisible.value = true
-}
-
 const copyMode = store.reactive(addPrefix(`copyMode`), `txt`)
 const isCopying = ref(false)
-const shareDialogVisible = ref(false)
 
 const { copy: copyContent } = useClipboard({
   legacy: true,
@@ -253,12 +230,12 @@ function copyToWeChat() {
     <!-- 桌面端左侧菜单 -->
     <div class="space-x-1 hidden md:flex">
       <Menubar class="menubar border-0">
-        <FileDropdown @open-editor-state="handleOpenEditorState" @open-share="shareDialogVisible = true" />
+        <FileDropdown />
         <EditDropdown @copy="handleCopy" />
         <FormatDropdown />
         <InsertDropdown />
         <StyleDropdown />
-        <HelpDropdown @open-about="handleOpenAbout" @open-fund="handleOpenFund" @open-markdown-help="handleOpenMarkdownHelp" />
+        <HelpDropdown />
       </Menubar>
     </div>
 
@@ -272,12 +249,12 @@ function copyToWeChat() {
             </Button>
           </MenubarTrigger>
           <MenubarContent align="start">
-            <FileDropdown :as-sub="true" @open-editor-state="handleOpenEditorState" @open-share="shareDialogVisible = true" />
+            <FileDropdown :as-sub="true" />
             <EditDropdown :as-sub="true" @copy="handleCopy" />
             <FormatDropdown :as-sub="true" />
             <InsertDropdown :as-sub="true" />
             <StyleDropdown :as-sub="true" />
-            <HelpDropdown :as-sub="true" @open-about="handleOpenAbout" @open-fund="handleOpenFund" @open-markdown-help="handleOpenMarkdownHelp" />
+            <HelpDropdown :as-sub="true" />
           </MenubarContent>
         </MenubarMenu>
       </Menubar>
@@ -314,13 +291,13 @@ function copyToWeChat() {
   </header>
 
   <!-- 对话框组件，嵌套菜单无法正常挂载，需要提取层级 -->
-  <AboutDialog :visible="aboutDialogVisible" @close="aboutDialogVisible = false" />
-  <FundDialog :visible="fundDialogVisible" @close="fundDialogVisible = false" />
-  <EditorStateDialog :visible="editorStateDialogVisible" @close="editorStateDialogVisible = false" />
-  <MarkdownHelpDialog :visible="markdownHelpDialogVisible" @close="markdownHelpDialogVisible = false" />
-  <AccountDialog :visible="isShowAccountDialog" @close="isShowAccountDialog = false" />
-  <SyncDialog :visible="isShowSyncDialog" @close="isShowSyncDialog = false" />
-  <ShareDialog v-model:open="shareDialogVisible" />
+  <AboutDialog v-model:open="isShowAboutDialog" />
+  <FundDialog v-model:open="isShowFundDialog" />
+  <EditorStateDialog v-model:open="isShowEditorStateDialog" />
+  <MarkdownHelpDialog v-model:open="isShowMarkdownHelpDialog" />
+  <AccountDialog v-model:open="isShowAccountDialog" />
+  <SyncDialog v-model:open="isShowSyncDialog" />
+  <ShareDialog v-model:open="isShowShareDialog" />
 </template>
 
 <style lang="less" scoped>

--- a/apps/web/src/composables/useSlashCommand.ts
+++ b/apps/web/src/composables/useSlashCommand.ts
@@ -4,8 +4,6 @@ import { Prec } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { buildSlashCommands } from '@/composables/slashCommands'
 
-export type { SlashCommandGroup, SlashCommandItem } from '@/composables/slashCommands'
-
 export function useSlashCommand() {
   const visible = ref(false)
   const position = ref({ x: 0, y: 0, top: 0 })

--- a/apps/web/src/composables/useSyncStatusMeta.ts
+++ b/apps/web/src/composables/useSyncStatusMeta.ts
@@ -1,0 +1,94 @@
+import type { Component } from 'vue'
+import { AlertCircle, CloudCheck, CloudOff, Loader2 } from '@lucide/vue'
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useSyncStore } from '@/stores/sync'
+
+export type SyncUiState = `syncing` | `synced` | `error` | `pending`
+
+export interface SyncStatusMeta {
+  label: string
+  hint: string
+  dotClass: string
+  icon: Component
+  iconClass: string
+  footerIconClass: string
+}
+
+function buildSyncStatusMeta(
+  state: SyncUiState,
+  lastError: string | null,
+  errorHint: `detail` | `generic`,
+): SyncStatusMeta {
+  switch (state) {
+    case `syncing`:
+      return {
+        label: `同步中`,
+        hint: `正在与云端交换数据…`,
+        dotClass: `bg-primary animate-pulse`,
+        icon: Loader2,
+        iconClass: `text-primary animate-spin`,
+        footerIconClass: `text-primary animate-spin`,
+      }
+    case `synced`:
+      return {
+        label: `已同步`,
+        hint: `本地内容与云端一致`,
+        dotClass: `bg-green-500`,
+        icon: CloudCheck,
+        iconClass: `text-green-600 dark:text-green-400`,
+        footerIconClass: `text-green-500`,
+      }
+    case `error`:
+      return {
+        label: `同步失败`,
+        hint: errorHint === `generic`
+          ? `同步失败，请查看下方详情`
+          : (lastError || `请稍后重试`),
+        dotClass: `bg-destructive`,
+        icon: AlertCircle,
+        iconClass: `text-destructive`,
+        footerIconClass: `text-destructive`,
+      }
+    default:
+      return {
+        label: `待同步`,
+        hint: `本地有未上传的更改`,
+        dotClass: `bg-amber-500`,
+        icon: CloudOff,
+        iconClass: `text-amber-600 dark:text-amber-400`,
+        footerIconClass: `text-amber-500`,
+      }
+  }
+}
+
+export function useSyncStatusMeta(options?: { errorHint?: `detail` | `generic` }) {
+  const syncStore = useSyncStore()
+  const { syncState, lastError, isSyncing } = storeToRefs(syncStore)
+  const errorHint = options?.errorHint ?? `detail`
+
+  const syncStatusMeta = computed(() =>
+    buildSyncStatusMeta(syncState.value, lastError.value, errorHint),
+  )
+
+  const syncTooltip = computed(() => {
+    switch (syncState.value) {
+      case `syncing`:
+        return `同步中…`
+      case `synced`:
+        return `已同步`
+      case `error`:
+        return `同步失败，点击重试`
+      default:
+        return `有未同步的更改`
+    }
+  })
+
+  return {
+    syncState,
+    lastError,
+    isSyncing,
+    syncStatusMeta,
+    syncTooltip,
+  }
+}

--- a/apps/web/src/services/share/client.ts
+++ b/apps/web/src/services/share/client.ts
@@ -1,9 +1,17 @@
 import type { CreateShareRequest, CreateShareResponse, ListSharesResponse } from './types'
+import type { AccountUser } from '@/services/account/types'
 import { ApiError, MdApiClient } from '@/services/account/client'
 import { isAccountConfigured, MD_API_URL } from '@/services/account/config'
 
 export function isShareConfigured(): boolean {
   return isAccountConfigured()
+}
+
+/** 是否为有效 Pro 用户（分享「我的分享」等 Pro 能力） */
+export function isShareProUser(user: Pick<AccountUser, `plan` | `planExpiresAt`> | null | undefined): boolean {
+  if (!user || user.plan !== `pro`)
+    return false
+  return user.planExpiresAt != null && user.planExpiresAt > Date.now()
 }
 
 /** 是否在 UI 中展示分享入口 */

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -132,6 +132,28 @@ export const useUIStore = defineStore(`ui`, () => {
   const isShowAccountDialog = ref(false)
   const toggleShowAccountDialog = useToggle(isShowAccountDialog)
 
+  // 是否展示分享对话框
+  const isShowShareDialog = ref(false)
+  const shareDialogInitialTab = ref<`create` | `manage`>(`create`)
+
+  function openShareDialog(options?: { tab?: `create` | `manage` }) {
+    shareDialogInitialTab.value = options?.tab ?? `create`
+    isShowShareDialog.value = true
+  }
+
+  // 是否展示关于 / 赞赏 / 语法帮助 / 配置导入导出对话框
+  const isShowAboutDialog = ref(false)
+  const toggleShowAboutDialog = useToggle(isShowAboutDialog)
+
+  const isShowFundDialog = ref(false)
+  const toggleShowFundDialog = useToggle(isShowFundDialog)
+
+  const isShowMarkdownHelpDialog = ref(false)
+  const toggleShowMarkdownHelpDialog = useToggle(isShowMarkdownHelpDialog)
+
+  const isShowEditorStateDialog = ref(false)
+  const toggleShowEditorStateDialog = useToggle(isShowEditorStateDialog)
+
   // 组件对话框 — 打开时预展开的组件名（如 'MpProfile'）
   const componentDialogTarget = ref<string | null>(null)
 
@@ -234,6 +256,17 @@ export const useUIStore = defineStore(`ui`, () => {
     toggleShowSyncDialog,
     isShowAccountDialog,
     toggleShowAccountDialog,
+    isShowShareDialog,
+    shareDialogInitialTab,
+    openShareDialog,
+    isShowAboutDialog,
+    toggleShowAboutDialog,
+    isShowFundDialog,
+    toggleShowFundDialog,
+    isShowMarkdownHelpDialog,
+    toggleShowMarkdownHelpDialog,
+    isShowEditorStateDialog,
+    toggleShowEditorStateDialog,
     componentDialogTarget,
     openComponentDialogWithTarget,
     aiDialogVisible,


### PR DESCRIPTION
## Summary

- Introduce shared cloud UI primitives (`CloudPanelCard`, `useSyncStatusMeta`) and extend `CloudPanelDialog` with size variants and mobile bottom sheet behavior.
- Migrate account, sync, share, about, fund, and markdown help dialogs to the unified shell; centralize dialog open state in `uiStore` with `v-model:open`.
- Improve logged-in account UX with quick actions (sync / share / my shares), footer share entry, four-state sync icons, and hide login-oriented header copy when already signed in.
- Extract `isShareProUser()` for consistent Pro gating; fix slash command type duplicate auto-import warning.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactor
- [x] Cosmetic / UI
- [ ] Documentation
- [ ] Workflow

## Test Procedure

- [ ] Open account / sync / share dialogs from footer on desktop and mobile; confirm bottom sheet layout on small screens.
- [ ] Log in and verify account header no longer shows login prompt; quick actions open the correct dialogs.
- [ ] Verify sync footer icon reflects pending / synced / error / syncing states.
- [ ] Open share dialog from file menu and account shortcuts; Pro users can open "My shares" tab from account page.
- [ ] Run `pnpm web type-check` and `pnpm web build:only` (no duplicated SlashCommand auto-import warnings).

## Pre-flight Checklist

- [x] Follows Conventional Commits for commit message
- [x] ESLint pre-commit hook passed
- [x] Type-check passes locally (`pnpm web type-check`)
- [ ] Manually tested in browser
