### PR TITLE
feat(web): polish cloud panel footer and style UI

### DIFF
--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { StateEffect } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { ArrowUpDown, BookOpen, ChevronRight, ChevronsUpDown, Clock, Cloud, CloudAlert, CloudCheck, CloudOff, Columns2, Eye, FileText, Keyboard, ListTree, Loader2, LogIn, Monitor, Moon, PenLine, Pilcrow, Search, Share2, Smartphone, Sun, Type, User } from '@lucide/vue'
+import { ArrowUpDown, BookOpen, ChevronRight, ChevronsUpDown, Clock, Columns2, Ellipsis, Eye, FileText, Keyboard, ListTree, LogIn, Monitor, Moon, PenLine, Pilcrow, Search, Share2, Smartphone, Sun, Type, User } from '@lucide/vue'
 import {
   Popover,
   PopoverContent,
@@ -13,7 +13,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { useSyncStatusMeta } from '@/composables/useSyncStatusMeta'
+import { useSyncFooterMeta } from '@/composables/useSyncStatusMeta'
 import { isAccountUiEnabled } from '@/services/account/config'
 import { isShareUiEnabled } from '@/services/share/client'
 import { isSyncUiEnabled } from '@/services/sync/client'
@@ -21,7 +21,6 @@ import { useAuthStore } from '@/stores/auth'
 import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
-import { useSyncStore } from '@/stores/sync'
 import { useUIStore } from '@/stores/ui'
 
 const renderStore = useRenderStore()
@@ -29,7 +28,6 @@ const editorStore = useEditorStore()
 const postStore = usePostStore()
 const uiStore = useUIStore()
 const authStore = useAuthStore()
-const syncStore = useSyncStore()
 const { readingTime } = storeToRefs(renderStore)
 const { editor } = storeToRefs(editorStore)
 const { currentPost } = storeToRefs(postStore)
@@ -39,8 +37,9 @@ const { isLoggedIn } = storeToRefs(authStore)
 const showAccountUi = isAccountUiEnabled()
 const showSyncUi = isSyncUiEnabled()
 const showShareUi = isShareUiEnabled()
-const { isSyncing, syncState } = storeToRefs(syncStore)
-const { syncStatusMeta, syncTooltip } = useSyncStatusMeta()
+const { syncFooterIcon, syncFooterIconClass, syncTooltip } = useSyncFooterMeta()
+
+const isMoreOpen = ref(false)
 
 const accountTooltip = computed(() => {
   if (!isLoggedIn.value)
@@ -48,26 +47,25 @@ const accountTooltip = computed(() => {
   return `账户 @${authStore.user?.login ?? ''}`
 })
 
-const syncFooterIcon = computed(() => {
-  if (!isLoggedIn.value)
-    return Cloud
-  if (isSyncing.value || syncState.value === `syncing`)
-    return Loader2
-  switch (syncState.value) {
-    case `synced`:
-      return CloudCheck
-    case `error`:
-      return CloudAlert
-    default:
-      return CloudOff
-  }
-})
+function openAccountDialog() {
+  isMoreOpen.value = false
+  uiStore.toggleShowAccountDialog(true)
+}
 
-const syncFooterIconClass = computed(() => {
-  if (!isLoggedIn.value)
-    return ``
-  return syncStatusMeta.value.footerIconClass
-})
+function openSyncDialog() {
+  isMoreOpen.value = false
+  uiStore.toggleShowSyncDialog(true)
+}
+
+function openShareDialog() {
+  isMoreOpen.value = false
+  uiStore.openShareDialog()
+}
+
+function toggleTheme() {
+  isMoreOpen.value = false
+  uiStore.toggleDark()
+}
 
 // 相对时间格式化（复用）
 function formatRelativeTime(date: Date | string) {
@@ -655,8 +653,8 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
         <span class="hidden text-border sm:block">·</span>
 
-        <!-- 账户 & 同步 & 分享 & 主题 -->
-        <div class="flex items-center gap-0.5">
+        <!-- 账户 & 同步 & 分享 & 主题（桌面端） -->
+        <div class="hidden items-center gap-0.5 sm:flex">
           <template v-if="showAccountUi">
             <Tooltip>
               <TooltipTrigger as-child>
@@ -664,7 +662,7 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
                   aria-label="账户"
                   class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
                   :class="isLoggedIn ? 'text-primary' : ''"
-                  @click="uiStore.toggleShowAccountDialog(true)"
+                  @click="openAccountDialog"
                 >
                   <img
                     v-if="isLoggedIn && authStore.user?.avatar"
@@ -688,8 +686,7 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
                 <button
                   aria-label="云同步"
                   class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
-                  :class="isLoggedIn ? 'text-primary' : ''"
-                  @click="uiStore.toggleShowSyncDialog(true)"
+                  @click="openSyncDialog"
                 >
                   <component
                     :is="syncFooterIcon"
@@ -710,7 +707,7 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
                 <button
                   aria-label="分享预览"
                   class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
-                  @click="uiStore.openShareDialog()"
+                  @click="openShareDialog"
                 >
                   <Share2 class="size-4" />
                 </button>
@@ -724,9 +721,10 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
           <Tooltip>
             <TooltipTrigger as-child>
               <button
+                aria-label="切换深色模式"
                 class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
                 :class="isDark ? 'text-foreground' : ''"
-                @click="uiStore.toggleDark()"
+                @click="toggleTheme"
               >
                 <Moon v-if="isDark" class="size-4" />
                 <Sun v-else class="size-4" />
@@ -737,6 +735,63 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
             </TooltipContent>
           </Tooltip>
         </div>
+
+        <!-- 移动端：更多操作 -->
+        <Popover v-model:open="isMoreOpen">
+          <PopoverTriggerPrimitive as-child>
+            <button
+              aria-label="更多操作"
+              class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground sm:hidden"
+            >
+              <Ellipsis class="size-4" />
+            </button>
+          </PopoverTriggerPrimitive>
+          <PopoverContent side="top" :side-offset="8" align="end" class="w-48 p-1">
+            <button
+              v-if="showAccountUi"
+              class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent"
+              @click="openAccountDialog"
+            >
+              <img
+                v-if="isLoggedIn && authStore.user?.avatar"
+                :src="authStore.user.avatar"
+                :alt="authStore.user.login"
+                class="size-4 rounded-full"
+              >
+              <User v-else-if="isLoggedIn" class="size-4 shrink-0" />
+              <LogIn v-else class="size-4 shrink-0" />
+              <span class="min-w-0 flex-1 truncate">{{ accountTooltip }}</span>
+            </button>
+            <button
+              v-if="showSyncUi"
+              class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent"
+              @click="openSyncDialog"
+            >
+              <component
+                :is="syncFooterIcon"
+                class="size-4 shrink-0"
+                :class="syncFooterIconClass"
+              />
+              <span>{{ isLoggedIn ? syncTooltip : '云同步' }}</span>
+            </button>
+            <button
+              v-if="showShareUi"
+              class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent"
+              @click="openShareDialog"
+            >
+              <Share2 class="size-4 shrink-0" />
+              <span>分享预览</span>
+            </button>
+            <button
+              class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent"
+              @click="toggleTheme"
+            >
+              <Moon v-if="isDark" class="size-4 shrink-0" />
+              <Sun v-else class="size-4 shrink-0" />
+              <span>{{ isDark ? '浅色模式' : '深色模式' }}</span>
+            </button>
+          </PopoverContent>
+        </Popover>
       </div>
     </TooltipProvider>
   </footer>

--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -17,6 +17,8 @@ import {
   themeOptions,
 } from '@md/shared/configs'
 import PickColors from 'vue-pick-colors'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCssEditorStore } from '@/stores/cssEditor'
 import { useEditorStore } from '@/stores/editor'
@@ -147,6 +149,31 @@ function useJustifyChanged() {
   editorRefresh()
 }
 
+function setMacCodeBlock(checked: boolean) {
+  if (checked !== isMacCodeBlock.value)
+    macCodeBlockChanged()
+}
+
+function setShowLineNumber(checked: boolean) {
+  if (checked !== isShowLineNumber.value)
+    showLineNumberChanged()
+}
+
+function setCiteStatus(checked: boolean) {
+  if (checked !== isCiteStatus.value)
+    citeStatusChanged()
+}
+
+function setUseIndent(checked: boolean) {
+  if (checked !== isUseIndent.value)
+    useIndentChanged()
+}
+
+function setUseJustify(checked: boolean) {
+  if (checked !== isUseJustify.value)
+    useJustifyChanged()
+}
+
 function resetStyleConfirm() {
   confirmStore.confirm({
     title: '提示',
@@ -179,16 +206,6 @@ watch(isMobile, () => {
   enableAnimation.value = false
 })
 
-const isOpen = ref(false)
-
-const addPostInputVal = ref(``)
-
-watch(isOpen, () => {
-  if (isOpen.value) {
-    addPostInputVal.value = ``
-  }
-})
-
 const pickColorsContainer = useTemplateRef<HTMLElement | undefined>(`pickColorsContainer`)
 const format = ref<Format>(`rgb`)
 const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
@@ -211,7 +228,7 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
     :style="isMobile ? { transform: isOpenRightSlider ? 'translateX(0)' : 'translateX(100%)' } : undefined"
   >
     <div
-      class="space-y-4 h-full overflow-auto p-4"
+      class="h-full space-y-4 overflow-auto p-4"
       :class="{ 'pt-0': isMobile }"
     >
       <!-- 移动端标题栏 -->
@@ -226,8 +243,11 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
           </Button>
         </div>
       </div>
+
       <div class="space-y-2">
-        <h2>主题</h2>
+        <h2 class="text-sm font-medium">
+          主题
+        </h2>
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in themeOptions" :key="value" class="w-full" variant="outline" :class="{
@@ -239,7 +259,9 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         </div>
       </div>
       <div class="space-y-2">
-        <h2>字体</h2>
+        <h2 class="text-sm font-medium">
+          字体
+        </h2>
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in fontFamilyOptions" :key="value" variant="outline" class="w-full"
@@ -250,7 +272,9 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         </div>
       </div>
       <div class="space-y-2">
-        <h2>字号</h2>
+        <h2 class="text-sm font-medium">
+          字号
+        </h2>
         <div class="grid grid-cols-5 justify-items-center gap-2">
           <Button
             v-for="{ value, desc } in fontSizeOptions" :key="value" variant="outline" class="w-full" :class="{
@@ -262,7 +286,9 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         </div>
       </div>
       <div class="space-y-2">
-        <h2>主题色</h2>
+        <h2 class="text-sm font-medium">
+          主题色
+        </h2>
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in colorOptions" :key="value" class="w-full" variant="outline" :class="{
@@ -279,7 +305,9 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         </div>
       </div>
       <div class="space-y-2">
-        <h2>自定义主题色</h2>
+        <h2 class="text-sm font-medium">
+          自定义主题色
+        </h2>
         <div ref="pickColorsContainer">
           <PickColors
             v-if="pickColorsContainer" v-model:value="primaryColor" show-alpha :format="format"
@@ -289,7 +317,9 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         </div>
       </div>
       <div class="space-y-2">
-        <h2>标题样式</h2>
+        <h2 class="text-sm font-medium">
+          标题样式
+        </h2>
         <div class="flex gap-2">
           <Select v-model="selectedHeadingLevel">
             <SelectTrigger class="w-[120px]">
@@ -314,22 +344,24 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         </div>
       </div>
       <div class="space-y-2">
-        <h2>代码块主题</h2>
-        <div>
-          <Select v-model="codeBlockTheme" @update:model-value="codeBlockThemeChanged">
-            <SelectTrigger>
-              <SelectValue placeholder="Select a code block theme" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem v-for="{ label, value } in codeBlockThemeOptions" :key="label" :value="value">
-                {{ label }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        <h2 class="text-sm font-medium">
+          代码块主题
+        </h2>
+        <Select v-model="codeBlockTheme" @update:model-value="codeBlockThemeChanged">
+          <SelectTrigger>
+            <SelectValue placeholder="Select a code block theme" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem v-for="{ label, value } in codeBlockThemeOptions" :key="label" :value="value">
+              {{ label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </div>
       <div class="space-y-2">
-        <h2>图注格式</h2>
+        <h2 class="text-sm font-medium">
+          图注格式
+        </h2>
         <div class="grid grid-cols-3 justify-items-center gap-2">
           <Button
             v-for="{ label, value } in legendOptions" :key="value" class="w-full" variant="outline" :class="{
@@ -340,105 +372,30 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
           </Button>
         </div>
       </div>
-
-      <div class="space-y-2">
-        <h2>Mac 代码块</h2>
-        <div class="grid grid-cols-5 justify-items-center gap-2">
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': isMacCodeBlock,
-            }" @click="!isMacCodeBlock && macCodeBlockChanged()"
-          >
-            开启
-          </Button>
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': !isMacCodeBlock,
-            }" @click="isMacCodeBlock && macCodeBlockChanged()"
-          >
-            关闭
-          </Button>
-        </div>
+      <div class="flex items-center justify-between gap-3">
+        <Label for="mac-code-block" class="text-sm">Mac 代码块</Label>
+        <Switch id="mac-code-block" :model-value="isMacCodeBlock" @update:model-value="setMacCodeBlock" />
+      </div>
+      <div class="flex items-center justify-between gap-3">
+        <Label for="show-line-number" class="text-sm">代码块行号</Label>
+        <Switch id="show-line-number" :model-value="isShowLineNumber" @update:model-value="setShowLineNumber" />
+      </div>
+      <div class="flex items-center justify-between gap-3">
+        <Label for="cite-status" class="text-sm">微信外链转底部引用</Label>
+        <Switch id="cite-status" :model-value="isCiteStatus" @update:model-value="setCiteStatus" />
+      </div>
+      <div class="flex items-center justify-between gap-3">
+        <Label for="use-indent" class="text-sm">段落首行缩进</Label>
+        <Switch id="use-indent" :model-value="isUseIndent" @update:model-value="setUseIndent" />
+      </div>
+      <div class="flex items-center justify-between gap-3">
+        <Label for="use-justify" class="text-sm">段落两端对齐</Label>
+        <Switch id="use-justify" :model-value="isUseJustify" @update:model-value="setUseJustify" />
       </div>
       <div class="space-y-2">
-        <h2>代码块行号</h2>
-        <div class="grid grid-cols-5 justify-items-center gap-2">
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': isShowLineNumber,
-            }" @click="!isShowLineNumber && showLineNumberChanged()"
-          >
-            开启
-          </Button>
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': !isShowLineNumber,
-            }" @click="isShowLineNumber && showLineNumberChanged()"
-          >
-            关闭
-          </Button>
-        </div>
-      </div>
-
-      <div class="space-y-2">
-        <h2>微信外链转底部引用</h2>
-        <div class="grid grid-cols-5 justify-items-center gap-2">
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': isCiteStatus,
-            }" @click="!isCiteStatus && citeStatusChanged()"
-          >
-            开启
-          </Button>
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': !isCiteStatus,
-            }" @click="isCiteStatus && citeStatusChanged()"
-          >
-            关闭
-          </Button>
-        </div>
-      </div>
-      <div class="space-y-2">
-        <h2>段落首行缩进</h2>
-        <div class="grid grid-cols-5 justify-items-center gap-2">
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': isUseIndent,
-            }" @click="!isUseIndent && useIndentChanged()"
-          >
-            开启
-          </Button>
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': !isUseIndent,
-            }" @click="isUseIndent && useIndentChanged()"
-          >
-            关闭
-          </Button>
-        </div>
-      </div>
-      <div class="space-y-2">
-        <h2>段落两端对齐</h2>
-        <div class="grid grid-cols-5 justify-items-center gap-2">
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': isUseJustify,
-            }" @click="!isUseJustify && useJustifyChanged()"
-          >
-            开启
-          </Button>
-          <Button
-            class="w-full" variant="outline" :class="{
-              'border-primary ring-1 ring-primary/20 border-2': !isUseJustify,
-            }" @click="isUseJustify && useJustifyChanged()"
-          >
-            关闭
-          </Button>
-        </div>
-      </div>
-      <div class="space-y-2">
-        <h2>样式配置</h2>
+        <h2 class="text-sm font-medium">
+          样式配置
+        </h2>
         <Button variant="destructive" @click="resetStyleConfirm">
           重置
         </Button>

--- a/apps/web/src/components/editor/editor-header/AccountDialog.vue
+++ b/apps/web/src/components/editor/editor-header/AccountDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Cloud, Crown, List, LogIn, LogOut, Settings2, Share2, User } from '@lucide/vue'
+import { Cloud, Crown, LogIn, LogOut, Settings2, Share2, User } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
@@ -55,9 +55,9 @@ function openSyncDialog() {
   uiStore.toggleShowSyncDialog(true)
 }
 
