### PR TITLE
refactor(web): extract app bootstrap and fix document IndexedDB save

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,55 +1,15 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
 import ConfirmDialog from '@/components/confirm-dialog/ConfirmDialog.vue'
 import CodemirrorEditor from '@/components/editor/CodemirrorEditor.vue'
 import { Toaster } from '@/components/ui/sonner'
-import { isAccountConfigured } from '@/services/account/config'
-import { isSyncUiEnabled } from '@/services/sync/client'
-import { useAuthStore } from '@/stores/auth'
-import { useSyncStore } from '@/stores/sync'
 import { useUIStore } from '@/stores/ui'
 
 const uiStore = useUIStore()
 const { isDark } = storeToRefs(uiStore)
 
-const authStore = useAuthStore()
-const syncStore = useSyncStore()
-
-const isUtools = ref(false)
-
-/** 初始化账户与云同步 */
-async function bootstrapApp() {
-  if (isAccountConfigured())
-    await authStore.bootstrap()
-
-  if (!isSyncUiEnabled() || !authStore.isLoggedIn)
-    return
-
-  syncStore.startAutoSyncWatcher()
-  void syncStore.sync()
-}
-
-onMounted(() => {
-  // 检测是否为 Utools 环境
-  isUtools.value = !!(window as any).__MD_UTOOLS__
-  if (isUtools.value) {
-    document.documentElement.classList.add(`is-utools`)
-  }
-
-  bootstrapApp()
-
-  // 若 URL 带有 open 参数（Markdown 链接），打开导入对话框并自动导入
-  const params = new URLSearchParams(window.location.search)
-  const openUrl = params.get(`open`)
-  if (openUrl && URL.canParse(openUrl) && /^https?:\/\//i.test(openUrl)) {
-    uiStore.importMdOpenUrl = openUrl
-    uiStore.isShowImportMdDialog = true
-    params.delete(`open`)
-    const newSearch = params.toString()
-    const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : ``) + window.location.hash
-    window.history.replaceState({}, ``, newUrl)
-  }
-})
+usePlatformEnv()
+useAccountSyncBootstrap()
+useDeepLinkImport()
 </script>
 
 <template>
@@ -66,96 +26,3 @@ onMounted(() => {
     :theme="isDark ? 'dark' : 'light'"
   />
 </template>
-
-<style lang="less">
-html,
-body,
-#app {
-  width: 100vw;
-  height: 100vh;
-  margin: 0;
-  padding: 0;
-}
-
-// 抵消下拉菜单开启时带来的样式
-body {
-  pointer-events: initial !important;
-}
-
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-  background-color: transparent;
-}
-
-::-webkit-scrollbar-track {
-  border-radius: 6px;
-  background-color: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 6px;
-  background-color: #dadada;
-}
-
-.dark ::-webkit-scrollbar-thumb {
-  background-color: #424242;
-}
-
-// Utools 模式下隐藏所有滚动条
-.is-utools {
-  ::-webkit-scrollbar {
-    display: none;
-  }
-
-  // Firefox
-  * {
-    scrollbar-width: none;
-  }
-
-  // IE and Edge
-  * {
-    -ms-overflow-style: none;
-  }
-}
-
-/* CSS-hints */
-.CodeMirror-hints {
-  position: absolute;
-  z-index: 10;
-  overflow-y: auto;
-  margin: 0;
-  padding: 2px;
-  border-radius: 4px;
-  max-height: 20em;
-  min-width: 200px;
-  font-size: 12px;
-  font-family: monospace;
-
-  color: #333333;
-  background-color: #ffffff;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12), 0 2px 4px 0 rgba(0, 0, 0, 0.08);
-}
-
-.CodeMirror-hint {
-  margin-top: 10px;
-  padding: 4px 6px;
-  border-radius: 2px;
-  white-space: pre;
-  color: #000000;
-  cursor: pointer;
-
-  &:first-of-type {
-    margin-top: 0;
-  }
-  &:hover {
-    background: #f0f0f0;
-  }
-}
-.search-match {
-  background-color: #ffeb3b; /* 所有匹配项颜色 */
-}
-.current-match {
-  background-color: #ff5722; /* 当前匹配项更鲜艳的颜色 */
-}
-</style>

--- a/apps/web/src/assets/less/codemirror-global.less
+++ b/apps/web/src/assets/less/codemirror-global.less
@@ -1,0 +1,41 @@
+/* CSS-hints */
+.CodeMirror-hints {
+  position: absolute;
+  z-index: 10;
+  overflow-y: auto;
+  margin: 0;
+  padding: 2px;
+  border-radius: 4px;
+  max-height: 20em;
+  min-width: 200px;
+  font-size: 12px;
+  font-family: monospace;
+
+  color: #333333;
+  background-color: #ffffff;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12), 0 2px 4px 0 rgba(0, 0, 0, 0.08);
+}
+
+.CodeMirror-hint {
+  margin-top: 10px;
+  padding: 4px 6px;
+  border-radius: 2px;
+  white-space: pre;
+  color: #000000;
+  cursor: pointer;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+  &:hover {
+    background: #f0f0f0;
+  }
+}
+
+.search-match {
+  background-color: #ffeb3b; /* 所有匹配项颜色 */
+}
+
+.current-match {
+  background-color: #ff5722; /* 当前匹配项更鲜艳的颜色 */
+}

