### PR TITLE
fix(web): export PNG when preview panel is hidden

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,7 @@
     "hono": "^4.12.25"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260615.1",
+    "@cloudflare/workers-types": "4.20260616.1",
     "@types/node": "^25.9.3",
     "typescript": "~6.0.3",
     "wrangler": "^4.100.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.40.2",
-    "@cloudflare/workers-types": "^4.20260615.1",
+    "@cloudflare/workers-types": "^4.20260616.1",
     "@md/config": "workspace:*",
     "@tailwindcss/postcss": "^4.3.1",
     "@tailwindcss/vite": "^4.3.1",

--- a/apps/web/src/stores/export.ts
+++ b/apps/web/src/stores/export.ts
@@ -1,12 +1,11 @@
-import { toPng } from 'html-to-image'
 import {
   downloadMD,
   exportHTML,
   exportPDF,
+  exportPNG,
   exportPureHTML,
   getHtmlContent,
 } from '@/utils/export-content'
-import { downloadFile, sanitizeTitle } from '@/utils/shared-helpers'
 import { usePostStore } from './post'
 import { useUIStore } from './ui'
 
@@ -45,46 +44,10 @@ export const useExportStore = defineStore(`export`, () => {
     if (!currentPost)
       return
 
-    const el = document.querySelector<HTMLElement>(`#output-wrapper>.preview`)
-    if (!el)
-      return
-
-    // 添加临时样式：禁用代码块滚动，启用换行，隐藏仅用于预览的 UI 覆盖层
-    const style = document.createElement('style')
-    style.textContent = `
-      .diagram-download-bar { display: none !important; }
-      .preview pre.code__pre,
-      .preview .hljs.code__pre,
-      .preview pre.code__pre > code,
-      .preview .hljs.code__pre > code,
-      .preview .code-scroll,
-      .preview pre section,
-      .preview code section {
-        overflow: visible !important;
-      }
-      .preview pre.code__pre > code,
-      .preview .code-scroll,
-      .preview .code-scroll > div {
-        white-space: pre-wrap !important;
-        word-break: break-all !important;
-        min-width: auto !important;
-      }
-    `
-    document.head.appendChild(style)
-
-    try {
-      await new Promise(resolve => setTimeout(resolve, 100)) // brief delay for style application
-      const url = await toPng(el, {
-        backgroundColor: uiStore.isDark ? `` : `#fff`,
-        skipFonts: true,
-        pixelRatio: Math.max(window.devicePixelRatio || 1, 2),
-        style: { margin: `0` },
-      })
-      downloadFile(url, `${sanitizeTitle(currentPost.title)}.png`, `image/png`)
-    }
-    finally {
-      style.remove()
-    }
+    await exportPNG(currentPost.title, {
+      isDark: uiStore.isDark,
+      previewDevice: uiStore.previewDevice,
+    })
   }
 
   // 导出编辑器内容为 PDF

--- a/apps/web/src/utils/export-content.ts
+++ b/apps/web/src/utils/export-content.ts
@@ -1,4 +1,5 @@
 import { markedAlert, MDKatex } from '@md/core'
+import { toPng } from 'html-to-image'
 import { Marked } from 'marked'
 import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from './preview-ready'
 import { downloadFile, sanitizeTitle } from './shared-helpers'
@@ -195,6 +196,191 @@ export async function exportPDF(title: string = `untitled`) {
 
   // 兜底：如果 onload/onerror 都未触发，5 秒后强制清理
   setTimeout(removeIframe, 5000)
+}
+
+const PNG_CAPTURE_STYLES = `
+  .diagram-download-bar { display: none !important; }
+  .preview pre.code__pre,
+  .preview .hljs.code__pre,
+  .preview pre.code__pre > code,
+  .preview .hljs.code__pre > code,
+  .preview .code-scroll,
+  .preview pre section,
+  .preview code section {
+    overflow: visible !important;
+  }
+  .preview pre.code__pre > code,
+  .preview .code-scroll,
+  .preview .code-scroll > div {
+    white-space: pre-wrap !important;
+    word-break: break-all !important;
+    min-width: auto !important;
+  }
+`
+
+const OFFSCREEN_NIGHT_PREVIEW_CSS = `
+  .output_night .preview {
+    background-color: #191919;
+    box-shadow: 0 0 70px rgba(0, 0, 0, 0.3);
+  }
+`
+
+function delay(ms: number) {
+  return new Promise<void>(resolve => window.setTimeout(resolve, ms))
+}
+
+function isCapturable(el: HTMLElement): boolean {
+  const rect = el.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+
+/** 将隐藏或折叠的预览区临时移到视口外可见位置，便于 html-to-image 截图 */
+function revealPreviewForCapture(target: HTMLElement, fallbackWidth: string): () => void {
+  const saved: Array<{ el: HTMLElement, cssText: string }> = []
+  let node: HTMLElement | null = target
+
+  while (node && node !== document.body) {
+    const rect = node.getBoundingClientRect()
+    const computed = getComputedStyle(node)
+    const needsFix = computed.display === `none`
+      || computed.visibility === `hidden`
+      || rect.width === 0
+
+    if (needsFix) {
+      saved.push({ el: node, cssText: node.style.cssText })
+      node.style.setProperty(`display`, `block`, `important`)
+      node.style.setProperty(`visibility`, `visible`, `important`)
+      node.style.position = `fixed`
+      node.style.left = `-99999px`
+      node.style.top = `0`
+      node.style.zIndex = `-1`
+      node.style.pointerEvents = `none`
+      node.style.overflow = `visible`
+      node.style.height = `auto`
+      node.style.maxHeight = `none`
+      node.style.minWidth = `0`
+      node.style.flex = `none`
+      if (rect.width === 0)
+        node.style.width = fallbackWidth
+    }
+
+    node = node.parentElement
+  }
+
+  if (!isCapturable(target)) {
+    saved.push({ el: target, cssText: target.style.cssText })
+    target.style.width = fallbackWidth
+    target.style.margin = `0`
+  }
+
+  return () => {
+    for (const { el, cssText } of saved)
+      el.style.cssText = cssText
+  }
+}
+
+/** 预览区未挂载时，克隆 #output 到离屏容器再截图 */
+async function createOffScreenPreviewElement(
+  previewDevice: `desktop` | `mobile`,
+): Promise<{ el: HTMLElement, cleanup: () => void } | null> {
+  const output = document.getElementById(`output`)
+  if (!output)
+    return null
+
+  const outputWrapper = document.getElementById(`output-wrapper`)
+  const isNight = outputWrapper?.classList.contains(`output_night`) ?? false
+  const width = previewDevice === `mobile` ? `375px` : `750px`
+  const stylesToAdd = await getStylesToAdd()
+
+  const host = document.createElement(`div`)
+  host.setAttribute(`data-png-export-host`, ``)
+  host.style.cssText = `position:fixed;left:-99999px;top:0;z-index:-1;visibility:visible;pointer-events:none;`
+  host.innerHTML = [
+    `<style>${SHARE_SHELL_VARS_CSS}</style>`,
+    `<style>${OFFSCREEN_NIGHT_PREVIEW_CSS}</style>`,
+    stylesToAdd,
+  ].join(``)
+
+  const wrapper = document.createElement(`div`)
+  wrapper.className = isNight ? `output_night` : ``
+  wrapper.style.width = width
+
+  const preview = document.createElement(`div`)
+  preview.className = `preview border-x shadow-xl mx-auto`
+  preview.style.width = width
+  preview.style.margin = `0`
+
+  const content = output.cloneNode(true) as HTMLElement
+  content.removeAttribute(`id`)
+  content.style.width = `100%`
+  content.querySelectorAll(`.diagram-download-bar`).forEach(el => el.remove())
+  stripUnresolvedAsyncPlaceholders(content)
+
+  preview.appendChild(content)
+  wrapper.appendChild(preview)
+  host.appendChild(wrapper)
+  document.body.appendChild(host)
+
+  return {
+    el: preview,
+    cleanup: () => host.remove(),
+  }
+}
+
+/**
+ * 导出 PNG 卡片图片
+ * 预览区关闭时通过离屏渲染截图，避免 html-to-image 对 display:none 元素截出空白图
+ */
+export async function exportPNG(
+  title: string = `untitled`,
+  options: { isDark: boolean, previewDevice: `desktop` | `mobile` },
+) {
+  await waitForPreviewReady()
+
+  const fallbackWidth = options.previewDevice === `mobile` ? `375px` : `750px`
+  const livePreview = document.querySelector<HTMLElement>(`#output-wrapper>.preview`)
+
+  let captureEl: HTMLElement | null = livePreview
+  let restoreVisibility: (() => void) | null = null
+  let cleanupOffScreen: (() => void) | null = null
+
+  if (captureEl && !isCapturable(captureEl)) {
+    restoreVisibility = revealPreviewForCapture(captureEl, fallbackWidth)
+    await delay(100)
+  }
+
+  if (!captureEl || !isCapturable(captureEl)) {
+    restoreVisibility?.()
+    restoreVisibility = null
+
+    const offScreen = await createOffScreenPreviewElement(options.previewDevice)
+    if (!offScreen)
+      return
+
+    captureEl = offScreen.el
+    cleanupOffScreen = offScreen.cleanup
+    await delay(100)
+  }
+
+  const style = document.createElement(`style`)
+  style.textContent = PNG_CAPTURE_STYLES
+  document.head.appendChild(style)
+
+  try {
+    await delay(100)
+    const url = await toPng(captureEl, {
+      backgroundColor: options.isDark ? `` : `#fff`,
+      skipFonts: true,
+      pixelRatio: Math.max(window.devicePixelRatio || 1, 2),
+      style: { margin: `0` },
+    })
+    downloadFile(url, `${sanitizeTitle(title)}.png`, `image/png`)
+  }
+  finally {
+    style.remove()
+    restoreVisibility?.()
+    cleanupOffScreen?.()
+  }
 }
 
 export function solveWeChatImage(container?: HTMLElement) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ importers:
         version: 4.12.25
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 4.20260615.1
-        version: 4.20260615.1
+        specifier: 4.20260616.1
+        version: 4.20260616.1
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
@@ -108,7 +108,7 @@ importers:
         version: 6.0.3
       wrangler:
         specifier: ^4.100.0
-        version: 4.100.0(@cloudflare/workers-types@4.20260615.1)
+        version: 4.100.0(@cloudflare/workers-types@4.20260616.1)
 
   apps/utools: {}
 
@@ -250,10 +250,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.40.2
-        version: 1.40.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1))
+        version: 1.40.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260616.1))
       '@cloudflare/workers-types':
