### PR TITLE
fix(web): fix export blockquote spacing and async diagram copy

### DIFF
--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -132,6 +132,7 @@ async function copy() {
         let processedClipboardContent: {
           html: string
           plainText: string
+          hasPendingAsyncContent: boolean
         }
 
         try {
@@ -141,6 +142,10 @@ async function copy() {
           toast.error(`处理 HTML 失败，请联系开发者。${normalizeErrorMessage(error)}`)
           editorRefresh()
           return
+        }
+
+        if (processedClipboardContent.hasPendingAsyncContent) {
+          toast.warning(`部分图表或公式尚未渲染完成，已跳过未加载内容。请稍后再试。`)
         }
 
         const clipboardDiv = document.getElementById(`output`)

--- a/apps/web/src/services/share/capture-snapshot.ts
+++ b/apps/web/src/services/share/capture-snapshot.ts
@@ -2,55 +2,7 @@ import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
 import { getHtmlContent, getShareExportStyles } from '@/utils/export-content'
-
-const PREVIEW_READY_TIMEOUT_MS = 20_000
-const PREVIEW_POLL_INTERVAL_MS = 250
-
-function delay(ms: number) {
-  return new Promise<void>(resolve => window.setTimeout(resolve, ms))
-}
-
-function isDiagramStillLoading(output: HTMLElement): boolean {
-  for (const el of output.querySelectorAll<HTMLElement>(`.mermaid-diagram, .plantuml-diagram, .infographic-diagram`)) {
-    if (el.querySelector(`svg, img`))
-      continue
-
-    const text = el.textContent ?? ``
-    if (text.includes(`正在加载`) || text.includes(`加载失败`))
-      return true
-
-    if (el.classList.contains(`mermaid-diagram`) || el.classList.contains(`infographic-diagram`))
-      return true
-  }
-
-  return false
-}
-
-function isMathStillLoading(output: HTMLElement): boolean {
-  if (output.querySelector(`.katex-fallback`))
-    return true
-
-  for (const el of output.querySelectorAll<HTMLElement>(`.katex-block, .katex-inline`)) {
-    if (!el.querySelector(`svg, mjx-container`))
-      return true
-  }
-
-  return false
-}
-
-/** 等待预览区异步图表与公式渲染完成 */
-export async function waitForPreviewReady(timeoutMs = PREVIEW_READY_TIMEOUT_MS): Promise<void> {
-  const output = document.getElementById(`output`)
-  if (!output)
-    throw new Error(`preview_not_ready`)
-
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (!isDiagramStillLoading(output) && !isMathStillLoading(output))
-      return
-    await delay(PREVIEW_POLL_INTERVAL_MS)
-  }
-}
+import { waitForPreviewReady } from '@/utils/preview-ready'
 
 /** 捕获浅色模式分享快照（编辑器处于深色模式时会临时按浅色重渲染） */
 export async function captureShareSnapshot(): Promise<{ bodyHtml: string, stylesHtml: string }> {

--- a/apps/web/src/utils/export-content.ts
+++ b/apps/web/src/utils/export-content.ts
@@ -1,5 +1,6 @@
 import { markedAlert, MDKatex } from '@md/core'
 import { Marked } from 'marked'
+import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from './preview-ready'
 import { downloadFile, sanitizeTitle } from './shared-helpers'
 
 /**
@@ -65,6 +66,7 @@ export function getHtmlContent(): string {
  * 导出 HTML 生成内容
  */
 export async function exportHTML(title: string = `untitled`) {
+  await waitForPreviewReady()
   const htmlStr = getHtmlContent()
   const stylesToAdd = await getStylesToAdd()
 
@@ -119,6 +121,7 @@ export async function exportPureHTML(raw: string, title: string = `untitled`) {
  * @param {string} title - 文档标题
  */
 export async function exportPDF(title: string = `untitled`) {
+  await waitForPreviewReady()
   const htmlStr = getHtmlContent()
   const stylesToAdd = await getStylesToAdd()
   const safeTitle = sanitizeTitle(title)
@@ -341,10 +344,14 @@ export async function processClipboardContent(primaryColor: string) {
     return {
       html: ``,
       plainText: ``,
+      hasPendingAsyncContent: false,
     }
   }
 
+  const previewReady = await waitForPreviewReady()
+
   const clipboardDiv = outputElement.cloneNode(true) as HTMLElement
+  stripUnresolvedAsyncPlaceholders(clipboardDiv)
 
   const stylesToAdd = await getStylesToAdd()
 
@@ -442,5 +449,6 @@ export async function processClipboardContent(primaryColor: string) {
   return {
     html: clipboardDiv.innerHTML,
     plainText: clipboardDiv.textContent || ``,
+    hasPendingAsyncContent: !previewReady,
   }
 }

--- a/apps/web/src/utils/preview-ready.ts
+++ b/apps/web/src/utils/preview-ready.ts
@@ -1,0 +1,67 @@
+const PREVIEW_READY_TIMEOUT_MS = 20_000
+const PREVIEW_POLL_INTERVAL_MS = 250
+
+function delay(ms: number) {
+  return new Promise<void>(resolve => window.setTimeout(resolve, ms))
+}
+
+function isDiagramStillLoading(output: HTMLElement): boolean {
+  for (const el of output.querySelectorAll<HTMLElement>(`.mermaid-diagram, .plantuml-diagram, .infographic-diagram`)) {
+    if (el.querySelector(`svg, img`))
+      continue
+
+    const text = el.textContent ?? ``
+    if (text.includes(`正在加载`) || text.includes(`加载失败`))
+      return true
+
+    if (el.classList.contains(`mermaid-diagram`) || el.classList.contains(`infographic-diagram`))
+      return true
+  }
+
+  return false
+}
+
+function isMathStillLoading(output: HTMLElement): boolean {
+  if (output.querySelector(`.katex-fallback`))
+    return true
+
+  for (const el of output.querySelectorAll<HTMLElement>(`.katex-block, .katex-inline`)) {
+    if (!el.querySelector(`svg, mjx-container`))
+      return true
+  }
+
+  return false
+}
+
+/** 等待预览区异步图表与公式渲染完成；超时返回 false */
+export async function waitForPreviewReady(timeoutMs = PREVIEW_READY_TIMEOUT_MS): Promise<boolean> {
+  const output = document.getElementById(`output`)
+  if (!output)
+    return false
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!isDiagramStillLoading(output) && !isMathStillLoading(output))
+      return true
+    await delay(PREVIEW_POLL_INTERVAL_MS)
+  }
+
+  return false
+}
+
+/** 移除仍未渲染完成的占位内容，避免复制/导出时出现「正在加载…」文案 */
+export function stripUnresolvedAsyncPlaceholders(root: ParentNode) {
+  root.querySelectorAll<HTMLElement>(`.mermaid-diagram, .plantuml-diagram, .infographic-diagram`).forEach((el) => {
+    if (el.querySelector(`svg, img`))
+      return
+
+    const text = el.textContent ?? ``
+    if (text.includes(`正在加载`) || text.includes(`加载失败`))
+      el.remove()
+  })
+
+  root.querySelectorAll<HTMLElement>(`.katex-pending`).forEach((el) => {
+    if (!el.querySelector(`svg, mjx-container`))
+      el.remove()
+  })
+}

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -29,12 +29,15 @@ section,
  * 兜底重置：导出 HTML / 分享页 / VSCode 预览等脱离 Web App 的场景
  * 没有 Tailwind preflight，浏览器 UA 默认样式会冒出来（如
  * blockquote 默认左右各 40px margin、table 默认 border-collapse: separate）。
- * 这里统一重置，保证导出结果与预览一致。各主题可在其后覆盖（如 margin-bottom）。
+ * 这里统一重置左右（及顶部）外边距，保证导出结果与预览一致。
+ * 垂直间距由主题 blockquote { margin-bottom } 控制，勿在此处 margin: 0 覆盖。
  * section 选择器用于 VSCode 预览（无 #output 容器，内容在 section.container 内）。
  */
 #output blockquote,
 section blockquote {
-  margin: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
 }
 
 #output table,


### PR DESCRIPTION
## Summary

- Restore vertical spacing between consecutive alert blockquotes (Note, Tip, Definition, etc.) in exported HTML and share pages by only resetting horizontal blockquote margins in `base.css`, instead of `margin: 0` which overrode theme `margin-bottom` via the higher-specificity `section blockquote` selector.
- Wait for async Mermaid, PlantUML, Infographic, and MathJax content to finish rendering before WeChat clipboard copy and HTML/PDF export.
- Extract shared `waitForPreviewReady` / `stripUnresolvedAsyncPlaceholders` utilities and strip unresolved loading placeholders so "正在加载…" text is not pasted into WeChat.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [ ] Export HTML with multiple consecutive alert blocks (`> [!NOTE]`, `> [!TIP]`, `::: definition`, etc.) and verify spacing between blocks
- [ ] Copy rendered content to WeChat with Mermaid/PlantUML/Infographic blocks and confirm rendered diagrams appear instead of "正在加载…" placeholders
- [ ] Generate a share preview link and confirm diagrams and alert block spacing render correctly
- [ ] Copy before diagrams finish loading (slow network) and confirm warning toast appears; clipboard should not contain loading placeholder text

## Pre-flight Checklist

- [x] Changes are focused on export/copy preview output quality
- [x] Pre-commit ESLint hook passed
- [ ] Manual copy/export verification in browser
