### PR TITLE
feat(collab): add cloud collaboration with document-scoped styles

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -7,6 +7,7 @@ doocs/md 的后端 API，基于 **Cloudflare Workers + Hono + D1**，提供 GitH
 - GitHub OAuth 登录，签发自有 JWT（HS256，有效期 30 天）
 - 文章与偏好设置的增量同步（`/sync/pull`、`/sync/push`）
 - **预览分享**：登录用户可将编辑器预览快照发布为只读链接（`/share` → `GET /s/:id`），支持访问密码，默认 1 天过期
+- **云端协作**：登录用户可创建协作文档，邀请他人按角色（`owner` / `editor` / `viewer`）共同编辑正文与文档级样式（`/collab`）
 - **免费 / Pro 套餐**：Pro 支持更高同步频率；免费版限 30 次/小时，Pro 限 300 次/小时
 - **爱发电 Pro 开通**：Webhook 自动激活 + 订单号手动激活
 - 冲突策略：**last-write-wins**（按 `updateDatetime`），软删除墓碑保证删除可传播
@@ -30,6 +31,16 @@ doocs/md 的后端 API，基于 **Cloudflare Workers + Hono + D1**，提供 GitH
 - `DELETE /share/:id` 取消分享（需登录 + Pro；链接立即失效）
 - `GET  /s/:shareId` 只读分享页（有密码时需先解锁）
 - `POST /s/:shareId/unlock` 校验分享密码并写入访问 Cookie
+- `GET  /collab` 列出当前用户参与的协作文档
+- `POST /collab` 创建协作文档（含正文 + `CollabStyleBundle` 样式包）
+- `GET  /collab/:id` 文档详情与成员列表
+- `DELETE /collab/:id` 软删除（owner）
+- `GET  /collab/:id/pull?since=<ms>` 增量拉取
+- `POST /collab/:id/push` 推送正文/样式变更（LWW，`editor`+）
+- `POST /collab/:id/invite` 生成邀请链接（owner）
+- `POST /collab/invites/:token/accept` 接受邀请（需登录）
+- `GET  /collab/:id/members` 成员列表（owner）
+- `PATCH /collab/:id/members/:userId` 修改角色或移除成员（owner）
 - `POST /webhooks/afdian` 爱发电订单 Webhook
 - `POST /upload` 默认图床上传（GitHub 或 R2，由服务端 `UPLOAD_BACKEND` 配置）
 

