### PR TITLE
feat(web): hot-apply synced settings without page reload

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -150,6 +150,6 @@ VITE_AFDIAN_ORDER_BASE=https://ifdian.net
 ## 说明与限制
 
 - 前端约定「先 pull 再 push」，`push` 仅返回本次被接受的记录与新游标。
-- 偏好设置应用到本地后需刷新页面生效（前端会给出提示），文章为即时生效。
+- 偏好设置同步后会自动应用到当前页面，文章为即时生效。
 - 同步白名单见 `apps/web/src/services/sync/settings.ts`，新增可同步项请在此维护，
   切勿加入任何密钥类字段。

--- a/apps/web/src/components/editor/editor-header/AccountDialog.vue
+++ b/apps/web/src/components/editor/editor-header/AccountDialog.vue
@@ -73,7 +73,7 @@ function openShareDialog() {
       v-if="!isConfigured"
       :icon="Settings2"
       title="账户服务未配置"
-      description="部署方需配置 VITE_MD_API_URL 或 VITE_SYNC_API_URL 后，方可使用登录与云同步。"
+      description="部署方需配置 VITE_MD_API_URL 后，方可使用登录与云同步。"
       compact
     >
       <code class="rounded-md border bg-muted/40 px-2 py-1 text-[11px] text-muted-foreground">

--- a/apps/web/src/components/editor/editor-header/SyncDialog.vue
+++ b/apps/web/src/components/editor/editor-header/SyncDialog.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { AlertCircle, Cloud, CloudOff, Info, Loader2, LogIn, RefreshCw } from '@lucide/vue'
+import { AlertCircle, Cloud, CloudOff, Loader2, LogIn, RefreshCw } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
 import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
-import CloudPanelInfoRows from '@/components/editor/editor-header/cloud-panel/CloudPanelInfoRows.vue'
 import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -27,7 +26,7 @@ const syncStore = useSyncStore()
 const uiStore = useUIStore()
 
 const { isLoggedIn } = storeToRefs(authStore)
-const { status, lastError, lastSyncAt, needsRefresh, isSyncing, syncState } = storeToRefs(syncStore)
+const { status, lastError, lastSyncAt, isSyncing, syncState } = storeToRefs(syncStore)
 const { syncStatusMeta } = useSyncStatusMeta({ errorHint: `generic` })
 
 const dialogOpen = computed({
@@ -46,11 +45,6 @@ const lastSyncText = computed(() => {
   })
 })
 
-const syncInfoRows = computed(() => [
-  { label: `上次同步`, value: lastSyncText.value, numeric: true },
-  { label: `同步范围`, value: `文章、编辑器设置` },
-])
-
 function openAccountDialog() {
   dialogOpen.value = false
   uiStore.toggleShowAccountDialog(true)
@@ -62,10 +56,6 @@ async function handleSync() {
     toast.error(`同步失败：${lastError.value}`)
   else
     toast.success(`同步完成`)
-}
-
-function handleReload() {
-  window.location.reload()
 }
 </script>
 
@@ -117,30 +107,11 @@ function handleReload() {
           <p class="text-xs leading-relaxed text-muted-foreground">
             {{ syncStatusMeta.hint }}
           </p>
-        </div>
-      </CloudPanelCard>
-
-      <CloudPanelInfoRows :rows="syncInfoRows" />
-
-      <div
-        v-if="needsRefresh"
-        class="flex flex-col gap-3 rounded-xl border border-dashed px-3.5 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4 sm:py-4"
-      >
-        <div class="flex min-w-0 items-start gap-2.5">
-          <Info class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <p class="text-xs leading-relaxed text-muted-foreground">
-            部分设置已从云端更新，刷新页面后生效
+          <p class="text-xs tabular-nums text-muted-foreground/80">
+            上次同步：{{ lastSyncText }}
           </p>
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          class="h-8 w-full shrink-0 sm:w-auto"
-          @click="handleReload"
-        >
-          刷新页面
-        </Button>
-      </div>
+      </CloudPanelCard>
 
       <Alert v-if="syncState === 'error' && lastError" variant="destructive" class="py-3">
         <AlertCircle class="size-4" />

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -7,8 +7,6 @@ import { useRenderStore } from '@/stores/render'
 import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 import { generatePureHTML, processClipboardContent } from '@/utils/export-content'
-import { addPrefix } from '@/utils/prefix'
-import { store } from '@/utils/storage'
 import EditDropdown from './EditDropdown.vue'
 import FileDropdown from './FileDropdown.vue'
 import FormatDropdown from './FormatDropdown.vue'
@@ -34,7 +32,7 @@ const exportStore = useExportStore()
 const { editor } = storeToRefs(editorStore)
 const { output } = storeToRefs(renderStore)
 const { primaryColor } = storeToRefs(themeStore)
-const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog } = storeToRefs(uiStore)
+const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog, copyMode } = storeToRefs(uiStore)
 
 // Editor refresh function
 function editorRefresh() {
@@ -44,7 +42,6 @@ function editorRefresh() {
   renderStore.render(raw)
 }
 
-const copyMode = store.reactive(addPrefix(`copyMode`), `txt`)
 const isCopying = ref(false)
 
 const { copy: copyContent } = useClipboard({

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -5,8 +5,6 @@ import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
 import { useUIStore } from '@/stores/ui'
 import { downloadMD, exportPostsAsZip } from '@/utils/export-content'
-import { addPrefix } from '@/utils/prefix'
-import { store } from '@/utils/storage'
 import {
   getPostSliderDropdownContentProps,
   providePostSliderMenu,
@@ -29,7 +27,7 @@ function onHeaderMenuOpenChange(open: boolean) {
 const headerDropdownProps = computed(() => getPostSliderDropdownContentProps(isMobile.value, `w-48`))
 
 const postStore = usePostStore()
-const { posts } = storeToRefs(postStore)
+const { posts, sortMode } = storeToRefs(postStore)
 
 const editorStore = useEditorStore()
 const { editor } = storeToRefs(editorStore)
@@ -399,7 +397,6 @@ function replaceAll() {
 }
 
 /* ============ 排序 ============ */
-const sortMode = store.reactive(addPrefix(`sort_mode`), `create-old-new`)
 const sortedPosts = computed(() => {
   return [...posts.value].sort((a, b) => {
     switch (sortMode.value) {

--- a/apps/web/src/services/sync/client.ts
+++ b/apps/web/src/services/sync/client.ts
@@ -1,9 +1,6 @@
 import type { ActivateProResponse, PullResponse, PushRequest, PushResponse } from './types'
-import { ApiError, MdApiClient } from '@/services/account/client'
-import { isAccountConfigured, MD_API_URL } from '@/services/account/config'
-
-/** @deprecated 使用 MD_API_URL */
-export const SYNC_API_URL = MD_API_URL
+import { MdApiClient } from '@/services/account/client'
+import { isAccountConfigured } from '@/services/account/config'
 
 /** 爱发电创作者主页，用于 Pro 升级跳转 */
 export const AFDIAN_PAGE_URL = (import.meta.env.VITE_AFDIAN_PAGE_URL ?? ``).replace(/\/$/, ``)
@@ -19,9 +16,6 @@ export function isSyncUiEnabled(): boolean {
     return false
   return isSyncConfigured()
 }
-
-/** @deprecated 使用 ApiError */
-export { ApiError as SyncApiError }
 
 export class SyncClient extends MdApiClient {
   pull(since: number): Promise<PullResponse> {

--- a/apps/web/src/services/sync/hydrate.ts
+++ b/apps/web/src/services/sync/hydrate.ts
@@ -1,0 +1,103 @@
+import { storeToRefs } from 'pinia'
+import { useAIConfigStore } from '@/stores/aiConfig'
+import { useCssEditorStore } from '@/stores/cssEditor'
+import { useCustomComponentStore } from '@/stores/customComponent'
+import { useEditorStore } from '@/stores/editor'
+import { usePostStore } from '@/stores/post'
+import { useQuickCommandsStore } from '@/stores/quickCommands'
+import { useRenderStore } from '@/stores/render'
+import { useTemplateStore } from '@/stores/template'
+import { useThemeStore } from '@/stores/theme'
+import { useUIStore } from '@/stores/ui'
+import { parseStoredValue, safeGetItem } from '@/utils/localStorageSafe'
+import { addPrefix } from '@/utils/prefix'
+
+const PREVIEW_REFRESH_KEYS = new Set([
+  addPrefix(`theme`),
+  addPrefix(`themeSettings`),
+  addPrefix(`use_indent`),
+  addPrefix(`use_justify`),
+  `isCiteStatus`,
+  `isCountStatus`,
+  `legend`,
+  `previewWidth`,
+  addPrefix(`css_content_config`),
+  addPrefix(`custom_components`),
+])
+
+function hydrateRef<T>(key: string, keys: Set<string>, ref: { value: T }): void {
+  if (!keys.has(key))
+    return
+  const raw = safeGetItem(key)
+  if (raw === null)
+    return
+  ref.value = parseStoredValue(raw, ref.value)
+}
+
+async function refreshPreview(keys: Set<string>): Promise<void> {
+  if (![...PREVIEW_REFRESH_KEYS].some(key => keys.has(key)))
+    return
+
+  const themeStore = useThemeStore()
+  const editorStore = useEditorStore()
+  const renderStore = useRenderStore()
+
+  themeStore.updateCodeTheme()
+  await themeStore.applyCurrentTheme()
+  renderStore.render(editorStore.getContent())
+}
+
+/** 将已写入 localStorage 的远端设置同步到各 Pinia Store，无需整页刷新 */
+export async function hydrateSyncedSettings(appliedKeys: string[]): Promise<void> {
+  if (!appliedKeys.length)
+    return
+
+  const keys = new Set(appliedKeys)
+  const themeStore = useThemeStore()
+  const uiStore = useUIStore()
+  const postStore = usePostStore()
+  const aiConfigStore = useAIConfigStore()
+  const cssEditorStore = useCssEditorStore()
+  const templateStore = useTemplateStore()
+  const customComponentStore = useCustomComponentStore()
+  const quickCommandsStore = useQuickCommandsStore()
+
+  const theme = storeToRefs(themeStore)
+  const ui = storeToRefs(uiStore)
+  const post = storeToRefs(postStore)
+  const aiConfig = storeToRefs(aiConfigStore)
+  const cssEditor = storeToRefs(cssEditorStore)
+  const template = storeToRefs(templateStore)
+  const customComponent = storeToRefs(customComponentStore)
+
+  hydrateRef(addPrefix(`theme`), keys, theme.theme)
+  hydrateRef(addPrefix(`themeSettings`), keys, theme.themeSettings)
+  hydrateRef(addPrefix(`use_indent`), keys, theme.isUseIndent)
+  hydrateRef(addPrefix(`use_justify`), keys, theme.isUseJustify)
+  hydrateRef(`isCiteStatus`, keys, theme.isCiteStatus)
+  hydrateRef(`isCountStatus`, keys, theme.isCountStatus)
+  hydrateRef(`legend`, keys, theme.legend)
+  hydrateRef(`previewWidth`, keys, theme.previewWidth)
+
+  hydrateRef(`isEditOnLeft`, keys, ui.isEditOnLeft)
+  hydrateRef(`showAIToolbox`, keys, ui.showAIToolbox)
+  hydrateRef(`viewMode`, keys, ui.viewMode)
+  hydrateRef(`previewDevice`, keys, ui.previewDevice)
+  hydrateRef(addPrefix(`enableImageReupload`), keys, ui.enableImageReupload)
+  hydrateRef(addPrefix(`enableScrollSync`), keys, ui.enableScrollSync)
+  hydrateRef(addPrefix(`copyMode`), keys, ui.copyMode)
+
+  hydrateRef(`openai_type`, keys, aiConfig.type)
+  hydrateRef(`openai_temperature`, keys, aiConfig.temperature)
+  hydrateRef(`openai_max_token`, keys, aiConfig.maxToken)
+
+  hydrateRef(addPrefix(`css_content_config`), keys, cssEditor.cssContentConfig)
+  hydrateRef(addPrefix(`templates`), keys, template.templates)
+  hydrateRef(addPrefix(`custom_components`), keys, customComponent.userComponents)
+  hydrateRef(addPrefix(`sort_mode`), keys, post.sortMode)
+
+  if (keys.has(`quick_commands`))
+    await quickCommandsStore.reloadFromStorage()
+
+  await refreshPreview(keys)
+}

--- a/apps/web/src/services/sync/settings.ts
+++ b/apps/web/src/services/sync/settings.ts
@@ -1,5 +1,10 @@
 import type { SyncSetting } from './types'
+import { safeGetItem, safeRemoveItem, safeSetItem } from '@/utils/localStorageSafe'
 import { addPrefix } from '@/utils/prefix'
+
+export interface ApplyRemoteSettingsResult {
+  keys: string[]
+}
 
 /**
  * 允许同步的偏好设置 key 白名单（显式枚举，避免泄露密钥）。
@@ -46,9 +51,11 @@ interface SettingMeta {
 type MetaMap = Record<string, SettingMeta>
 
 function readMeta(): MetaMap {
+  const raw = safeGetItem(META_KEY)
+  if (!raw)
+    return {}
   try {
-    const raw = localStorage.getItem(META_KEY)
-    return raw ? JSON.parse(raw) as MetaMap : {}
+    return JSON.parse(raw) as MetaMap
   }
   catch {
     return {}
@@ -56,19 +63,11 @@ function readMeta(): MetaMap {
 }
 
 function writeMeta(meta: MetaMap): void {
-  try {
-    localStorage.setItem(META_KEY, JSON.stringify(meta))
-  }
-  catch { /* 配额错误，非致命 */ }
+  safeSetItem(META_KEY, JSON.stringify(meta))
 }
 
 function readLocal(key: string): string | null {
-  try {
-    return localStorage.getItem(key)
-  }
-  catch {
-    return null
-  }
+  return safeGetItem(key)
 }
 
 /**
@@ -95,11 +94,11 @@ export function collectChangedSettings(): SyncSetting[] {
 
 /**
  * 应用远端设置到本地（LWW，仅当远端更新时间较新时写入）。
- * 返回实际应用的数量（>0 表示建议刷新页面以生效）。
+ * 返回实际应用的 key 列表，供 hydrateSyncedSettings 热更新 Store。
  */
-export function applyRemoteSettings(remote: SyncSetting[]): number {
+export function applyRemoteSettings(remote: SyncSetting[]): ApplyRemoteSettingsResult {
   const meta = readMeta()
-  let applied = 0
+  const appliedKeys: string[] = []
 
   for (const setting of remote) {
     if (!SYNC_SETTING_KEYS.includes(setting.key))
@@ -109,20 +108,16 @@ export function applyRemoteSettings(remote: SyncSetting[]): number {
     if (local && local.updatedAt >= setting.updatedAt)
       continue
 
-    try {
-      if (setting.value === null)
-        localStorage.removeItem(setting.key)
-      else
-        localStorage.setItem(setting.key, setting.value)
-    }
-    catch {
+    const saved = setting.value === null
+      ? safeRemoveItem(setting.key)
+      : safeSetItem(setting.key, setting.value)
+    if (!saved)
       continue
-    }
 
     meta[setting.key] = { value: setting.value, updatedAt: setting.updatedAt }
-    applied++
+    appliedKeys.push(setting.key)
   }
 
   writeMeta(meta)
-  return applied
+  return { keys: appliedKeys }
 }

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -34,13 +34,6 @@ export const useAuthStore = defineStore(`auth`, () => {
       await fetchMe()
   }
 
-  /** @deprecated 使用 bootstrap */
-  function captureRedirectToken(): boolean {
-    return captureOAuthToken((t) => {
-      token.value = t
-    })
-  }
-
   async function fetchMe(): Promise<void> {
     if (!token.value)
       return
@@ -75,10 +68,7 @@ export const useAuthStore = defineStore(`auth`, () => {
     isLoggedIn,
     api,
     syncClient,
-    /** @deprecated 使用 syncClient */
-    client: syncClient,
     bootstrap,
-    captureRedirectToken,
     fetchMe,
     login,
     logout,

--- a/apps/web/src/stores/post.ts
+++ b/apps/web/src/stores/post.ts
@@ -28,6 +28,9 @@ export const usePostStore = defineStore(`post`, () => {
   // 当前文章 ID
   const currentPostId = store.reactive(addPrefix(`current_post_id`), ``)
 
+  // 文章列表排序方式
+  const sortMode = store.reactive(addPrefix(`sort_mode`), `create-old-new`)
+
   // 在补齐 id 后，若 currentPostId 无效 ➜ 自动指向第一篇
   onBeforeMount(() => {
     posts.value = posts.value.map((post, index) => {
@@ -172,6 +175,7 @@ export const usePostStore = defineStore(`post`, () => {
     // State
     posts,
     currentPostId,
+    sortMode,
     currentPostIndex,
     currentPost,
 

--- a/apps/web/src/stores/quickCommands.ts
+++ b/apps/web/src/stores/quickCommands.ts
@@ -43,7 +43,7 @@ export const useQuickCommandsStore = defineStore(`quickCommands`, () => {
     await store.setJSON(STORAGE_KEY, toSave)
   }
 
-  async function load() {
+  async function reloadFromStorage() {
     const parsed = await store.getJSON<QuickCommandPersisted[]>(STORAGE_KEY)
 
     if (parsed && Array.isArray(parsed)) {
@@ -79,8 +79,8 @@ export const useQuickCommandsStore = defineStore(`quickCommands`, () => {
   }
 
   // ---------- init ----------
-  load()
+  reloadFromStorage()
   watch(commands, save, { deep: true })
 
-  return { commands, add, update, remove }
+  return { commands, add, update, remove, reloadFromStorage }
 })

--- a/apps/web/src/stores/sync.ts
+++ b/apps/web/src/stores/sync.ts
@@ -1,11 +1,13 @@
 import type { SyncDocument } from '@/services/sync/types'
 import { ApiError } from '@/services/account/client'
 import { isSyncConfigured } from '@/services/sync/client'
+import { hydrateSyncedSettings } from '@/services/sync/hydrate'
 import { mergeRemoteIntoLocal, postToDoc, toMs } from '@/services/sync/merge'
 import { isProPlan, SYNC_DEBOUNCE_MS_PRO, SYNC_PRO_ENABLED } from '@/services/sync/plan'
 import { applyRemoteSettings, collectChangedSettings } from '@/services/sync/settings'
 import { useAuthStore } from '@/stores/auth'
 import { usePostStore } from '@/stores/post'
+import { safeGetItem, safeRemoveItem, safeSetItem } from '@/utils/localStorageSafe'
 import { addPrefix } from '@/utils/prefix'
 import { store } from '@/utils/storage'
 
@@ -14,9 +16,11 @@ export type SyncStatus = 'idle' | 'syncing' | 'error'
 const SYNCED_IDS_KEY = addPrefix(`sync_post_ids`)
 
 function readSyncedIds(): string[] {
+  const raw = safeGetItem(SYNCED_IDS_KEY)
+  if (!raw)
+    return []
   try {
-    const raw = localStorage.getItem(SYNCED_IDS_KEY)
-    return raw ? JSON.parse(raw) as string[] : []
+    return JSON.parse(raw) as string[]
   }
   catch {
     return []
@@ -24,10 +28,7 @@ function readSyncedIds(): string[] {
 }
 
 function writeSyncedIds(ids: string[]): void {
-  try {
-    localStorage.setItem(SYNCED_IDS_KEY, JSON.stringify(ids))
-  }
-  catch { /* 配额错误，非致命 */ }
+  safeSetItem(SYNCED_IDS_KEY, JSON.stringify(ids))
 }
 
 /**
@@ -42,7 +43,6 @@ export const useSyncStore = defineStore(`sync`, () => {
   const lastError = ref<string>(``)
   const lastSyncAt = store.reactive<number>(addPrefix(`sync_last_at`), 0)
   const autoSyncEnabled = store.reactive(addPrefix(`sync_auto`), false)
-  const needsRefresh = ref(false)
 
   let cursor = 0
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -125,9 +125,9 @@ export const useSyncStore = defineStore(`sync`, () => {
       }
 
       if (pulled.settings.length) {
-        const applied = applyRemoteSettings(pulled.settings)
-        if (applied > 0)
-          needsRefresh.value = true
+        const { keys } = applyRemoteSettings(pulled.settings)
+        if (keys.length)
+          await hydrateSyncedSettings(keys)
       }
 
       cursor = Math.max(cursor, pulled.cursor)
@@ -177,13 +177,9 @@ export const useSyncStore = defineStore(`sync`, () => {
   function reset(): void {
     cursor = 0
     lastSyncAt.value = 0
-    needsRefresh.value = false
     status.value = `idle`
-    try {
-      localStorage.removeItem(SYNCED_IDS_KEY)
-      localStorage.removeItem(addPrefix(`sync_settings_meta`))
-    }
-    catch { /* ignore */ }
+    safeRemoveItem(SYNCED_IDS_KEY)
+    safeRemoveItem(addPrefix(`sync_settings_meta`))
   }
 
   return {
@@ -191,7 +187,6 @@ export const useSyncStore = defineStore(`sync`, () => {
     lastError,
     lastSyncAt,
     autoSyncEnabled,
-    needsRefresh,
     isAvailable,
     isSyncing,
     isPro,

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -60,6 +60,9 @@ export const useUIStore = defineStore(`ui`, () => {
   const enableScrollSync = store.reactive(addPrefix(`enableScrollSync`), true)
   const toggleScrollSync = useToggle(enableScrollSync)
 
+  // 复制到公众号时的格式模式
+  const copyMode = store.reactive(addPrefix(`copyMode`), `txt`)
+
   // ==================== 对话框状态 ====================
   // 是否展示 CSS 编辑器
   const isShowCssEditor = store.reactive(`isShowCssEditor`, false)
@@ -228,6 +231,7 @@ export const useUIStore = defineStore(`ui`, () => {
     isOpenFolderPanel,
     enableImageReupload,
     enableScrollSync,
+    copyMode,
 
     // ==================== 对话框状态 ====================
     isShowCssEditor,

--- a/apps/web/src/utils/localStorageSafe.ts
+++ b/apps/web/src/utils/localStorageSafe.ts
@@ -1,0 +1,58 @@
+let lastQuotaWarnAt = 0
+
+/** 本地存储配额不足时提示（5 秒内去重） */
+export function warnStorageQuota(): void {
+  const now = Date.now()
+  if (now - lastQuotaWarnAt < 5000)
+    return
+  lastQuotaWarnAt = now
+  toast.warning(`本地存储空间不足，部分设置可能无法保存`)
+}
+
+export function isStorageQuotaError(error: unknown): boolean {
+  if (!(error instanceof DOMException))
+    return false
+  return error.name === `QuotaExceededError` || error.code === 22
+}
+
+export function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  }
+  catch {
+    return null
+  }
+}
+
+export function safeSetItem(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value)
+    return true
+  }
+  catch (error) {
+    if (isStorageQuotaError(error))
+      warnStorageQuota()
+    return false
+  }
+}
+
+export function safeRemoveItem(key: string): boolean {
+  try {
+    localStorage.removeItem(key)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+export function parseStoredValue<T>(raw: string, fallback: T): T {
+  if (typeof fallback === `string`)
+    return raw as T
+  try {
+    return JSON.parse(raw) as T
+  }
+  catch {
+    return fallback
+  }
+}

--- a/apps/web/src/utils/storage.ts
+++ b/apps/web/src/utils/storage.ts
@@ -5,6 +5,7 @@
 
 import type { Ref } from 'vue'
 import { customRef, ref, watch } from 'vue'
+import { isStorageQuotaError, warnStorageQuota } from '@/utils/localStorageSafe'
 
 /**
  * 存储引擎接口 - 完全异步化
@@ -37,6 +38,8 @@ export class LocalStorageEngine implements StorageEngine {
       localStorage.setItem(key, value)
     }
     catch (error) {
+      if (isStorageQuotaError(error))
+        warnStorageQuota()
       console.error(`[Storage] Failed to set item:`, key, error)
       throw error
     }
@@ -294,6 +297,8 @@ class StorageManager {
             : this.setJSON(key, newValue)
 
           savePromise.catch((error) => {
+            if (isStorageQuotaError(error))
+              warnStorageQuota()
             console.error(`[Storage] Failed to save reactive data:`, key, error)
           })
         },
@@ -335,7 +340,9 @@ class StorageManager {
         trigger()
 
         // 异步保存
-        this.setJSON(key, valueToStore).catch((error: any) => {
+        this.setJSON(key, valueToStore).catch((error: unknown) => {
+          if (isStorageQuotaError(error))
+            warnStorageQuota()
           console.error(`[Storage] Failed to save custom reactive data:`, key, error)
         })
       },


### PR DESCRIPTION
## Summary

- Apply remote sync settings to Pinia stores immediately after pull, removing the full-page reload flow (`needsRefresh`).
- Add `hydrateSyncedSettings` to map synced localStorage keys back into theme, UI, post, AI, template, and related stores, including preview re-render when needed.
- Introduce `localStorageSafe` helpers with deduplicated quota-exceeded toasts; move `copyMode` and `sortMode` into stores so they participate in sync hydration.
- Remove deprecated auth/sync shims and update API docs to reflect hot-apply behavior.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Cosmetic
- [x] Documentation
- [ ] Workflow

## Test Procedure

- [x] `pnpm web build` passes (includes `vue-tsc`)
- [x] `pnpm web dev` starts without errors
- [ ] Manual: log in with sync enabled, change theme/layout on device A, sync on device B, confirm settings apply without refresh

## Pre-flight Checklist

- [x] Working tree clean before PR
- [x] Conventional commit message in English
- [x] API README updated for sync behavior change
- [x] No secrets committed