-function openShareDialog(tab: `create` | `manage` = `create`) {
+function openShareDialog() {
   dialogOpen.value = false
-  uiStore.openShareDialog({ tab })
+  uiStore.openShareDialog()
 }
 </script>
 
@@ -145,25 +145,16 @@ function openShareDialog(tab: `create` | `manage` = `create`) {
           v-if="showShareUi"
           variant="outline"
           class="h-10 justify-start gap-2"
-          @click="openShareDialog('create')"
+          @click="openShareDialog"
         >
           <Share2 class="size-4 shrink-0" />
           分享预览
-        </Button>
-        <Button
-          v-if="showShareUi && isSharePro"
-          variant="outline"
-          class="h-10 justify-start gap-2 sm:col-span-2"
-          @click="openShareDialog('manage')"
-        >
-          <List class="size-4 shrink-0" />
-          我的分享
         </Button>
       </div>
     </div>
 
     <template v-if="isConfigured && isLoggedIn" #footer>
-      <div class="border-t px-4 py-4 sm:px-6">
+      <div class="px-4 py-4 sm:px-6">
         <Button
           variant="outline"
           class="h-10 w-full gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"

--- a/apps/web/src/components/editor/editor-header/ShareDialog.vue
+++ b/apps/web/src/components/editor/editor-header/ShareDialog.vue
@@ -505,27 +505,25 @@ watch(isProUser, (pro) => {
           />
 
           <div v-else class="max-h-80 space-y-2 overflow-y-auto pr-1">
-            <div
+            <CloudPanelCard
               v-for="share in shareList"
               :key="share.id"
-              class="rounded-lg border p-3"
+              align="start"
               :class="share.expired ? 'opacity-70' : ''"
             >
-              <div class="flex items-start justify-between gap-2">
-                <div class="min-w-0 flex-1">
-                  <p class="truncate text-sm font-medium">
-                    {{ formatShareTitle(share.title) }}
-                  </p>
-                  <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                    <span class="inline-flex items-center gap-1">
-                      <Eye class="size-3" />
-                      {{ share.viewCount }} 次阅读
-                    </span>
-                    <span>{{ formatShareExpiry(share.expiresAt, share.expired) }}</span>
-                    <span v-if="share.protected">已设密码</span>
-                  </div>
-                </div>
-                <div class="flex shrink-0 items-center gap-1">
+              <p class="truncate text-sm font-medium">
+                {{ formatShareTitle(share.title) }}
+              </p>
+              <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                <span class="inline-flex items-center gap-1">
+                  <Eye class="size-3" />
+                  {{ share.viewCount }} 次阅读
+                </span>
+                <span>{{ formatShareExpiry(share.expiresAt, share.expired) }}</span>
+                <span v-if="share.protected">已设密码</span>
+              </div>
+              <template #trailing>
+                <div class="flex shrink-0 flex-wrap items-center justify-end gap-0.5">
                   <Button variant="ghost" size="icon" title="复制链接" @click="copyText(share.url, 'link')">
                     <Copy class="size-4" />
                   </Button>
@@ -544,8 +542,8 @@ watch(isProUser, (pro) => {
                     <Trash2 v-else class="size-4" />
                   </Button>
                 </div>
-              </div>
-            </div>
+              </template>
+            </CloudPanelCard>
           </div>
         </div>
       </TabsContent>

--- a/apps/web/src/components/editor/editor-header/SyncDialog.vue
+++ b/apps/web/src/components/editor/editor-header/SyncDialog.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
 import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import CloudPanelInfoRows from '@/components/editor/editor-header/cloud-panel/CloudPanelInfoRows.vue'
 import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -44,6 +45,11 @@ const lastSyncText = computed(() => {
     minute: `2-digit`,
   })
 })
+
+const syncInfoRows = computed(() => [
+  { label: `上次同步`, value: lastSyncText.value, numeric: true },
+  { label: `同步范围`, value: `文章、编辑器设置` },
+])
 
 function openAccountDialog() {
   dialogOpen.value = false
@@ -115,20 +121,11 @@ function handleReload() {
         </div>
       </CloudPanelCard>
 
-      <div class="grid gap-2 rounded-xl border px-3.5 py-3 text-xs sm:px-4">
-        <div class="flex items-center justify-between gap-3">
-          <span class="text-muted-foreground">上次同步</span>
-          <span class="font-medium tabular-nums">{{ lastSyncText }}</span>
-        </div>
-        <div class="flex items-center justify-between gap-3">
-          <span class="text-muted-foreground">同步范围</span>
-          <span class="text-right">文章、编辑器设置</span>
-        </div>
-      </div>
+      <CloudPanelInfoRows :rows="syncInfoRows" />
 
       <div
         v-if="needsRefresh"
-        class="flex flex-col gap-3 rounded-xl border bg-muted/30 p-3.5 sm:flex-row sm:items-center sm:justify-between sm:p-4"
+        class="flex flex-col gap-3 rounded-xl border border-dashed px-3.5 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4 sm:py-4"
       >
         <div class="flex min-w-0 items-start gap-2.5">
           <Info class="mt-0.5 size-4 shrink-0 text-muted-foreground" />

--- a/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelInfoRows.vue
+++ b/apps/web/src/components/editor/editor-header/cloud-panel/CloudPanelInfoRows.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+defineProps<{
+  rows: Array<{ label: string, value: string, numeric?: boolean }>
+}>()
+</script>
+
+<template>
+  <div class="grid gap-2 rounded-xl border px-3.5 py-3 text-xs sm:px-4">
+    <div
+      v-for="row in rows"
+      :key="row.label"
+      class="flex items-center justify-between gap-3"
+    >
+      <span class="text-muted-foreground">{{ row.label }}</span>
+      <span
+        class="text-right font-medium"
+        :class="row.numeric ? 'tabular-nums' : ''"
+      >{{ row.value }}</span>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/composables/useSyncStatusMeta.ts
+++ b/apps/web/src/composables/useSyncStatusMeta.ts
@@ -1,7 +1,8 @@
 import type { Component } from 'vue'
-import { AlertCircle, CloudCheck, CloudOff, Loader2 } from '@lucide/vue'
+import { AlertCircle, Cloud, CloudCheck, CloudOff, Loader2 } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
 import { useSyncStore } from '@/stores/sync'
 
 export type SyncUiState = `syncing` | `synced` | `error` | `pending`
@@ -89,6 +90,39 @@ export function useSyncStatusMeta(options?: { errorHint?: `detail` | `generic` }
     lastError,
     isSyncing,
     syncStatusMeta,
+    syncTooltip,
+  }
+}
+
+/** Footer 云同步图标：依赖登录态，与弹窗内 meta 分离 */
+export function useSyncFooterMeta() {
+  const authStore = useAuthStore()
+  const { isLoggedIn } = storeToRefs(authStore)
+  const { syncStatusMeta, syncState, isSyncing, syncTooltip } = useSyncStatusMeta()
+
+  const isActivelySyncing = computed(
+    () => isSyncing.value || syncState.value === `syncing`,
+  )
+
+  const syncFooterIcon = computed(() => {
+    if (!isLoggedIn.value)
+      return Cloud
+    if (isActivelySyncing.value)
+      return Loader2
+    return syncStatusMeta.value.icon
+  })
+
+  const syncFooterIconClass = computed(() => {
+    if (!isLoggedIn.value)
+      return ``
+    if (isActivelySyncing.value)
+      return `text-primary animate-spin`
+    return syncStatusMeta.value.footerIconClass
+  })
+
+  return {
+    syncFooterIcon,
+    syncFooterIconClass,
     syncTooltip,
   }
 }


### PR DESCRIPTION
## Summary

- Extract `useSyncFooterMeta` from sync status metadata and use it in the editor footer for consistent cloud sync icons
- Collapse mobile footer account/sync/share/theme actions into an overflow menu
- Replace boolean style settings in the right slider with `Switch` controls and tidy section headings
- Add reusable `CloudPanelInfoRows` for sync dialog details; use `CloudPanelCard` for share list items
- Simplify account dialog by removing the "My Shares" shortcut and footer divider

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactor / cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

- [ ] Open account, sync, and share dialogs on desktop; verify layout and actions
- [ ] On mobile width, open footer overflow menu and verify account/sync/share/theme entries
- [ ] Toggle style panel switches (indent, justify, code block options) and confirm preview updates
- [ ] Trigger sync states (pending/synced/error) and confirm footer icon styling
- [ ] Pro user: manage shares from Share dialog "My Shares" tab (no longer linked from account dialog)
- [x] `pnpm run type-check`

## Pre-flight Checklist

- [x] Changes are focused on editor cloud/footer/style UI
- [x] No secrets or env files committed
- [x] Conventional commit message in English
- [ ] Manually verified in browser (recommended before merge)