-        specifier: ^4.20260615.1
-        version: 4.20260615.1
+        specifier: ^4.20260616.1
+        version: 4.20260616.1
       '@md/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -328,7 +328,7 @@ importers:
         version: 3.3.5(typescript@6.0.3)
       wrangler:
         specifier: ^4.100.0
-        version: 4.100.0(@cloudflare/workers-types@4.20260615.1)
+        version: 4.100.0(@cloudflare/workers-types@4.20260616.1)
       wxt:
         specifier: ^0.20.26
         version: 0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(less@4.6.6)(rolldown@1.0.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -954,8 +954,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260615.1':
-    resolution: {integrity: sha512-fGOiTwoLj/8bU8mj3VAfa1EULx4ceZhDwnjvY+afDBlSXI9pvY7PE9t62rGEhJjbAOGd7i5WUDun0eZCWBDrzg==}
+  '@cloudflare/workers-types@4.20260616.1':
+    resolution: {integrity: sha512-AHyA0NC2/gNOHiMN6vzS25xenMaQ0XTzfw+MUQSQHXQDjLldxCBwjjtbNfKhBg540qGXIEx31kM1+L84GyECJw==}
 
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
@@ -3659,8 +3659,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.372:
-    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+  electron-to-chromium@1.5.373:
+    resolution: {integrity: sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -7735,13 +7735,13 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260611.1
 
-  '@cloudflare/vite-plugin@1.40.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1))':
+  '@cloudflare/vite-plugin@1.40.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260616.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)
       miniflare: 4.20260611.0
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      wrangler: 4.100.0(@cloudflare/workers-types@4.20260615.1)
+      wrangler: 4.100.0(@cloudflare/workers-types@4.20260616.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -7763,7 +7763,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260615.1': {}
+  '@cloudflare/workers-types@4.20260616.1': {}
 
   '@codemirror/autocomplete@6.20.3':
     dependencies:
@@ -10013,7 +10013,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.37
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.372
+      electron-to-chromium: 1.5.373
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -10676,7 +10676,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.372: {}
+  electron-to-chromium@1.5.373: {}
 
   emoji-regex@10.6.0: {}
 
@@ -14281,7 +14281,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260611.1
       '@cloudflare/workerd-windows-64': 1.20260611.1
 
-  wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1):
+  wrangler@4.100.0(@cloudflare/workers-types@4.20260616.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)
@@ -14292,7 +14292,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260611.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260615.1
+      '@cloudflare/workers-types': 4.20260616.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Summary

- Fix blank PNG export when the preview panel is closed or collapsed by capturing via off-screen reveal or a cloned preview container with theme styles
- Wait for async preview content (Mermaid, KaTeX, etc.) before PNG capture, matching HTML/PDF export behavior
- Bump `@cloudflare/workers-types` to `4.20260616.1` in `@md/web` and `@md/api`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic / UI
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [x] `pnpm run type-check` passes
- [ ] Switch to edit-only mode (preview hidden), export `.png` — image contains rendered content instead of a blank file
- [ ] With preview open, export `.png` — output unchanged from before
- [ ] Export `.png` with Mermaid or KaTeX content — async blocks appear in the image

## Pre-flight Checklist

- [x] Commit messages follow Conventional Commits (English)
- [x] Changes are on a feature branch, not `main`
- [x] No secrets or credentials included
- [x] Pre-commit lint hook passed