--- a/apps/web/src/assets/less/global.less
+++ b/apps/web/src/assets/less/global.less
@@ -1,0 +1,50 @@
+html,
+body,
+#app {
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
+// 抵消下拉菜单开启时带来的样式
+body {
+  pointer-events: initial !important;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-track {
+  border-radius: 6px;
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 6px;
+  background-color: #dadada;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background-color: #424242;
+}
+
+// Utools 模式下隐藏所有滚动条
+.is-utools {
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  // Firefox
+  * {
+    scrollbar-width: none;
+  }
+
+  // IE and Edge
+  * {
+    -ms-overflow-style: none;
+  }
+}

--- a/apps/web/src/bootstrap.ts
+++ b/apps/web/src/bootstrap.ts
@@ -1,0 +1,17 @@
+import { initComponentDarkVars } from '@md/core'
+import { createPinia } from 'pinia'
+import { createApp } from 'vue'
+import { initStorage } from '@/storage'
+
+import AppRoot from './App.vue'
+import { setupComponents } from './utils/setup-components'
+
+export async function bootstrap(): Promise<void> {
+  initComponentDarkVars()
+  setupComponents()
+  await initStorage()
+
+  const app = createApp(AppRoot)
+  app.use(createPinia())
+  app.mount(`#app`)
+}

--- a/apps/web/src/composables/useAccountSyncBootstrap.ts
+++ b/apps/web/src/composables/useAccountSyncBootstrap.ts
@@ -1,0 +1,19 @@
+import { isAccountConfigured } from '@/services/account/config'
+import { isSyncUiEnabled } from '@/services/sync/client'
+
+/** 初始化账户与云同步（需在 Pinia 就绪后调用） */
+export function useAccountSyncBootstrap() {
+  const authStore = useAuthStore()
+  const syncStore = useSyncStore()
+
+  onMounted(async () => {
+    if (isAccountConfigured())
+      await authStore.bootstrap()
+
+    if (!isSyncUiEnabled() || !authStore.isLoggedIn)
+      return
+
+    syncStore.startAutoSyncWatcher()
+    void syncStore.sync()
+  })
+}

--- a/apps/web/src/composables/useDeepLinkImport.ts
+++ b/apps/web/src/composables/useDeepLinkImport.ts
@@ -1,0 +1,17 @@
+export function useDeepLinkImport() {
+  const uiStore = useUIStore()
+
+  onMounted(() => {
+    const params = new URLSearchParams(window.location.search)
+    const openUrl = params.get(`open`)
+    if (!openUrl || !URL.canParse(openUrl) || !/^https?:\/\//i.test(openUrl))
+      return
+
+    uiStore.importMdOpenUrl = openUrl
+    uiStore.isShowImportMdDialog = true
+    params.delete(`open`)
+    const newSearch = params.toString()
+    const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : ``) + window.location.hash
+    window.history.replaceState({}, ``, newUrl)
+  })
+}

--- a/apps/web/src/composables/usePlatformEnv.ts
+++ b/apps/web/src/composables/usePlatformEnv.ts
@@ -1,0 +1,5 @@
+/** 检测 uTools 环境并标记根元素（setup 阶段同步执行，尽早生效） */
+export function usePlatformEnv() {
+  if (window.__MD_UTOOLS__)
+    document.documentElement.classList.add(`is-utools`)
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,25 +1,10 @@
-import { initComponentDarkVars } from '@md/core'
-import { createPinia } from 'pinia'
-import { createApp } from 'vue'
-import { initStorage } from '@/storage'
-
-import App from './App.vue'
-import { setupComponents } from './utils/setup-components'
+import { bootstrap } from './bootstrap'
 
 import 'vue-sonner/style.css'
-
-/* 每个页面公共css */
 import '@/assets/index.css'
+import '@/assets/less/codemirror-global.less'
+import '@/assets/less/global.less'
+
 import '@/assets/less/theme.less'
 
-async function bootstrap() {
-  initComponentDarkVars()
-  setupComponents()
-  await initStorage()
-
-  const app = createApp(App)
-  app.use(createPinia())
-  app.mount(`#app`)
-}
-
-bootstrap()
+bootstrap().catch(console.error)

--- a/apps/web/src/storage/repositories/documents.ts
+++ b/apps/web/src/storage/repositories/documents.ts
@@ -10,7 +10,10 @@ function toStored(post: Post): StoredDocument {
     id: post.id,
     title: post.title,
     content: post.content,
-    history: post.history ?? [],
+    history: (post.history ?? []).map(({ datetime, content }) => ({
+      datetime: String(datetime),
+      content: String(content),
+    })),
     createDatetime: new Date(post.createDatetime).toISOString(),
     updateDatetime: new Date(post.updateDatetime).toISOString(),
     parentId: post.parentId ?? null,

--- a/apps/web/src/types/global.d.ts
+++ b/apps/web/src/types/global.d.ts
@@ -1,4 +1,6 @@
 interface Window {
+  __MD_UTOOLS__?: boolean
+
   __MP_Editor_JSAPI__: {
     invoke: (params: {
       apiName: string


### PR DESCRIPTION
## Summary

- Refactor the web app entry layer: `main.ts` only imports CSS and calls `bootstrap.ts`; `App.vue` becomes a thin shell driven by composables.
- Extract global styles from `App.vue` into `assets/less/global.less` and `codemirror-global.less`.
- Add composables for uTools detection, account/sync bootstrap, and `?open=` deep-link import.
- Fix `DataCloneError` when saving documents to IndexedDB by serializing reactive `post.history` into plain objects before `put`.

## Type of Change

- [x] Refactor
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] `pnpm web build` (type-check + production build)
- [x] `pnpm web dev` — app loads at `/md/` without IndexedDB `DataCloneError` on document save
- [ ] Manual: verify uTools `is-utools` class still applied when `window.__MD_UTOOLS__` is set
- [ ] Manual: verify `?open=https://...` opens import dialog and strips query param

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits (English)
- [x] Branch created off `main` (`refactor/web-app-bootstrap`)
- [x] No secrets or env files included
- [x] Scope limited to web app bootstrap shell and document persistence fix