--- a/apps/api/migrations/0004_collab.sql
+++ b/apps/api/migrations/0004_collab.sql
@@ -1,0 +1,48 @@
+-- 协作文档：正文 + 文档级样式包
+CREATE TABLE IF NOT EXISTS collab_documents (
+  id                  TEXT PRIMARY KEY,
+  owner_user_id       TEXT NOT NULL,
+  source_post_id      TEXT,
+  title               TEXT NOT NULL DEFAULT '',
+  content             TEXT NOT NULL DEFAULT '',
+  style               TEXT NOT NULL DEFAULT '{}',
+  content_updated_at  INTEGER NOT NULL,
+  style_updated_at    INTEGER NOT NULL,
+  history             TEXT NOT NULL DEFAULT '[]',
+  created_at          INTEGER NOT NULL,
+  server_updated_at   INTEGER NOT NULL,
+  deleted             INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_collab_documents_owner
+  ON collab_documents (owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_collab_documents_cursor
+  ON collab_documents (server_updated_at);
+
+-- 协作成员
+CREATE TABLE IF NOT EXISTS collab_members (
+  document_id  TEXT NOT NULL,
+  user_id      TEXT NOT NULL,
+  role         TEXT NOT NULL,
+  joined_at    INTEGER NOT NULL,
+  PRIMARY KEY (document_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_collab_members_user
+  ON collab_members (user_id);
+
+-- 邀请链接
+CREATE TABLE IF NOT EXISTS collab_invites (
+  token        TEXT PRIMARY KEY,
+  document_id  TEXT NOT NULL,
+  role         TEXT NOT NULL,
+  created_by   TEXT NOT NULL,
+  expires_at   INTEGER,
+  max_uses     INTEGER,
+  use_count    INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_collab_invites_document
+  ON collab_invites (document_id);

--- a/apps/api/src/collab-db.ts
+++ b/apps/api/src/collab-db.ts
@@ -1,0 +1,421 @@
+import type {
+  CollabDocument,
+  CollabHistoryEntry,
+  CollabInviteRole,
+  CollabListItem,
+  CollabMember,
+  CollabRole,
+  CollabStyleBundle,
+} from './collab-types'
+import { defaultCollabStyleBundle, parseCollabStyleBundle } from './collab-style'
+
+interface CollabDocumentRow {
+  id: string
+  owner_user_id: string
+  source_post_id: string | null
+  title: string
+  content: string
+  style: string
+  content_updated_at: number
+  style_updated_at: number
+  history: string
+  created_at: number
+  server_updated_at: number
+  deleted: number
+}
+
+interface CollabInviteRow {
+  token: string
+  document_id: string
+  role: string
+  created_by: string
+  expires_at: number | null
+  max_uses: number | null
+  use_count: number
+  created_at: number
+}
+
+function parseHistory(raw: string): CollabHistoryEntry[] {
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  }
+  catch {
+    return []
+  }
+}
+
+function rowToDocument(row: CollabDocumentRow): CollabDocument {
+  return {
+    id: row.id,
+    ownerUserId: row.owner_user_id,
+    sourcePostId: row.source_post_id,
+    title: row.title,
+    content: row.content,
+    style: parseCollabStyleBundle(row.style) ?? defaultCollabStyleBundle(),
+    contentUpdatedAt: row.content_updated_at,
+    styleUpdatedAt: row.style_updated_at,
+    history: parseHistory(row.history),
+    createdAt: row.created_at,
+    updatedAt: row.server_updated_at,
+    deleted: row.deleted === 1,
+  }
+}
+
+export async function getMemberRole(
+  db: D1Database,
+  documentId: string,
+  userId: string,
+): Promise<CollabRole | null> {
+  const row = await db
+    .prepare(`SELECT role FROM collab_members WHERE document_id = ? AND user_id = ?`)
+    .bind(documentId, userId)
+    .first<{ role: string }>()
+  if (!row)
+    return null
+  if (row.role === `owner` || row.role === `editor` || row.role === `viewer`)
+    return row.role
+  return null
+}
+
+export async function getCollabDocumentRow(
+  db: D1Database,
+  documentId: string,
+): Promise<CollabDocumentRow | null> {
+  return db
+    .prepare(`SELECT * FROM collab_documents WHERE id = ?`)
+    .bind(documentId)
+    .first<CollabDocumentRow>()
+}
+
+export async function getCollabDocument(
+  db: D1Database,
+  documentId: string,
+): Promise<CollabDocument | null> {
+  const row = await getCollabDocumentRow(db, documentId)
+  return row ? rowToDocument(row) : null
+}
+
+export async function listCollabDocumentsForUser(
+  db: D1Database,
+  userId: string,
+): Promise<CollabListItem[]> {
+  const result = await db
+    .prepare(
+      `SELECT d.id, d.title, d.content_updated_at, d.style_updated_at, d.server_updated_at,
+              m.role, u.login AS owner_login
+       FROM collab_members m
+       JOIN collab_documents d ON d.id = m.document_id
+       JOIN users u ON u.id = d.owner_user_id
+       WHERE m.user_id = ? AND d.deleted = 0
+       ORDER BY d.server_updated_at DESC`,
+    )
+    .bind(userId)
+    .all<{
+    id: string
+    title: string
+    content_updated_at: number
+    style_updated_at: number
+    server_updated_at: number
+    role: string
+    owner_login: string
+  }>()
+
+  return (result.results ?? []).map(row => ({
+    id: row.id,
+    title: row.title,
+    role: row.role as CollabRole,
+    ownerLogin: row.owner_login,
+    contentUpdatedAt: row.content_updated_at,
+    styleUpdatedAt: row.style_updated_at,
+    updatedAt: row.server_updated_at,
+  }))
+}
+
+export async function listCollabMembers(
+  db: D1Database,
+  documentId: string,
+): Promise<CollabMember[]> {
+  const result = await db
+    .prepare(
+      `SELECT m.user_id, m.role, m.joined_at, u.login, u.name, u.avatar
+       FROM collab_members m
+       JOIN users u ON u.id = m.user_id
+       WHERE m.document_id = ?
+       ORDER BY CASE m.role WHEN 'owner' THEN 0 WHEN 'editor' THEN 1 ELSE 2 END, m.joined_at ASC`,
+    )
+    .bind(documentId)
+    .all<{
+    user_id: string
+    role: string
+    joined_at: number
+    login: string
+    name: string | null
+    avatar: string | null
+  }>()
+
+  return (result.results ?? []).map(row => ({
+    userId: row.user_id,
+    login: row.login,
+    name: row.name,
+    avatar: row.avatar,
+    role: row.role as CollabRole,
+    joinedAt: row.joined_at,
+  }))
+}
+
+export async function insertCollabDocument(
+  db: D1Database,
+  input: {
+    id: string
+    ownerUserId: string
+    sourcePostId: string | null
+    title: string
+    content: string
+    style: CollabStyleBundle
+    now: number
+  },
+): Promise<CollabDocument> {
+  const history: CollabHistoryEntry[] = []
+  await db
+    .prepare(
+      `INSERT INTO collab_documents
+         (id, owner_user_id, source_post_id, title, content, style,
+          content_updated_at, style_updated_at, history, created_at, server_updated_at, deleted)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    )
+    .bind(
+      input.id,
+      input.ownerUserId,
+      input.sourcePostId,
+      input.title,
+      input.content,
+      JSON.stringify(input.style),
+      input.now,
+      input.now,
+      JSON.stringify(history),
+      input.now,
+      input.now,
+    )
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO collab_members (document_id, user_id, role, joined_at)
+       VALUES (?, ?, 'owner', ?)`,
+    )
+    .bind(input.id, input.ownerUserId, input.now)
+    .run()
+
+  const doc = await getCollabDocument(db, input.id)
+  if (!doc)
+    throw new Error(`collab_insert_failed`)
+  return doc
+}
+
+export async function pushCollabDocument(
+  db: D1Database,
+  documentId: string,
+  input: {
+    title?: string
+    content?: string
+    contentUpdatedAt?: number
+    style?: CollabStyleBundle
+    styleUpdatedAt?: number
+  },
+): Promise<{ document: CollabDocument, contentAccepted: boolean, styleAccepted: boolean, cursor: number }> {
+  const row = await getCollabDocumentRow(db, documentId)
+  if (!row || row.deleted === 1)
+    throw new Error(`not_found`)
+
+  const now = Date.now()
+  let contentAccepted = false
+  let styleAccepted = false
+
+  let title = row.title
+  let content = row.content
+  let contentUpdatedAt = row.content_updated_at
+  let style = row.style
+  let styleUpdatedAt = row.style_updated_at
+
+  if (input.content !== undefined && input.contentUpdatedAt !== undefined) {
+    if (input.contentUpdatedAt > row.content_updated_at) {
+      content = input.content
+      contentUpdatedAt = input.contentUpdatedAt
+      contentAccepted = true
+      if (input.title !== undefined)
+        title = input.title
+    }
+  }
+  else if (input.title !== undefined && input.contentUpdatedAt !== undefined) {
+    if (input.contentUpdatedAt > row.content_updated_at) {
+      title = input.title
+      contentUpdatedAt = input.contentUpdatedAt
+      contentAccepted = true
+    }
+  }
+
+  if (input.style !== undefined && input.styleUpdatedAt !== undefined) {
+    if (input.styleUpdatedAt > row.style_updated_at) {
+      style = JSON.stringify(input.style)
+      styleUpdatedAt = input.styleUpdatedAt
+      styleAccepted = true
+    }
+  }
+
+  if (contentAccepted || styleAccepted) {
+    await db
+      .prepare(
+        `UPDATE collab_documents SET
+           title = ?,
+           content = ?,
+           style = ?,
+           content_updated_at = ?,
+           style_updated_at = ?,
+           server_updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(title, content, style, contentUpdatedAt, styleUpdatedAt, now, documentId)
+      .run()
+  }
+
+  const document = await getCollabDocument(db, documentId)
+  if (!document)
+    throw new Error(`not_found`)
+
+  return {
+    document,
+    contentAccepted,
+    styleAccepted,
+    cursor: contentAccepted || styleAccepted ? now : row.server_updated_at,
+  }
+}
+
+export async function pullCollabDocument(
+  db: D1Database,
+  documentId: string,
+  since: number,
+): Promise<{ document: CollabDocument | null, cursor: number }> {
+  const row = await getCollabDocumentRow(db, documentId)
+  if (!row || row.deleted === 1)
+    throw new Error(`not_found`)
+
+  const cursor = Math.max(since, row.server_updated_at)
+  if (row.server_updated_at <= since)
+    return { document: null, cursor }
+
+  return { document: rowToDocument(row), cursor: row.server_updated_at }
+}
+
+export async function softDeleteCollabDocument(
+  db: D1Database,
+  documentId: string,
+): Promise<void> {
+  const now = Date.now()
+  await db
+    .prepare(`UPDATE collab_documents SET deleted = 1, server_updated_at = ? WHERE id = ?`)
+    .bind(now, documentId)
+    .run()
+}
+
+export async function insertCollabInvite(
+  db: D1Database,
+  input: {
+    token: string
+    documentId: string
+    role: CollabInviteRole
+    createdBy: string
+    expiresAt: number | null
+    maxUses: number | null
+    now: number
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO collab_invites
+         (token, document_id, role, created_by, expires_at, max_uses, use_count, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?)`,
+    )
+    .bind(
+      input.token,
+      input.documentId,
+      input.role,
+      input.createdBy,
+      input.expiresAt,
+      input.maxUses,
+      input.now,
+    )
+    .run()
+}
+
+export async function getCollabInvite(
+  db: D1Database,
+  token: string,
+): Promise<CollabInviteRow | null> {
+  return db
+    .prepare(`SELECT * FROM collab_invites WHERE token = ?`)
+    .bind(token)
+    .first<CollabInviteRow>()
+}
+
+export async function acceptCollabInvite(
+  db: D1Database,
+  token: string,
+  userId: string,
+): Promise<{ documentId: string, role: CollabRole }> {
+  const invite = await getCollabInvite(db, token)
+  if (!invite)
+    throw new Error(`invite_not_found`)
+
+  const now = Date.now()
+  if (invite.expires_at != null && invite.expires_at < now)
+    throw new Error(`invite_expired`)
+
+  if (invite.max_uses != null && invite.use_count >= invite.max_uses)
+    throw new Error(`invite_exhausted`)
+
+  const doc = await getCollabDocumentRow(db, invite.document_id)
+  if (!doc || doc.deleted === 1)
+    throw new Error(`not_found`)
+
+  const existingRole = await getMemberRole(db, invite.document_id, userId)
+  if (existingRole) {
+    return { documentId: invite.document_id, role: existingRole }
+  }
+
+  const role = invite.role === `editor` ? `editor` : `viewer`
+
+  await db.batch([
+    db
+      .prepare(
+        `INSERT INTO collab_members (document_id, user_id, role, joined_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .bind(invite.document_id, userId, role, now),
+    db
+      .prepare(`UPDATE collab_invites SET use_count = use_count + 1 WHERE token = ?`)
+      .bind(token),
+  ])
+
+  return { documentId: invite.document_id, role }
+}
+
+export async function updateCollabMemberRole(
+  db: D1Database,
+  documentId: string,
+  targetUserId: string,
+  role: CollabInviteRole | null,
+): Promise<void> {
+  if (role === null) {
+    await db
+      .prepare(`DELETE FROM collab_members WHERE document_id = ? AND user_id = ? AND role != 'owner'`)
+      .bind(documentId, targetUserId)
+      .run()
+    return
+  }
+
+  await db
+    .prepare(`UPDATE collab_members SET role = ? WHERE document_id = ? AND user_id = ? AND role != 'owner'`)
+    .bind(role, documentId, targetUserId)
+    .run()
+}

--- a/apps/api/src/collab-style.ts
+++ b/apps/api/src/collab-style.ts
@@ -1,0 +1,61 @@
+import type { CollabStyleBundle } from './collab-types'
+
+const MAX_STYLE_BYTES = 512 * 1024
+
+export function defaultCollabStyleBundle(): CollabStyleBundle {
+  return {
+    version: 1,
+    theme: `default`,
+    themeSettings: {},
+    layout: {
+      useIndent: false,
+      useJustify: false,
+      isCiteStatus: false,
+      isCountStatus: false,
+      legend: ``,
+      previewWidth: `max-w-[750px]`,
+    },
+    customCss: {
+      activeTabId: `default`,
+      tabs: [{ id: `default`, title: `默认`, content: `` }],
+    },
+    customComponents: [],
+  }
+}
+
+export function parseCollabStyleBundle(raw: string | null | undefined): CollabStyleBundle | null {
+  if (!raw?.trim())
+    return null
+  try {
+    const parsed = JSON.parse(raw) as CollabStyleBundle
+    if (parsed?.version !== 1 || typeof parsed.theme !== `string`)
+      return null
+    if (!parsed.themeSettings || typeof parsed.themeSettings !== `object`)
+      return null
+    if (!parsed.layout || typeof parsed.layout !== `object`)
+      return null
+    if (!parsed.customCss || !Array.isArray(parsed.customCss.tabs))
+      return null
+    return parsed
+  }
+  catch {
+    return null
+  }
+}
+
+export function validateCollabStyleBundle(input: unknown): { ok: true, style: CollabStyleBundle } | { ok: false, error: string } {
+  if (!input || typeof input !== `object`)
+    return { ok: false, error: `invalid_style` }
+
+  const serialized = JSON.stringify(input)
+  if (serialized.length > MAX_STYLE_BYTES)
+    return { ok: false, error: `style_too_large` }
+
+  const style = parseCollabStyleBundle(serialized)
+  if (!style)
+    return { ok: false, error: `invalid_style` }
+
+  return { ok: true, style }
+}
+
+export { MAX_STYLE_BYTES }

--- a/apps/api/src/collab-types.ts
+++ b/apps/api/src/collab-types.ts
@@ -1,0 +1,130 @@
+/** 协作 API 契约（与 packages/shared/src/types/collab.ts 保持一致） */
+
+export type CollabRole = `owner` | `editor` | `viewer`
+export type CollabInviteRole = `editor` | `viewer`
+
+export interface CollabCustomCssTab {
+  id: string
+  title: string
+  content: string
+}
+
+export interface CollabStyleLayout {
+  useIndent: boolean
+  useJustify: boolean
+  isCiteStatus: boolean
+  isCountStatus: boolean
+  legend: string
+  previewWidth: string
+}
+
+export interface CollabStyleBundle {
+  version: 1
+  theme: string
+  themeSettings: Record<string, unknown>
+  layout: CollabStyleLayout
+  customCss: {
+    activeTabId: string
+    tabs: CollabCustomCssTab[]
+  }
+  customComponents?: unknown[]
+}
+
+export interface CollabHistoryEntry {
+  datetime: string
+  content: string
+}
+
+export interface CollabDocument {
+  id: string
+  ownerUserId: string
+  sourcePostId: string | null
+  title: string
+  content: string
+  style: CollabStyleBundle
+  contentUpdatedAt: number
+  styleUpdatedAt: number
+  history: CollabHistoryEntry[]
+  createdAt: number
+  updatedAt: number
+  deleted: boolean
+}
+
+export interface CollabListItem {
+  id: string
+  title: string
+  role: CollabRole
+  ownerLogin: string
+  contentUpdatedAt: number
+  styleUpdatedAt: number
+  updatedAt: number
+}
+
+export interface CollabMember {
+  userId: string
+  login: string
+  name: string | null
+  avatar: string | null
+  role: CollabRole
+  joinedAt: number
+}
+
+export interface CreateCollabRequest {
+  sourcePostId?: string
+  title: string
+  content: string
+  style: CollabStyleBundle
+}
+
+export interface CreateCollabResponse {
+  id: string
+  document: CollabDocument
+}
+
+export interface CollabInviteRequest {
+  role: CollabInviteRole
+  expiresInHours?: number
+  maxUses?: number
+}
+
+export interface CollabInviteResponse {
+  token: string
+  role: CollabInviteRole
+  expiresAt: number | null
+  maxUses: number | null
+  inviteUrl: string
+}
+
+export interface AcceptCollabInviteResponse {
+  documentId: string
+  role: CollabRole
+}
+
+export interface CollabPushRequest {
+  title?: string
+  content?: string
+  contentUpdatedAt?: number
+  style?: CollabStyleBundle
+  styleUpdatedAt?: number
+}
+
+export interface CollabPushResponse {
+  document: CollabDocument
+  cursor: number
+  merged: {
+    contentAccepted: boolean
+    styleAccepted: boolean
+  }
+}
+
+export interface CollabPullResponse {
+  document: CollabDocument | null
+  role: CollabRole
+  cursor: number
+}
+
+export interface CollabDetailResponse {
+  document: CollabDocument
+  role: CollabRole
+  members: CollabMember[]
+}

--- a/apps/api/src/collab.ts
+++ b/apps/api/src/collab.ts
@@ -1,0 +1,386 @@
+import type { Context } from 'hono'
+import type {
+  AcceptCollabInviteResponse,
+  CollabDetailResponse,
+  CollabInviteRequest,
+  CollabInviteResponse,
+  CollabPullResponse,
+  CollabPushRequest,
+  CollabPushResponse,
+  CollabRole,
+  CreateCollabRequest,
+  CreateCollabResponse,
+} from './collab-types'
+import type { Env } from './types'
+import {
+  acceptCollabInvite,
+  getCollabDocument,
+  getMemberRole,
+  insertCollabDocument,
+  insertCollabInvite,
+  listCollabDocumentsForUser,
+  listCollabMembers,
+  pullCollabDocument,
+  pushCollabDocument,
+  softDeleteCollabDocument,
+  updateCollabMemberRole,
+} from './collab-db'
+import { validateCollabStyleBundle } from './collab-style'
+import { defaultOrigin } from './origin'
+
+type CollabContext = Context<{ Bindings: Env, Variables: { userId: string } }>
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function parseDocumentId(value: string | undefined): string | null {
+  if (!value || !UUID_RE.test(value))
+    return null
+  return value
+}
+
+function parseInviteToken(value: string | undefined): string | null {
+  if (!value || value.length < 16)
+    return null
+  return value
+}
+
+const MAX_CONTENT_BYTES = 2 * 1024 * 1024
+const MAX_TITLE_LENGTH = 256
+const MAX_POST_ID_LENGTH = 64
+const DEFAULT_INVITE_HOURS = 24 * 7
+
+function canWrite(role: CollabRole): boolean {
+  return role === `owner` || role === `editor`
+}
+
+async function requireMembership(
+  c: CollabContext,
+  documentId: string,
+): Promise<{ role: CollabRole } | Response> {
+  const role = await getMemberRole(c.env.DB, documentId, c.get(`userId`))
+  if (!role)
+    return c.json({ error: `forbidden` }, 403)
+  return { role }
+}
+
+function parseTitle(value: unknown): string | null {
+  if (typeof value !== `string`)
+    return null
+  const title = value.trim()
+  if (!title || title.length > MAX_TITLE_LENGTH)
+    return null
+  return title
+}
+
+function parseContent(value: unknown): string | null {
+  if (typeof value !== `string`)
+    return null
+  if (value.length > MAX_CONTENT_BYTES)
+    return null
+  return value
+}
+
+function parseSourcePostId(value: unknown): string | null {
+  if (value === undefined || value === null)
+    return null
+  if (typeof value !== `string`)
+    return null
+  const id = value.trim()
+  if (!id || id.length > MAX_POST_ID_LENGTH)
+    return null
+  return id
+}
+
+function buildInviteUrl(c: CollabContext, token: string): string {
+  const base = defaultOrigin(c.env)
+  const url = new URL(base)
+  url.searchParams.set(`collab_invite`, token)
+  return url.toString()
+}
+
+export async function listCollabHandler(c: CollabContext) {
+  const items = await listCollabDocumentsForUser(c.env.DB, c.get(`userId`))
+  return c.json({ documents: items })
+}
+
+export async function createCollabHandler(c: CollabContext) {
+  let body: CreateCollabRequest
+  try {
+    body = await c.req.json<CreateCollabRequest>()
+  }
+  catch {
+    return c.json({ error: `invalid_body` }, 400)
+  }
+
+  const title = parseTitle(body.title)
+  const content = parseContent(body.content)
+  if (!title || content === null)
+    return c.json({ error: `invalid_document` }, 400)
+
+  const styleResult = validateCollabStyleBundle(body.style)
+  if (!styleResult.ok)
+    return c.json({ error: styleResult.error }, 400)
+
+  const now = Date.now()
+  const id = crypto.randomUUID()
+  const userId = c.get(`userId`)
+
+  const document = await insertCollabDocument(c.env.DB, {
+    id,
+    ownerUserId: userId,
+    sourcePostId: parseSourcePostId(body.sourcePostId),
+    title,
+    content,
+    style: styleResult.style,
+    now,
+  })
+
+  const response: CreateCollabResponse = { id, document }
+  return c.json(response, 201)
+}
+
+export async function getCollabHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  if (!documentId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  const document = await getCollabDocument(c.env.DB, documentId)
+  if (!document || document.deleted)
+    return c.json({ error: `not_found` }, 404)
+
+  const members = await listCollabMembers(c.env.DB, documentId)
+  const response: CollabDetailResponse = {
+    document,
+    role: membership.role,
+    members,
+  }
+  return c.json(response)
+}
+
+export async function deleteCollabHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  if (!documentId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  if (membership.role !== `owner`)
+    return c.json({ error: `forbidden` }, 403)
+
+  await softDeleteCollabDocument(c.env.DB, documentId)
+  return c.json({ ok: true })
+}
+
+export async function pullCollabHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  if (!documentId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  const sinceRaw = c.req.query(`since`)
+  const since = Number.parseInt(sinceRaw ?? `0`, 10)
+  const cursor = Number.isFinite(since) && since > 0 ? since : 0
+
+  try {
+    const { document, cursor: newCursor } = await pullCollabDocument(c.env.DB, documentId, cursor)
+    const response: CollabPullResponse = {
+      document,
+      role: membership.role,
+      cursor: newCursor,
+    }
+    return c.json(response)
+  }
+  catch {
+    return c.json({ error: `not_found` }, 404)
+  }
+}
+
+export async function pushCollabHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  if (!documentId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  if (!canWrite(membership.role))
+    return c.json({ error: `forbidden` }, 403)
+
+  let body: CollabPushRequest
+  try {
+    body = await c.req.json<CollabPushRequest>()
+  }
+  catch {
+    return c.json({ error: `invalid_body` }, 400)
+  }
+
+  if (body.content !== undefined) {
+    const content = parseContent(body.content)
+    if (content === null)
+      return c.json({ error: `invalid_content` }, 400)
+    body.content = content
+  }
+
+  if (body.title !== undefined) {
+    const title = parseTitle(body.title)
+    if (!title)
+      return c.json({ error: `invalid_title` }, 400)
+    body.title = title
+  }
+
+  if (body.style !== undefined) {
+    const styleResult = validateCollabStyleBundle(body.style)
+    if (!styleResult.ok)
+      return c.json({ error: styleResult.error }, 400)
+    body.style = styleResult.style
+  }
+
+  try {
+    const result = await pushCollabDocument(c.env.DB, documentId, body)
+    const response: CollabPushResponse = {
+      document: result.document,
+      cursor: result.cursor,
+      merged: {
+        contentAccepted: result.contentAccepted,
+        styleAccepted: result.styleAccepted,
+      },
+    }
+    return c.json(response)
+  }
+  catch (e) {
+    if (e instanceof Error && e.message === `not_found`)
+      return c.json({ error: `not_found` }, 404)
+    throw e
+  }
+}
+
+export async function createInviteHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  if (!documentId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  if (membership.role !== `owner`)
+    return c.json({ error: `forbidden` }, 403)
+
+  let body: CollabInviteRequest
+  try {
+    body = await c.req.json<CollabInviteRequest>()
+  }
+  catch {
+    return c.json({ error: `invalid_body` }, 400)
+  }
+
+  if (body.role !== `editor` && body.role !== `viewer`)
+    return c.json({ error: `invalid_role` }, 400)
+
+  const now = Date.now()
+  const hours = body.expiresInHours ?? DEFAULT_INVITE_HOURS
+  const expiresAt = hours > 0 ? now + hours * 60 * 60 * 1000 : null
+  const maxUses = body.maxUses ?? null
+  const token = crypto.randomUUID().replace(/-/g, ``)
+
+  await insertCollabInvite(c.env.DB, {
+    token,
+    documentId,
+    role: body.role,
+    createdBy: c.get(`userId`),
+    expiresAt,
+    maxUses: maxUses != null && maxUses > 0 ? maxUses : null,
+    now,
+  })
+
+  const response: CollabInviteResponse = {
+    token,
+    role: body.role,
+    expiresAt,
+    maxUses: maxUses != null && maxUses > 0 ? maxUses : null,
+    inviteUrl: buildInviteUrl(c, token),
+  }
+  return c.json(response)
+}
+
+export async function acceptInviteHandler(c: CollabContext) {
+  const token = parseInviteToken(c.req.param(`token`))
+  if (!token)
+    return c.json({ error: `invalid_token` }, 400)
+  try {
+    const result = await acceptCollabInvite(c.env.DB, token, c.get(`userId`))
+    const response: AcceptCollabInviteResponse = {
+      documentId: result.documentId,
+      role: result.role,
+    }
+    return c.json(response)
+  }
+  catch (e) {
+    if (e instanceof Error) {
+      if (e.message === `invite_not_found`)
+        return c.json({ error: `invite_not_found` }, 404)
+      if (e.message === `invite_expired`)
+        return c.json({ error: `invite_expired` }, 410)
+      if (e.message === `invite_exhausted`)
+        return c.json({ error: `invite_exhausted` }, 410)
+      if (e.message === `not_found`)
+        return c.json({ error: `not_found` }, 404)
+    }
+    throw e
+  }
+}
+
+export async function listMembersHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  if (!documentId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  if (membership.role !== `owner`)
+    return c.json({ error: `forbidden` }, 403)
+
+  const members = await listCollabMembers(c.env.DB, documentId)
+  return c.json({ members })
+}
+
+export async function updateMemberHandler(c: CollabContext) {
+  const documentId = parseDocumentId(c.req.param(`id`))
+  const targetUserId = parseDocumentId(c.req.param(`userId`))
+  if (!documentId || !targetUserId)
+    return c.json({ error: `invalid_id` }, 400)
+  const membership = await requireMembership(c, documentId)
+  if (membership instanceof Response)
+    return membership
+
+  if (membership.role !== `owner`)
+    return c.json({ error: `forbidden` }, 403)
+
+  if (targetUserId === c.get(`userId`))
+    return c.json({ error: `cannot_modify_self` }, 400)
+
+  const targetRole = await getMemberRole(c.env.DB, documentId, targetUserId)
+  if (!targetRole || targetRole === `owner`)
+    return c.json({ error: `not_found` }, 404)
+
+  let body: { role?: `editor` | `viewer` | null }
+  try {
+    body = await c.req.json<{ role?: `editor` | `viewer` | null }>()
+  }
+  catch {
+    return c.json({ error: `invalid_body` }, 400)
+  }
+
+  if (body.role !== undefined && body.role !== `editor` && body.role !== `viewer` && body.role !== null)
+    return c.json({ error: `invalid_role` }, 400)
+
+  await updateCollabMemberRole(c.env.DB, documentId, targetUserId, body.role ?? null)
+  const members = await listCollabMembers(c.env.DB, documentId)
+  return c.json({ members })
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,18 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { activateHandler } from './activate'
 import { authMiddleware, authRoutes, meHandler } from './auth'
+import {
+  acceptInviteHandler,
+  createCollabHandler,
+  createInviteHandler,
+  deleteCollabHandler,
+  getCollabHandler,
+  listCollabHandler,
+  listMembersHandler,
+  pullCollabHandler,
+  pushCollabHandler,
+  updateMemberHandler,
+} from './collab'
 import { isAllowedOrigin } from './origin'
 import { createShareHandler, deleteShareHandler, listSharesHandler, unlockShareHandler, viewShareHandler } from './share'
 import { SHARE_FAVICON_PATH } from './share-head'
@@ -16,7 +28,7 @@ const app = new Hono<{ Bindings: Env, Variables: { userId: string } }>()
 app.use(`*`, async (c, next) => {
   const handler = cors({
     origin: origin => (isAllowedOrigin(c.env, origin) ? origin : null),
-    allowMethods: [`GET`, `POST`, `DELETE`, `OPTIONS`],
+    allowMethods: [`GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS`],
     allowHeaders: [`Authorization`, `Content-Type`],
     credentials: true,
     maxAge: 86400,
@@ -50,6 +62,16 @@ api.post(`/sync/activate`, activateHandler)
 api.get(`/share`, listSharesHandler)
 api.post(`/share`, createShareHandler)
 api.delete(`/share/:id`, deleteShareHandler)
+api.get(`/collab`, listCollabHandler)
+api.post(`/collab`, createCollabHandler)
+api.get(`/collab/:id`, getCollabHandler)
+api.delete(`/collab/:id`, deleteCollabHandler)
+api.get(`/collab/:id/pull`, pullCollabHandler)
+api.post(`/collab/:id/push`, pushCollabHandler)
+api.post(`/collab/:id/invite`, createInviteHandler)
+api.post(`/collab/invites/:token/accept`, acceptInviteHandler)
+api.get(`/collab/:id/members`, listMembersHandler)
+api.patch(`/collab/:id/members/:userId`, updateMemberHandler)
 
 app.route(`/`, api)
 

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -9,6 +9,8 @@ const { isDark } = storeToRefs(uiStore)
 
 usePlatformEnv()
 useAccountSyncBootstrap()
+useCollabBootstrap()
+useCollabStyleWatcher()
 useDeepLinkImport()
 </script>
 

--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -3,6 +3,7 @@ import { Check, CheckSquare, Download, Edit3, Ellipsis, Eye, Plus, X } from '@lu
 import { exportMergedTheme } from '@md/core'
 import { themeMap, themeOptionsMap } from '@md/shared'
 import { copyPlain } from '@/lib/browser/clipboard'
+import { useCollabStore } from '@/stores/collab'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCssEditorStore } from '@/stores/cssEditor'
 import { useEditorStore } from '@/stores/editor'
@@ -11,6 +12,8 @@ import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 
 const confirmStore = useConfirmStore()
+const collabStore = useCollabStore()
+const { isReadOnly: isCollabReadOnly } = storeToRefs(collabStore)
 const cssEditorStore = useCssEditorStore()
 const uiStore = useUIStore()
 const renderStore = useRenderStore()
@@ -359,6 +362,7 @@ function exportCurrentTheme() {
     :class="{
       'fixed top-0 right-0 w-full h-full z-100 bg-background border-l shadow-lg mobile-css-editor': isMobile,
       'animate': isMobile && enableAnimation,
+      'pointer-events-none opacity-60': isCollabReadOnly,
     }"
     :style="isMobile ? { transform: uiStore.isShowCssEditor ? 'translateX(0)' : 'translateX(100%)' } : undefined"
   >

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -15,6 +15,7 @@ import { useSlashCommand } from '@/composables/useSlashCommand'
 import { contentHasMath, loadMathJax, MATHJAX_READY_EVENT } from '@/lib/preview/mathjax'
 import { fileUpload } from '@/services/upload'
 import { store } from '@/storage'
+import { useCollabStore } from '@/stores/collab'
 import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
@@ -24,6 +25,7 @@ import { useUIStore } from '@/stores/ui'
 const SidebarAIToolbar = defineAsyncComponent(() => import('@/components/ai/SidebarAIToolbar.vue'))
 
 const editorStore = useEditorStore()
+const collabStore = useCollabStore()
 const postStore = usePostStore()
 const renderStore = useRenderStore()
 const themeStore = useThemeStore()
@@ -61,6 +63,7 @@ const {
   enableImageReupload,
   viewMode,
 } = storeToRefs(uiStore)
+const { isCollabMode, isReadOnly } = storeToRefs(collabStore)
 
 const { toggleShowUploadImgDialog } = uiStore
 
@@ -68,7 +71,10 @@ const showEditor = computed(() => viewMode.value !== `preview`)
 
 const codeMirrorView = shallowRef<EditorView | null>(null)
 const themeCompartment = new Compartment()
+const editableCompartment = new Compartment()
 const changeTimer = ref<ReturnType<typeof setTimeout>>()
+
+let lastCollabEditorContent = ``
 
 const editorRef = useTemplateRef<HTMLDivElement>(`editorRef`)
 const codeMirrorWrapper = useTemplateRef<HTMLDivElement>(`codeMirrorWrapper`)
@@ -447,6 +453,7 @@ function createFormTextArea(dom: HTMLDivElement) {
         onReplace: openReplaceWithSelection,
       }),
       themeCompartment.of(theme(isDark.value)),
+      editableCompartment.of(EditorView.editable.of(!isReadOnly.value)),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           clearTimeout(changeTimer.value)
@@ -498,6 +505,15 @@ function commitEditorContentToPost() {
     return
 
   const value = codeMirrorView.value.state.doc.toString()
+
+  if (isCollabMode.value) {
+    if (value !== lastCollabEditorContent) {
+      lastCollabEditorContent = value
+      collabStore.notifyContentChanged()
+    }
+    return
+  }
+
   const post = posts.value[currentPostIndex.value]
   if (!post || value === post.content)
     return
@@ -547,6 +563,14 @@ watch(isDark, () => {
   editorRefresh()
 })
 
+watch(isReadOnly, (readonly) => {
+  if (!codeMirrorView.value)
+    return
+  codeMirrorView.value.dispatch({
+    effects: editableCompartment.reconfigure(EditorView.editable.of(!readonly)),
+  })
+})
+
 function syncEditorToPostContent(content: string) {
   if (!codeMirrorView.value)
     return
@@ -571,6 +595,8 @@ function syncEditorToPostContent(content: string) {
 }
 
 watch(currentPostIndex, () => {
+  if (isCollabMode.value)
+    return
   const post = posts.value[currentPostIndex.value]
   if (!post)
     return
@@ -581,7 +607,7 @@ watch(currentPostIndex, () => {
 watch(
   () => currentPost.value?.content,
   (content) => {
-    if (content == null)
+    if (isCollabMode.value || content == null)
       return
     syncEditorToPostContent(content)
   },

--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -20,12 +20,15 @@ import PickColors from 'vue-pick-colors'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { useEditorRefresh } from '@/composables/useEditorRefresh'
+import { useCollabStore } from '@/stores/collab'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCssEditorStore } from '@/stores/cssEditor'
 import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 
 const confirmStore = useConfirmStore()
+const collabStore = useCollabStore()
+const { isReadOnly: isCollabReadOnly } = storeToRefs(collabStore)
 const cssEditorStore = useCssEditorStore()
 const uiStore = useUIStore()
 const themeStore = useThemeStore()
@@ -217,7 +220,7 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
   >
     <div
       class="h-full space-y-4 overflow-auto p-4"
-      :class="{ 'pt-0': isMobile }"
+      :class="{ 'pt-0': isMobile, 'pointer-events-none opacity-60': isCollabReadOnly }"
     >
       <!-- 移动端标题栏 -->
       <div v-if="isMobile" class="sticky top-0 z-10 -mx-4 mb-4 border-b bg-background px-4 pb-3 pt-[max(0.5rem,env(safe-area-inset-top,0px))]">

--- a/apps/web/src/components/editor/editor-header/CollabBanner.vue
+++ b/apps/web/src/components/editor/editor-header/CollabBanner.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { Loader2, Users, X } from '@lucide/vue'
+import { storeToRefs } from 'pinia'
+
+const collabStore = useCollabStore()
+const uiStore = useUIStore()
+
+const { isCollabMode, role, document, isReadOnly, status, lastError } = storeToRefs(collabStore)
+
+const roleLabel: Record<string, string> = {
+  owner: `所有者`,
+  editor: `编辑者`,
+  viewer: `查看者`,
+}
+
+function openManage() {
+  uiStore.toggleShowCollabDialog(true)
+}
+
+async function handleExit() {
+  await collabStore.exitCollab()
+  toast.success(`已退出协作`)
+}
+</script>
+
+<template>
+  <div
+    v-if="isCollabMode"
+    class="flex flex-wrap items-center justify-between gap-2 border-b border-primary/20 bg-primary/5 px-4 py-2 text-sm"
+  >
+    <div class="flex min-w-0 flex-1 items-center gap-2">
+      <Users class="size-4 shrink-0 text-primary" />
+      <span class="truncate font-medium">
+        协作中：{{ document?.title?.trim() || '无标题' }}
+      </span>
+      <span class="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
+        {{ roleLabel[role ?? ''] ?? role }}
+        <template v-if="isReadOnly"> · 只读</template>
+      </span>
+      <Loader2 v-if="status === 'syncing'" class="size-3.5 animate-spin text-muted-foreground" />
+      <span v-else-if="status === 'error'" class="text-xs text-destructive" :title="lastError">
+        同步失败
+      </span>
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      <Button size="sm" variant="outline" @click="openManage">
+        管理
+      </Button>
+      <Button size="sm" variant="ghost" @click="handleExit">
+        <X class="mr-1 size-3.5" />
+        退出
+      </Button>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/components/editor/editor-header/CollabDialog.vue
+++ b/apps/web/src/components/editor/editor-header/CollabDialog.vue
@@ -1,0 +1,368 @@
+<script setup lang="ts">
+import type { CollabListItem } from '@md/shared/types'
+import { Check, Copy, Loader2, LogIn, LogOut, RefreshCw, Trash2, UserPlus, Users } from '@lucide/vue'
+import { storeToRefs } from 'pinia'
+import { computed, ref, watch } from 'vue'
+import CloudPanelCard from '@/components/editor/editor-header/cloud-panel/CloudPanelCard.vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import CloudPanelState from '@/components/editor/editor-header/cloud-panel/CloudPanelState.vue'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ApiError } from '@/services/account/client'
+import { isCollabConfigured, isCollabUiEnabled } from '@/services/collab/client'
+import { useAuthStore } from '@/stores/auth'
+import { useCollabStore } from '@/stores/collab'
+import { useConfirmStore } from '@/stores/confirm'
+import { useEditorStore } from '@/stores/editor'
+import { usePostStore } from '@/stores/post'
+import { useUIStore } from '@/stores/ui'
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const authStore = useAuthStore()
+const collabStore = useCollabStore()
+const postStore = usePostStore()
+const editorStore = useEditorStore()
+const uiStore = useUIStore()
+const confirmStore = useConfirmStore()
+
+const { isLoggedIn } = storeToRefs(authStore)
+const { currentPost } = storeToRefs(postStore)
+const { list, members, isOwner, isCollabMode, activeId, status } = storeToRefs(collabStore)
+
+const activeTab = ref<`create` | `open` | `manage`>(`create`)
+const isLoadingList = ref(false)
+const isSubmitting = ref(false)
+const inviteRole = ref<`editor` | `viewer`>(`editor`)
+const inviteUrl = ref(``)
+const copiedInvite = ref(false)
+const errorMessage = ref(``)
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (value: boolean) => emit(`update:open`, value),
+})
+
+const roleLabel: Record<string, string> = {
+  owner: `所有者`,
+  editor: `编辑者`,
+  viewer: `查看者`,
+}
+
+watch(() => props.open, async (open) => {
+  if (!open)
+    return
+  activeTab.value = isCollabMode.value ? `manage` : `create`
+  inviteUrl.value = ``
+  errorMessage.value = ``
+  if (isLoggedIn.value) {
+    isLoadingList.value = true
+    try {
+      await collabStore.loadList()
+    }
+    finally {
+      isLoadingList.value = false
+    }
+  }
+})
+
+function openAccountDialog() {
+  dialogOpen.value = false
+  uiStore.toggleShowAccountDialog(true)
+}
+
+function formatTitle(title: string): string {
+  return title.trim() || `无标题`
+}
+
+async function handleCreate() {
+  if (!currentPost.value)
+    return
+  isSubmitting.value = true
+  errorMessage.value = ``
+  try {
+    editorStore.flushContentToPostStore()
+    const content = editorStore.getContent()
+    await collabStore.createFromCurrentPost(
+      currentPost.value.id,
+      currentPost.value.title,
+      content,
+    )
+    dialogOpen.value = false
+    toast.success(`已创建协作文档`)
+  }
+  catch (e) {
+    errorMessage.value = e instanceof ApiError ? e.message : String(e)
+  }
+  finally {
+    isSubmitting.value = false
+  }
+}
+
+async function handleOpen(item: CollabListItem) {
+  isSubmitting.value = true
+  errorMessage.value = ``
+  try {
+    await collabStore.openDocument(item.id)
+    dialogOpen.value = false
+    toast.success(`已进入协作：${formatTitle(item.title)}`)
+  }
+  catch (e) {
+    errorMessage.value = e instanceof ApiError ? e.message : String(e)
+  }
+  finally {
+    isSubmitting.value = false
+  }
+}
+
+async function handleCreateInvite() {
+  if (!activeId.value)
+    return
+  isSubmitting.value = true
+  errorMessage.value = ``
+  try {
+    await collabStore.refreshMembers()
+    inviteUrl.value = await collabStore.createInvite(inviteRole.value)
+    copiedInvite.value = false
+  }
+  catch (e) {
+    errorMessage.value = e instanceof ApiError ? e.message : String(e)
+  }
+  finally {
+    isSubmitting.value = false
+  }
+}
+
+async function copyInviteUrl() {
+  if (!inviteUrl.value)
+    return
+  await navigator.clipboard.writeText(inviteUrl.value)
+  copiedInvite.value = true
+  toast.success(`邀请链接已复制`)
+}
+
+function confirmExit() {
+  confirmStore.confirm({
+    title: `退出协作`,
+    description: `退出后将恢复你的个人样式设置。未同步的修改会先尝试保存。`,
+    confirmText: `退出协作`,
+    onConfirm: async () => {
+      await collabStore.exitCollab()
+      dialogOpen.value = false
+      toast.success(`已退出协作`)
+    },
+  })
+}
+
+function confirmDelete() {
+  confirmStore.confirm({
+    title: `删除协作文档`,
+    description: `删除后所有成员将无法继续访问，此操作不可恢复。`,
+    confirmText: `删除`,
+    destructive: true,
+    onConfirm: async () => {
+      await collabStore.deleteCollab()
+      dialogOpen.value = false
+      toast.success(`已删除协作文档`)
+    },
+  })
+}
+
+function confirmRemoveMember(userId: string, login: string) {
+  confirmStore.confirm({
+    title: `移除成员`,
+    description: `确定将 ${login} 移出协作吗？`,
+    confirmText: `移除`,
+    destructive: true,
+    onConfirm: async () => {
+      await collabStore.removeMember(userId)
+      toast.success(`已移除成员`)
+    },
+  })
+}
+</script>
+
+<template>
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="云端协作"
+    description="邀请他人共同编辑正文与样式，需登录后使用。"
+    :icon="Users"
+    size="2xl"
+  >
+    <div class="space-y-4 p-4 sm:p-6">
+      <CloudPanelState
+        v-if="!isCollabUiEnabled() || !isCollabConfigured()"
+        :icon="Users"
+        title="协作未启用"
+        description="当前部署未配置协作服务。"
+        compact
+      />
+
+      <CloudPanelState
+        v-else-if="!isLoggedIn"
+        :icon="Users"
+        title="登录后使用协作"
+        description="使用 GitHub 账户登录，即可创建或加入协作文档。"
+        compact
+      >
+        <Button class="mt-4" @click="openAccountDialog">
+          <LogIn class="mr-2 size-4" />
+          去登录
+        </Button>
+      </CloudPanelState>
+
+      <template v-else>
+        <Alert v-if="errorMessage" variant="destructive">
+          <AlertDescription>{{ errorMessage }}</AlertDescription>
+        </Alert>
+
+        <Tabs v-model="activeTab" class="w-full">
+          <TabsList class="grid w-full grid-cols-3">
+            <TabsTrigger value="create">
+              发起协作
+            </TabsTrigger>
+            <TabsTrigger value="open">
+              我的协作
+            </TabsTrigger>
+            <TabsTrigger value="manage" :disabled="!isCollabMode">
+              管理
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="create" class="mt-4 space-y-4">
+            <CloudPanelCard title="从当前文章创建" description="将当前正文与样式快照发布为协作文档，成员可共同编辑。">
+              <p class="text-sm text-muted-foreground">
+                当前文章：{{ formatTitle(currentPost?.title ?? '') }}
+              </p>
+              <Button class="mt-4 w-full" :disabled="isSubmitting" @click="handleCreate">
+                <Loader2 v-if="isSubmitting" class="mr-2 size-4 animate-spin" />
+                <UserPlus v-else class="mr-2 size-4" />
+                创建协作文档
+              </Button>
+            </CloudPanelCard>
+          </TabsContent>
+
+          <TabsContent value="open" class="mt-4 space-y-3">
+            <div v-if="isLoadingList" class="flex justify-center py-8">
+              <Loader2 class="size-6 animate-spin text-muted-foreground" />
+            </div>
+            <CloudPanelState
+              v-else-if="!list.length"
+              :icon="Users"
+              title="暂无协作文档"
+              description="发起协作或接受邀请后，文档会显示在这里。"
+              compact
+            />
+            <div v-else class="space-y-2">
+              <button
+                v-for="item in list"
+                :key="item.id"
+                type="button"
+                class="flex w-full items-center justify-between rounded-lg border p-3 text-left transition-colors hover:bg-accent"
+                @click="handleOpen(item)"
+              >
+                <div>
+                  <div class="font-medium">
+                    {{ formatTitle(item.title) }}
+                  </div>
+                  <div class="text-xs text-muted-foreground">
+                    {{ roleLabel[item.role] ?? item.role }} · 所有者 {{ item.ownerLogin }}
+                  </div>
+                </div>
+                <Users class="size-4 shrink-0 text-muted-foreground" />
+              </button>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="manage" class="mt-4 space-y-4">
+            <CloudPanelCard v-if="isOwner" title="邀请协作者" description="生成邀请链接，对方登录后即可加入。">
+              <div class="space-y-3">
+                <div class="flex gap-2">
+                  <Button
+                    size="sm"
+                    :variant="inviteRole === 'editor' ? 'default' : 'outline'"
+                    @click="inviteRole = 'editor'"
+                  >
+                    编辑者
+                  </Button>
+                  <Button
+                    size="sm"
+                    :variant="inviteRole === 'viewer' ? 'default' : 'outline'"
+                    @click="inviteRole = 'viewer'"
+                  >
+                    查看者
+                  </Button>
+                </div>
+                <Button class="w-full" :disabled="isSubmitting" @click="handleCreateInvite">
+                  <Loader2 v-if="isSubmitting" class="mr-2 size-4 animate-spin" />
+                  <UserPlus v-else class="mr-2 size-4" />
+                  生成邀请链接
+                </Button>
+                <div v-if="inviteUrl" class="space-y-2">
+                  <Label>邀请链接</Label>
+                  <div class="flex gap-2">
+                    <Input :model-value="inviteUrl" readonly class="text-xs" />
+                    <Button size="icon" variant="outline" @click="copyInviteUrl">
+                      <Check v-if="copiedInvite" class="size-4" />
+                      <Copy v-else class="size-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CloudPanelCard>
+
+            <CloudPanelCard title="成员" description="当前协作文档的成员与权限。">
+              <ul class="space-y-2">
+                <li
+                  v-for="member in members"
+                  :key="member.userId"
+                  class="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                >
+                  <div>
+                    <span class="font-medium">{{ member.login }}</span>
+                    <span class="ml-2 text-muted-foreground">{{ roleLabel[member.role] }}</span>
+                  </div>
+                  <Button
+                    v-if="isOwner && member.role !== 'owner'"
+                    size="sm"
+                    variant="ghost"
+                    class="text-destructive"
+                    @click="confirmRemoveMember(member.userId, member.login)"
+                  >
+                    移除
+                  </Button>
+                </li>
+              </ul>
+            </CloudPanelCard>
+
+            <div class="flex flex-wrap gap-2">
+              <Button variant="outline" :disabled="status === 'syncing'" @click="collabStore.syncNow()">
+                <Loader2 v-if="status === 'syncing'" class="mr-2 size-4 animate-spin" />
+                <RefreshCw v-else class="mr-2 size-4" />
+                立即同步
+              </Button>
+              <Button variant="outline" @click="confirmExit">
+                <LogOut class="mr-2 size-4" />
+                退出协作
+              </Button>
+              <Button v-if="isOwner" variant="destructive" @click="confirmDelete">
+                <Trash2 class="mr-2 size-4" />
+                删除文档
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </template>
+    </div>
+  </CloudPanelDialog>
+</template>

--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Cloud, Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Share2, Upload } from '@lucide/vue'
+import { Cloud, Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Share2, Upload, Users } from '@lucide/vue'
+import { isCollabUiEnabled } from '@/services/collab/client'
 import { isShareUiEnabled } from '@/services/share/client'
 import { isSyncUiEnabled } from '@/services/sync/client'
 import { useEditorStore } from '@/stores/editor'
@@ -19,9 +20,10 @@ const exportStore = useExportStore()
 const uiStore = useUIStore()
 
 const { isOpenPostSlider, isOpenFolderPanel } = storeToRefs(uiStore)
-const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog, toggleShowEditorStateDialog, openShareDialog } = uiStore
+const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog, toggleShowCollabDialog, toggleShowEditorStateDialog, openShareDialog } = uiStore
 const showSyncUi = isSyncUiEnabled()
 const showShareUi = isShareUiEnabled()
+const showCollabUi = isCollabUiEnabled()
 
 function openEditorStateDialog() {
   toggleShowEditorStateDialog(true)
@@ -128,12 +130,17 @@ function exportEditorContent2PDF() {
         内容管理
       </MenubarItem>
 
-      <template v-if="showSyncUi || showShareUi">
+      <template v-if="showSyncUi || showShareUi || showCollabUi">
         <MenubarSeparator />
         <!-- 云同步 -->
         <MenubarItem v-if="showSyncUi" @click="toggleShowSyncDialog(true)">
           <Cloud class="mr-2 size-4" />
           云同步
+        </MenubarItem>
+        <!-- 云端协作 -->
+        <MenubarItem v-if="showCollabUi" @click="toggleShowCollabDialog(true)">
+          <Users class="mr-2 size-4" />
+          云端协作
         </MenubarItem>
         <!-- 分享预览 -->
         <MenubarItem v-if="showShareUi" @click="openShareDialog()">
@@ -226,12 +233,17 @@ function exportEditorContent2PDF() {
         内容管理
       </MenubarItem>
 
-      <template v-if="showSyncUi || showShareUi">
+      <template v-if="showSyncUi || showShareUi || showCollabUi">
         <MenubarSeparator />
         <!-- 云同步 -->
         <MenubarItem v-if="showSyncUi" @click="toggleShowSyncDialog(true)">
           <Cloud class="mr-2 size-4" />
           云同步
+        </MenubarItem>
+        <!-- 云端协作 -->
+        <MenubarItem v-if="showCollabUi" @click="toggleShowCollabDialog(true)">
+          <Users class="mr-2 size-4" />
+          云端协作
         </MenubarItem>
         <!-- 分享预览 -->
         <MenubarItem v-if="showShareUi" @click="openShareDialog()">

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Copy, Loader2, Menu, Palette } from '@lucide/vue'
+import { Copy, Loader2, Menu, Palette, Users } from '@lucide/vue'
 import { defineAsyncComponent } from 'vue'
 import { useEditorRefresh } from '@/composables/useEditorRefresh'
 import { generatePureHTML, processClipboardContent } from '@/services/export'
@@ -23,6 +23,8 @@ const MarkdownHelpDialog = defineAsyncComponent(() => import('./MarkdownHelpDial
 const AccountDialog = defineAsyncComponent(() => import('./AccountDialog.vue'))
 const SyncDialog = defineAsyncComponent(() => import('./SyncDialog.vue'))
 const ShareDialog = defineAsyncComponent(() => import('./ShareDialog.vue'))
+const CollabDialog = defineAsyncComponent(() => import('./CollabDialog.vue'))
+const CollabBanner = defineAsyncComponent(() => import('./CollabBanner.vue'))
 
 const editorStore = useEditorStore()
 const themeStore = useThemeStore()
@@ -34,7 +36,9 @@ const { editorRefresh } = useEditorRefresh()
 const { editor } = storeToRefs(editorStore)
 const { output } = storeToRefs(renderStore)
 const { primaryColor } = storeToRefs(themeStore)
-const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog, copyMode } = storeToRefs(uiStore)
+const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowCollabDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog, copyMode } = storeToRefs(uiStore)
+const collabStore = useCollabStore()
+const { isCollabMode } = storeToRefs(collabStore)
 
 const isCopying = ref(false)
 
@@ -225,6 +229,7 @@ function copyToWeChat() {
 </script>
 
 <template>
+  <CollabBanner />
   <header
     class="header-container h-15 flex flex-wrap items-center justify-between px-5 relative"
   >
@@ -278,6 +283,17 @@ function copyToWeChat() {
       <!-- 文章信息（移动端隐藏） -->
       <PostInfo class="hidden md:inline-flex" />
 
+      <!-- 协作 -->
+      <Button
+        v-if="isCollabMode"
+        variant="outline"
+        class="h-9"
+        @click="uiStore.toggleShowCollabDialog(true)"
+      >
+        <Users class="mr-2 h-4 w-4" />
+        <span class="hidden sm:inline">协作</span>
+      </Button>
+
       <!-- 样式面板 -->
       <Button
         variant="outline"
@@ -299,6 +315,7 @@ function copyToWeChat() {
   <AccountDialog v-if="isShowAccountDialog" v-model:open="isShowAccountDialog" />
   <SyncDialog v-if="isShowSyncDialog" v-model:open="isShowSyncDialog" />
   <ShareDialog v-if="isShowShareDialog" v-model:open="isShowShareDialog" />
+  <CollabDialog v-if="isShowCollabDialog" v-model:open="isShowCollabDialog" />
 </template>
 
 <style lang="less" scoped>

--- a/apps/web/src/composables/useCollabBootstrap.ts
+++ b/apps/web/src/composables/useCollabBootstrap.ts
@@ -1,0 +1,87 @@
+import { isCollabUiEnabled } from '@/services/collab/client'
+
+/** 处理协作深链：?collab_invite=TOKEN 或 ?collab=DOCUMENT_ID */
+export function useCollabBootstrap() {
+  const authStore = useAuthStore()
+  const collabStore = useCollabStore()
+  const uiStore = useUIStore()
+
+  onMounted(async () => {
+    if (!isCollabUiEnabled())
+      return
+
+    const params = new URLSearchParams(window.location.search)
+    const inviteToken = params.get(`collab_invite`)
+    const collabId = params.get(`collab`)
+
+    const cleanUrl = () => {
+      params.delete(`collab_invite`)
+      params.delete(`collab`)
+      const newSearch = params.toString()
+      const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : ``) + window.location.hash
+      window.history.replaceState({}, ``, newUrl)
+    }
+
+    if (inviteToken) {
+      cleanUrl()
+      if (!authStore.isLoggedIn) {
+        uiStore.pendingCollabInviteToken = inviteToken
+        uiStore.toggleShowAccountDialog(true)
+        return
+      }
+      try {
+        const documentId = await collabStore.acceptInvite(inviteToken)
+        await collabStore.openDocument(documentId)
+        toast.success(`已加入协作文档`)
+      }
+      catch (e) {
+        toast.error(`加入协作失败：${e instanceof Error ? e.message : String(e)}`)
+      }
+      return
+    }
+
+    if (collabId) {
+      cleanUrl()
+      if (!authStore.isLoggedIn) {
+        uiStore.pendingCollabDocumentId = collabId
+        uiStore.toggleShowAccountDialog(true)
+        return
+      }
+      try {
+        await collabStore.openDocument(collabId)
+      }
+      catch (e) {
+        toast.error(`打开协作失败：${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+  })
+
+  watch(() => authStore.isLoggedIn, async (loggedIn) => {
+    if (!loggedIn || !isCollabUiEnabled())
+      return
+
+    const inviteToken = uiStore.pendingCollabInviteToken
+    const collabId = uiStore.pendingCollabDocumentId
+
+    if (inviteToken) {
+      uiStore.pendingCollabInviteToken = null
+      try {
+        const documentId = await collabStore.acceptInvite(inviteToken)
+        await collabStore.openDocument(documentId)
+        toast.success(`已加入协作文档`)
+      }
+      catch (e) {
+        toast.error(`加入协作失败：${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+    else if (collabId) {
+      uiStore.pendingCollabDocumentId = null
+      try {
+        await collabStore.openDocument(collabId)
+      }
+      catch (e) {
+        toast.error(`打开协作失败：${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+  })
+}

--- a/apps/web/src/composables/useCollabStyleWatcher.ts
+++ b/apps/web/src/composables/useCollabStyleWatcher.ts
@@ -1,0 +1,51 @@
+import { collectCollabStyle } from '@/services/collab/style'
+
+/** 协作模式下监听样式变更并触发同步 */
+export function useCollabStyleWatcher() {
+  const collabStore = useCollabStore()
+  const themeStore = useThemeStore()
+  const cssEditorStore = useCssEditorStore()
+  const customComponentStore = useCustomComponentStore()
+
+  let lastStyleSnapshot = ``
+
+  function snapshot(): string {
+    return JSON.stringify(collectCollabStyle())
+  }
+
+  watch(
+    () => [
+      collabStore.isCollabMode,
+      themeStore.theme,
+      themeStore.themeSettings,
+      themeStore.isCiteStatus,
+      themeStore.isCountStatus,
+      themeStore.isUseIndent,
+      themeStore.isUseJustify,
+      themeStore.legend,
+      themeStore.previewWidth,
+      cssEditorStore.cssContentConfig,
+      customComponentStore.userComponents,
+    ],
+    () => {
+      if (!collabStore.isCollabMode || !collabStore.canWrite)
+        return
+
+      const current = snapshot()
+      if (current === lastStyleSnapshot)
+        return
+
+      const prev = lastStyleSnapshot
+      lastStyleSnapshot = current
+      if (!prev)
+        return
+
+      collabStore.notifyStyleChanged()
+    },
+    { deep: true },
+  )
+
+  watch(() => collabStore.isCollabMode, (active) => {
+    lastStyleSnapshot = active ? snapshot() : ``
+  })
+}

--- a/apps/web/src/services/collab/client.ts
+++ b/apps/web/src/services/collab/client.ts
@@ -1,0 +1,85 @@
+import type {
+  AcceptCollabInviteResponse,
+  CollabDetailResponse,
+  CollabInviteRequest,
+  CollabInviteResponse,
+  CollabListItem,
+  CollabMember,
+  CollabPullResponse,
+  CollabPushRequest,
+  CollabPushResponse,
+  CreateCollabRequest,
+  CreateCollabResponse,
+} from '@md/shared/types'
+import { MdApiClient } from '@/services/account/client'
+import { isAccountConfigured } from '@/services/account/config'
+
+export type {
+  AcceptCollabInviteResponse,
+  CollabDetailResponse,
+  CollabDocument,
+  CollabInviteRequest,
+  CollabInviteResponse,
+  CollabListItem,
+  CollabMember,
+  CollabPullResponse,
+  CollabPushRequest,
+  CollabPushResponse,
+  CollabRole,
+  CollabStyleBundle,
+  CreateCollabRequest,
+  CreateCollabResponse,
+} from '@md/shared/types'
+
+export function isCollabConfigured(): boolean {
+  return isAccountConfigured()
+}
+
+export function isCollabUiEnabled(): boolean {
+  const flag = import.meta.env.VITE_COLLAB_UI_ENABLED
+  if (flag === `false` || flag === `0`)
+    return false
+  return isCollabConfigured()
+}
+
+export class CollabClient extends MdApiClient {
+  list(): Promise<{ documents: CollabListItem[] }> {
+    return this.request(`GET`, `/collab`)
+  }
+
+  create(payload: CreateCollabRequest): Promise<CreateCollabResponse> {
+    return this.request(`POST`, `/collab`, payload)
+  }
+
+  get(id: string): Promise<CollabDetailResponse> {
+    return this.request(`GET`, `/collab/${id}`)
+  }
+
+  remove(id: string): Promise<{ ok: true }> {
+    return this.request(`DELETE`, `/collab/${id}`)
+  }
+
+  pull(id: string, since: number): Promise<CollabPullResponse> {
+    return this.request(`GET`, `/collab/${id}/pull?since=${since}`)
+  }
+
+  push(id: string, payload: CollabPushRequest): Promise<CollabPushResponse> {
+    return this.request(`POST`, `/collab/${id}/push`, payload)
+  }
+
+  invite(id: string, payload: CollabInviteRequest): Promise<CollabInviteResponse> {
+    return this.request(`POST`, `/collab/${id}/invite`, payload)
+  }
+
+  acceptInvite(token: string): Promise<AcceptCollabInviteResponse> {
+    return this.request(`POST`, `/collab/invites/${token}/accept`)
+  }
+
+  listMembers(id: string): Promise<{ members: CollabMember[] }> {
+    return this.request(`GET`, `/collab/${id}/members`)
+  }
+
+  updateMember(id: string, userId: string, role: `editor` | `viewer` | null): Promise<{ members: CollabMember[] }> {
+    return this.request(`PATCH`, `/collab/${id}/members/${userId}`, { role })
+  }
+}

--- a/apps/web/src/services/collab/style.ts
+++ b/apps/web/src/services/collab/style.ts
@@ -1,0 +1,135 @@
+import type { PerThemeSettingsMap, ThemeName } from '@md/shared/configs'
+import type { CollabStyleBundle, CustomComponentDef } from '@md/shared/types'
+import type { CssContentConfig } from '@/stores/cssEditor'
+import { storeToRefs } from 'pinia'
+import { useCssEditorStore } from '@/stores/cssEditor'
+import { useCustomComponentStore } from '@/stores/customComponent'
+import { useThemeStore } from '@/stores/theme'
+
+export interface PersonalStyleSnapshot {
+  theme: ThemeName
+  themeSettings: PerThemeSettingsMap
+  isCiteStatus: boolean
+  isCountStatus: boolean
+  isUseIndent: boolean
+  isUseJustify: boolean
+  legend: string
+  previewWidth: string
+  cssContentConfig: CssContentConfig
+  customComponents: CustomComponentDef[]
+}
+
+/** 从当前编辑器状态采集文档级样式包 */
+export function collectCollabStyle(): CollabStyleBundle {
+  const themeStore = useThemeStore()
+  const cssEditorStore = useCssEditorStore()
+  const customComponentStore = useCustomComponentStore()
+
+  const { theme, themeSettings, isCiteStatus, isCountStatus, isUseIndent, isUseJustify, legend, previewWidth } = storeToRefs(themeStore)
+  const { cssContentConfig } = storeToRefs(cssEditorStore)
+  const { userComponents } = storeToRefs(customComponentStore)
+
+  return {
+    version: 1,
+    theme: theme.value,
+    themeSettings: { ...themeSettings.value },
+    layout: {
+      useIndent: isUseIndent.value,
+      useJustify: isUseJustify.value,
+      isCiteStatus: isCiteStatus.value,
+      isCountStatus: isCountStatus.value,
+      legend: legend.value,
+      previewWidth: previewWidth.value,
+    },
+    customCss: {
+      activeTabId: cssContentConfig.value.active,
+      tabs: cssContentConfig.value.tabs.map(tab => ({
+        id: tab.id,
+        title: tab.title,
+        content: tab.content,
+      })),
+    },
+    customComponents: [...userComponents.value],
+  }
+}
+
+/** 保存个人账户样式快照（进入协作前） */
+export function snapshotPersonalStyle(): PersonalStyleSnapshot {
+  const themeStore = useThemeStore()
+  const cssEditorStore = useCssEditorStore()
+  const customComponentStore = useCustomComponentStore()
+
+  return {
+    theme: themeStore.theme,
+    themeSettings: { ...themeStore.themeSettings },
+    isCiteStatus: themeStore.isCiteStatus,
+    isCountStatus: themeStore.isCountStatus,
+    isUseIndent: themeStore.isUseIndent,
+    isUseJustify: themeStore.isUseJustify,
+    legend: themeStore.legend,
+    previewWidth: themeStore.previewWidth,
+    cssContentConfig: JSON.parse(JSON.stringify(cssEditorStore.cssContentConfig)),
+    customComponents: [...customComponentStore.userComponents],
+  }
+}
+
+/** 将个人账户样式快照写回 Store */
+export function restorePersonalStyle(snapshot: PersonalStyleSnapshot): void {
+  const themeStore = useThemeStore()
+  const cssEditorStore = useCssEditorStore()
+  const customComponentStore = useCustomComponentStore()
+
+  themeStore.theme = snapshot.theme
+  themeStore.themeSettings = snapshot.themeSettings
+  themeStore.isCiteStatus = snapshot.isCiteStatus
+  themeStore.isCountStatus = snapshot.isCountStatus
+  themeStore.isUseIndent = snapshot.isUseIndent
+  themeStore.isUseJustify = snapshot.isUseJustify
+  themeStore.legend = snapshot.legend
+  themeStore.previewWidth = snapshot.previewWidth
+  cssEditorStore.cssContentConfig = snapshot.cssContentConfig
+  customComponentStore.userComponents = snapshot.customComponents
+}
+
+/** 将协作文档样式包应用到 Store 并刷新预览 */
+export async function hydrateCollabStyle(style: CollabStyleBundle): Promise<void> {
+  const themeStore = useThemeStore()
+  const cssEditorStore = useCssEditorStore()
+  const customComponentStore = useCustomComponentStore()
+
+  themeStore.theme = style.theme
+  themeStore.themeSettings = { ...style.themeSettings }
+  themeStore.isUseIndent = style.layout.useIndent
+  themeStore.isUseJustify = style.layout.useJustify
+  themeStore.isCiteStatus = style.layout.isCiteStatus
+  themeStore.isCountStatus = style.layout.isCountStatus
+  themeStore.legend = style.layout.legend
+  themeStore.previewWidth = style.layout.previewWidth
+
+  const activeTab = style.customCss.tabs.find(t => t.id === style.customCss.activeTabId)
+    ?? style.customCss.tabs[0]
+
+  cssEditorStore.cssContentConfig = {
+    ...cssEditorStore.cssContentConfig,
+    active: activeTab?.id ?? style.customCss.activeTabId,
+    tabs: style.customCss.tabs.map(tab => ({
+      id: tab.id,
+      title: tab.title,
+      name: tab.title,
+      content: tab.content,
+      createDatetime: new Date(),
+      updateDatetime: new Date(),
+    })),
+  }
+
+  if (style.customComponents)
+    customComponentStore.userComponents = [...style.customComponents]
+
+  themeStore.updateCodeTheme()
+  await themeStore.applyCurrentTheme()
+}
+
+/** 比较样式包是否与当前 Store 状态一致 */
+export function collabStyleEquals(a: CollabStyleBundle, b: CollabStyleBundle): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}

--- a/apps/web/src/stores/collab.ts
+++ b/apps/web/src/stores/collab.ts
@@ -1,0 +1,318 @@
+import type {
+  CollabDocument,
+  CollabListItem,
+  CollabMember,
+  CollabRole,
+} from '@md/shared/types'
+import { useEditorRefresh } from '@/composables/useEditorRefresh'
+import { ApiError } from '@/services/account/client'
+import { CollabClient } from '@/services/collab/client'
+import {
+  collabStyleEquals,
+  collectCollabStyle,
+  hydrateCollabStyle,
+  restorePersonalStyle,
+  snapshotPersonalStyle,
+} from '@/services/collab/style'
+import { useAuthStore } from '@/stores/auth'
+import { useEditorStore } from '@/stores/editor'
+import { useThemeStore } from '@/stores/theme'
+
+const SYNC_DEBOUNCE_MS = 2000
+
+export const useCollabStore = defineStore(`collab`, () => {
+  const authStore = useAuthStore()
+  const editorStore = useEditorStore()
+  const { editorRefresh } = useEditorRefresh()
+
+  const client = new CollabClient(() => authStore.token)
+
+  const isCollabMode = ref(false)
+  const activeId = ref<string | null>(null)
+  const role = ref<CollabRole | null>(null)
+  const document = ref<CollabDocument | null>(null)
+  const members = ref<CollabMember[]>([])
+  const list = ref<CollabListItem[]>([])
+  const cursor = ref(0)
+  const status = ref<`idle` | `syncing` | `error`>(`idle`)
+  const lastError = ref(``)
+  const personalStyleSnapshot = ref<ReturnType<typeof snapshotPersonalStyle> | null>(null)
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+  let lastPushedStyle: ReturnType<typeof collectCollabStyle> | null = null
+  let lastPushedContent = ``
+
+  const isReadOnly = computed(() => role.value === `viewer`)
+  const canWrite = computed(() => role.value === `owner` || role.value === `editor`)
+  const isOwner = computed(() => role.value === `owner`)
+
+  function applyRemoteDocument(remote: CollabDocument, options?: { refreshEditor?: boolean }): void {
+    document.value = remote
+
+    const localContent = editorStore.getContent()
+    if (remote.content !== localContent && options?.refreshEditor !== false) {
+      editorStore.importContent(remote.content)
+      editorRefresh()
+    }
+
+    const currentStyle = collectCollabStyle()
+    if (!collabStyleEquals(currentStyle, remote.style)) {
+      void hydrateCollabStyle(remote.style).then(() => {
+        editorRefresh()
+      })
+    }
+
+    lastPushedContent = remote.content
+    lastPushedStyle = { ...remote.style }
+  }
+
+  async function loadList(): Promise<void> {
+    if (!authStore.isLoggedIn)
+      return
+    const result = await client.list()
+    list.value = result.documents
+  }
+
+  async function openDocument(id: string): Promise<void> {
+    if (!authStore.isLoggedIn)
+      throw new Error(`login_required`)
+
+    const detail = await client.get(id)
+    if (!personalStyleSnapshot.value && !isCollabMode.value)
+      personalStyleSnapshot.value = snapshotPersonalStyle()
+
+    isCollabMode.value = true
+    activeId.value = id
+    role.value = detail.role
+    members.value = detail.members
+    document.value = detail.document
+    cursor.value = detail.document.updatedAt
+
+    await hydrateCollabStyle(detail.document.style)
+    editorStore.importContent(detail.document.content)
+    editorRefresh()
+
+    lastPushedContent = detail.document.content
+    lastPushedStyle = { ...detail.document.style }
+
+    startPolling()
+  }
+
+  async function createFromCurrentPost(sourcePostId: string, title: string, content: string): Promise<string> {
+    const style = collectCollabStyle()
+    const result = await client.create({
+      sourcePostId,
+      title: title.trim() || `无标题`,
+      content,
+      style,
+    })
+    await loadList()
+    await openDocument(result.id)
+    return result.id
+  }
+
+  async function syncNow(): Promise<void> {
+    if (!isCollabMode.value || !activeId.value || !canWrite.value)
+      return
+
+    status.value = `syncing`
+    lastError.value = ``
+
+    try {
+      const pulled = await client.pull(activeId.value, cursor.value)
+      if (pulled.document)
+        applyRemoteDocument(pulled.document, { refreshEditor: true })
+      cursor.value = Math.max(cursor.value, pulled.cursor)
+      role.value = pulled.role
+
+      const content = editorStore.getContent()
+      const style = collectCollabStyle()
+      const now = Date.now()
+      const payload: {
+        title?: string
+        content?: string
+        contentUpdatedAt?: number
+        style?: typeof style
+        styleUpdatedAt?: number
+      } = {}
+
+      const doc = document.value
+      if (doc && content !== lastPushedContent) {
+        payload.title = doc.title
+        payload.content = content
+        payload.contentUpdatedAt = now
+      }
+
+      if (lastPushedStyle && !collabStyleEquals(style, lastPushedStyle)) {
+        payload.style = style
+        payload.styleUpdatedAt = now
+      }
+      else if (!lastPushedStyle) {
+        payload.style = style
+        payload.styleUpdatedAt = now
+      }
+
+      if (payload.content !== undefined || payload.style !== undefined) {
+        const pushed = await client.push(activeId.value, payload)
+        document.value = pushed.document
+        cursor.value = Math.max(cursor.value, pushed.cursor)
+        lastPushedContent = pushed.document.content
+        lastPushedStyle = { ...pushed.document.style }
+
+        if (!pushed.merged.contentAccepted && payload.content !== undefined)
+          applyRemoteDocument(pushed.document)
+        if (!pushed.merged.styleAccepted && payload.style !== undefined) {
+          void hydrateCollabStyle(pushed.document.style).then(() => editorRefresh())
+        }
+      }
+
+      status.value = `idle`
+    }
+    catch (e) {
+      status.value = `error`
+      lastError.value = e instanceof ApiError ? e.message : String(e)
+    }
+  }
+
+  function scheduleSync(): void {
+    if (!isCollabMode.value || !canWrite.value)
+      return
+    if (debounceTimer)
+      clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      void syncNow()
+    }, SYNC_DEBOUNCE_MS)
+  }
+
+  function startPolling(): void {
+    stopPolling()
+    pollTimer = setInterval(() => {
+      void pullRemote()
+    }, 8000)
+  }
+
+  function stopPolling(): void {
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  async function pullRemote(): Promise<void> {
+    if (!isCollabMode.value || !activeId.value)
+      return
+
+    try {
+      const pulled = await client.pull(activeId.value, cursor.value)
+      if (pulled.document)
+        applyRemoteDocument(pulled.document)
+      cursor.value = Math.max(cursor.value, pulled.cursor)
+      role.value = pulled.role
+    }
+    catch {
+      // 轮询失败静默忽略
+    }
+  }
+
+  async function acceptInvite(token: string): Promise<string> {
+    const result = await client.acceptInvite(token)
+    await loadList()
+    return result.documentId
+  }
+
+  async function createInvite(inviteRole: `editor` | `viewer`): Promise<string> {
+    if (!activeId.value || !isOwner.value)
+      throw new Error(`forbidden`)
+    const result = await client.invite(activeId.value, { role: inviteRole })
+    return result.inviteUrl
+  }
+
+  async function refreshMembers(): Promise<void> {
+    if (!activeId.value || !isOwner.value)
+      return
+    const result = await client.listMembers(activeId.value)
+    members.value = result.members
+  }
+
+  async function removeMember(userId: string): Promise<void> {
+    if (!activeId.value || !isOwner.value)
+      return
+    const result = await client.updateMember(activeId.value, userId, null)
+    members.value = result.members
+  }
+
+  async function exitCollab(): Promise<void> {
+    stopPolling()
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+
+    if (canWrite.value && isCollabMode.value)
+      await syncNow().catch(() => {})
+
+    isCollabMode.value = false
+    activeId.value = null
+    role.value = null
+    document.value = null
+    members.value = []
+    cursor.value = 0
+    lastPushedStyle = null
+    lastPushedContent = ``
+
+    if (personalStyleSnapshot.value) {
+      restorePersonalStyle(personalStyleSnapshot.value)
+      personalStyleSnapshot.value = null
+      const themeStore = useThemeStore()
+      themeStore.updateCodeTheme()
+      await themeStore.applyCurrentTheme()
+      editorRefresh()
+    }
+  }
+
+  async function deleteCollab(): Promise<void> {
+    if (!activeId.value || !isOwner.value)
+      return
+    await client.remove(activeId.value)
+    await exitCollab()
+    await loadList()
+  }
+
+  function notifyContentChanged(): void {
+    scheduleSync()
+  }
+
+  function notifyStyleChanged(): void {
+    scheduleSync()
+  }
+
+  return {
+    isCollabMode,
+    activeId,
+    role,
+    document,
+    members,
+    list,
+    cursor,
+    status,
+    lastError,
+    isReadOnly,
+    canWrite,
+    isOwner,
+    loadList,
+    openDocument,
+    createFromCurrentPost,
+    syncNow,
+    scheduleSync,
+    acceptInvite,
+    createInvite,
+    refreshMembers,
+    removeMember,
+    exitCollab,
+    deleteCollab,
+    notifyContentChanged,
+    notifyStyleChanged,
+  }
+})

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -144,6 +144,15 @@ export const useUIStore = defineStore(`ui`, () => {
     isShowShareDialog.value = true
   }
 
+  // 是否展示协作对话框
+  const isShowCollabDialog = ref(false)
+  const toggleShowCollabDialog = useToggle(isShowCollabDialog)
+
+  /** 登录后待处理的协作邀请 token */
+  const pendingCollabInviteToken = ref<string | null>(null)
+  /** 登录后待打开的协作文档 id */
+  const pendingCollabDocumentId = ref<string | null>(null)
+
   // 是否展示关于 / 赞赏 / 语法帮助 / 配置导入导出对话框
   const isShowAboutDialog = ref(false)
   const toggleShowAboutDialog = useToggle(isShowAboutDialog)
@@ -263,6 +272,10 @@ export const useUIStore = defineStore(`ui`, () => {
     isShowShareDialog,
     shareDialogInitialTab,
     openShareDialog,
+    isShowCollabDialog,
+    toggleShowCollabDialog,
+    pendingCollabInviteToken,
+    pendingCollabDocumentId,
     isShowAboutDialog,
     toggleShowAboutDialog,
     isShowFundDialog,

--- a/packages/shared/src/types/collab.ts
+++ b/packages/shared/src/types/collab.ts
@@ -1,0 +1,133 @@
+import type { PerThemeSettingsMap } from '../configs/style'
+import type { ThemeName } from '../configs/theme-css'
+import type { CustomComponentDef } from './component'
+
+export type CollabRole = `owner` | `editor` | `viewer`
+export type CollabInviteRole = `editor` | `viewer`
+
+export interface CollabCustomCssTab {
+  id: string
+  title: string
+  content: string
+}
+
+export interface CollabStyleLayout {
+  useIndent: boolean
+  useJustify: boolean
+  isCiteStatus: boolean
+  isCountStatus: boolean
+  legend: string
+  previewWidth: string
+}
+
+/** 协作文档级样式包（与个人账户偏好隔离） */
+export interface CollabStyleBundle {
+  version: 1
+  theme: ThemeName
+  themeSettings: PerThemeSettingsMap
+  layout: CollabStyleLayout
+  customCss: {
+    activeTabId: string
+    tabs: CollabCustomCssTab[]
+  }
+  customComponents?: CustomComponentDef[]
+}
+
+export interface CollabHistoryEntry {
+  datetime: string
+  content: string
+}
+
+export interface CollabDocument {
+  id: string
+  ownerUserId: string
+  sourcePostId: string | null
+  title: string
+  content: string
+  style: CollabStyleBundle
+  contentUpdatedAt: number
+  styleUpdatedAt: number
+  history: CollabHistoryEntry[]
+  createdAt: number
+  updatedAt: number
+  deleted: boolean
+}
+
+export interface CollabListItem {
+  id: string
+  title: string
+  role: CollabRole
+  ownerLogin: string
+  contentUpdatedAt: number
+  styleUpdatedAt: number
+  updatedAt: number
+}
+
+export interface CollabMember {
+  userId: string
+  login: string
+  name: string | null
+  avatar: string | null
+  role: CollabRole
+  joinedAt: number
+}
+
+export interface CreateCollabRequest {
+  sourcePostId?: string
+  title: string
+  content: string
+  style: CollabStyleBundle
+}
+
+export interface CreateCollabResponse {
+  id: string
+  document: CollabDocument
+}
+
+export interface CollabInviteRequest {
+  role: CollabInviteRole
+  expiresInHours?: number
+  maxUses?: number
+}
+
+export interface CollabInviteResponse {
+  token: string
+  role: CollabInviteRole
+  expiresAt: number | null
+  maxUses: number | null
+  inviteUrl: string
+}
+
+export interface AcceptCollabInviteResponse {
+  documentId: string
+  role: CollabRole
+}
+
+export interface CollabPushRequest {
+  title?: string
+  content?: string
+  contentUpdatedAt?: number
+  style?: CollabStyleBundle
+  styleUpdatedAt?: number
+}
+
+export interface CollabPushResponse {
+  document: CollabDocument
+  cursor: number
+  merged: {
+    contentAccepted: boolean
+    styleAccepted: boolean
+  }
+}
+
+export interface CollabPullResponse {
+  document: CollabDocument | null
+  role: CollabRole
+  cursor: number
+}
+
+export interface CollabDetailResponse {
+  document: CollabDocument
+  role: CollabRole
+  members: CollabMember[]
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './ai-services-types'
+export * from './collab'
 export * from './common'
 export * from './component'
 export * from './front-matter'


### PR DESCRIPTION
## Summary

- Add phase 1 cloud collaboration: logged-in users can create collab documents from the current post, invite others via link, and edit markdown + document-scoped styles together.
- Backend (`@md/api`): D1 migration `0004_collab.sql`, `/collab` CRUD, member/invite APIs, LWW push/pull for content and `CollabStyleBundle` (owner / editor / viewer roles).
- Frontend (`@md/web`): Collab dialog, collab mode banner, read-only viewer UI, style isolation (snapshot/restore personal prefs), deep links (`?collab_invite=`, `?collab=`).

## Related Issue

Closes #499

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic/UI
- [ ] Documentation
- [ ] Workflow/CI

## Test Procedure

- [x] `pnpm api type-check` passes
- [x] `pnpm web build` passes (vue-tsc + vite)
- [x] D1 migration `0004_collab.sql` applied locally and on remote
- [x] Worker deployed to `md-api.doocs.org` (maintainer environment)
- [ ] Manual E2E: two GitHub accounts — create collab, invite editor/viewer, verify content + style sync and viewer read-only

## Pre-flight Checklist

- [x] Conventional commit message in English
- [x] No secrets committed
- [x] ESLint pre-commit hook passes
- [ ] Rate limiting for collab endpoints (follow-up; noted in review)
- [ ] Documentation update beyond API README (optional follow-up)
