### PR TITLE
build(deps): fix dependabot alerts for ws and js-yaml

### DIFF
--- a/patches/front-matter@4.0.2.patch
+++ b/patches/front-matter@4.0.2.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index 1111111..2222222 100644
+--- a/index.js
++++ b/index.js
+@@ -59,7 +59,7 @@ function parse (string, allowUnsafe) {
+     }
+   }
+ 
+-  var loader = allowUnsafe ? parser.load : parser.safeLoad
++  var loader = parser.load
+   var yaml = match[match.length - 1].replace(/^\s+|\s+$/g, '')
+   var attributes = loader(yaml) || {}
+   var body = string.replace(match[0], '')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   glob@^11: ^11.1.0
   inflight: npm:@hishprorg/voluptates-laborum@^2.0.0
   ini: '>=7.0.0'
+  js-yaml: ^4.2.0
   jsdom>undici: ^7.25.0
   lodash-es: ^4.18.1
   markdown-it: ^14.2.0
@@ -43,11 +44,12 @@ overrides:
   undici@^7: ^8.4.1
   uuid: ^14.0.0
   workbox-build>source-map: 0.7.4
-  ws@<8.20.1: ^8.21.0
+  ws@<8.21.0: ^8.21.0
   yauzl: ^3.4.0
 
 patchedDependencies:
   '@codemirror/view@6.43.1': 57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f
+  front-matter@4.0.2: 0b8ab26732d017d28a51b74567fc5a3e349276cd9e94bd77d6885e88af9a887b
   juice@12.1.1: dcd1f89cb59a233375a0b488e0c0fd2c299ff1c4ef138410f7c3018f3a25186d
 
 importers:
@@ -346,7 +348,7 @@ importers:
         version: 0.8.3
       front-matter:
         specifier: ^4.0.2
-        version: 4.0.2
+        version: 4.0.2(patch_hash=0b8ab26732d017d28a51b74567fc5a3e349276cd9e94bd77d6885e88af9a887b)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -2846,9 +2848,6 @@ packages:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -3982,11 +3981,6 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -4658,10 +4652,6 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -6121,9 +6111,6 @@ packages:
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -6919,8 +6906,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7755,7 +7742,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       wrangler: 4.100.0(@cloudflare/workers-types@4.20260615.1)
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9871,10 +9858,6 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -11093,8 +11076,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
-  esprima@4.0.1: {}
-
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -11318,9 +11299,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  front-matter@4.0.2:
+  front-matter@4.0.2(patch_hash=0b8ab26732d017d28a51b74567fc5a3e349276cd9e94bd77d6885e88af9a887b):
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
 
   fs-constants@1.0.0:
     optional: true
@@ -11712,11 +11693,6 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -12469,7 +12445,7 @@ snapshots:
       sharp: 0.34.5
       undici: 8.5.0
       workerd: 1.20260611.1
-      ws: 8.20.1
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -13503,8 +13479,6 @@ snapshots:
     dependencies:
       through: 2.3.8
 
-  sprintf-js@1.0.3: {}
-
   statuses@2.0.2: {}
 
   streamsearch@1.1.0: {}
@@ -14344,7 +14318,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ overrides:
   glob@^11: ^11.1.0
   inflight: npm:@hishprorg/voluptates-laborum@^2.0.0
   ini: '>=7.0.0'
+  js-yaml: ^4.2.0
   jsdom>undici: ^7.25.0
   lodash-es: ^4.18.1
   markdown-it: ^14.2.0
@@ -47,7 +48,7 @@ overrides:
   undici@^7: ^8.4.1
   uuid: ^14.0.0
   workbox-build>source-map: 0.7.4
-  ws@<8.20.1: ^8.21.0
+  ws@<8.21.0: ^8.21.0
   yauzl: ^3.4.0
 
 allowBuilds:
@@ -63,6 +64,7 @@ allowBuilds:
 
 patchedDependencies:
   '@codemirror/view@6.43.1': patches/@codemirror__view@6.43.1.patch
+  front-matter@4.0.2: patches/front-matter@4.0.2.patch
   juice@12.1.1: patches/juice@12.1.1.patch
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
## Summary

Fix two open Dependabot security alerts:

- **ws** (CVE-2026-48779, high): extend pnpm override to `ws@<8.21.0: ^8.21.0` so transitive deps (`miniflare`, `@cloudflare/vite-plugin`) resolve to `8.21.0` instead of vulnerable `8.20.1`.
- **js-yaml** (CVE-2026-53550, medium): add `js-yaml: ^4.2.0` override and patch `front-matter@4.0.2` to use `parser.load` (js-yaml 4 removed `safeLoad`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic / UI
- [ ] Documentation
- [x] Workflow / CI / build
- [ ] Other

## Test Procedure

- [x] `pnpm install` succeeds and lockfile resolves `ws@8.21.0` and `js-yaml@4.2.0`
- [x] Smoke test: `front-matter` parses YAML front matter correctly with patched `js-yaml` 4.x

## Pre-flight Checklist

- [x] Changes are focused on dependency security fixes only
- [x] No secrets or credentials included
- [ ] CI checks pass (pending)
