### PR TITLE
feat(web): add command palette and keyboard shortcuts help

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import CodemirrorEditor from '@/components/editor/CodemirrorEditor.vue'
+import CommandPalette from '@/components/editor/dialogs/CommandPalette.vue'
 import ConfirmDialog from '@/components/shared/confirm-dialog/ConfirmDialog.vue'
 import { Toaster } from '@/components/ui/sonner'
+import { useCommandPaletteHotkey } from '@/composables/useCommandPaletteHotkey'
 import { useUIStore } from '@/stores/ui'
 
 const uiStore = useUIStore()
@@ -10,10 +12,13 @@ const { isDark } = storeToRefs(uiStore)
 usePlatformEnv()
 useAccountSyncBootstrap()
 useDeepLinkImport()
+useCommandPaletteHotkey()
 </script>
 
 <template>
   <CodemirrorEditor />
+
+  <CommandPalette />
 
   <ConfirmDialog />
 

--- a/apps/web/src/components/editor/dialogs/CommandPalette.vue
+++ b/apps/web/src/components/editor/dialogs/CommandPalette.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import type { PaletteCommand } from '@/composables/useCommandPalette'
+import { Search } from '@lucide/vue'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useCommandPalette } from '@/composables/useCommandPalette'
+import { useUIStore } from '@/stores/ui'
+
+const uiStore = useUIStore()
+const { isShowCommandPalette } = storeToRefs(uiStore)
+const { buildCommands } = useCommandPalette()
+
+const query = ref(``)
+const activeIndex = ref(0)
+const inputRef = ref<HTMLInputElement | null>(null)
+
+const allCommands = computed(() => buildCommands())
+
+const filteredCommands = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q)
+    return allCommands.value
+
+  return allCommands.value.filter((cmd) => {
+    if (cmd.label.toLowerCase().includes(q))
+      return true
+    if (cmd.group.toLowerCase().includes(q))
+      return true
+    return cmd.keywords.some(k => k.toLowerCase().includes(q))
+  })
+})
+
+const groupedCommands = computed(() => {
+  const groups = new Map<string, PaletteCommand[]>()
+  for (const cmd of filteredCommands.value) {
+    const list = groups.get(cmd.group) ?? []
+    list.push(cmd)
+    groups.set(cmd.group, list)
+  }
+  return [...groups.entries()]
+})
+
+watch(isShowCommandPalette, (open) => {
+  if (open) {
+    query.value = ``
+    activeIndex.value = 0
+    nextTick(() => inputRef.value?.focus())
+  }
+})
+
+watch(filteredCommands, () => {
+  activeIndex.value = 0
+})
+
+function close() {
+  uiStore.toggleShowCommandPalette(false)
+}
+
+async function runCommand(cmd: PaletteCommand) {
+  close()
+  await cmd.action()
+}
+
+function getFlatIndex(groupIdx: number, cmdIdx: number) {
+  let index = 0
+  for (let i = 0; i < groupIdx; i++)
+    index += groupedCommands.value[i][1].length
+  return index + cmdIdx
+}
+
+function onKeydown(event: KeyboardEvent) {
+  const count = filteredCommands.value.length
+
+  if (event.key === `ArrowDown`) {
+    event.preventDefault()
+    if (count > 0)
+      activeIndex.value = (activeIndex.value + 1) % count
+  }
+  else if (event.key === `ArrowUp`) {
+    event.preventDefault()
+    if (count > 0)
+      activeIndex.value = (activeIndex.value - 1 + count) % count
+  }
+  else if (event.key === `Enter`) {
+    event.preventDefault()
+    const cmd = filteredCommands.value[activeIndex.value]
+    if (cmd)
+      void runCommand(cmd)
+  }
+}
+
+function isActive(groupIdx: number, cmdIdx: number) {
+  return activeIndex.value === getFlatIndex(groupIdx, cmdIdx)
+}
+</script>
+
+<template>
+  <Dialog :open="isShowCommandPalette" @update:open="(v) => !v && close()">
+    <DialogContent
+      class="top-[18%] max-h-[min(70vh,32rem)] max-w-xl translate-y-0 gap-0 overflow-hidden p-0"
+      @keydown.escape.stop="close"
+    >
+      <DialogHeader class="sr-only">
+        <DialogTitle>命令面板</DialogTitle>
+        <DialogDescription>搜索并执行编辑器命令</DialogDescription>
+      </DialogHeader>
+
+      <div class="flex items-center gap-2 border-b px-3 py-2.5">
+        <Search class="size-4 shrink-0 text-muted-foreground" />
+        <input
+          ref="inputRef"
+          v-model="query"
+          type="text"
+          class="h-8 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          placeholder="搜索命令…"
+          @keydown="onKeydown"
+        >
+      </div>
+
+      <div class="max-h-[min(52vh,24rem)] overflow-y-auto p-1">
+        <template v-if="groupedCommands.length">
+          <template v-for="([group, items], groupIdx) in groupedCommands" :key="group">
+            <p class="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+              {{ group }}
+            </p>
+            <button
+              v-for="(cmd, cmdIdx) in items"
+              :key="cmd.id"
+              type="button"
+              class="flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors"
+              :class="isActive(groupIdx, cmdIdx) ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60'"
+              @mouseenter="activeIndex = getFlatIndex(groupIdx, cmdIdx)"
+              @click="runCommand(cmd)"
+            >
+              <span>{{ cmd.label }}</span>
+              <span v-if="cmd.shortcut?.length" class="flex items-center gap-0.5 text-xs text-muted-foreground">
+                <kbd
+                  v-for="key in cmd.shortcut"
+                  :key="key"
+                  class="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]"
+                >
+                  {{ key }}
+                </kbd>
+              </span>
+            </button>
+          </template>
+        </template>
+        <p v-else class="px-3 py-8 text-center text-sm text-muted-foreground">
+          无匹配命令
+        </p>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/web/src/components/editor/editor-header/HelpDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/HelpDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { BookText, Heart, HelpCircle, MessageSquare, Tag } from '@lucide/vue'
+import { BookText, Command, Heart, HelpCircle, Keyboard, MessageSquare, Tag } from '@lucide/vue'
+import { ctrlSign, shiftSign } from '@md/shared/configs'
 import { useUIStore } from '@/stores/ui'
 
 const props = withDefaults(defineProps<{
@@ -10,7 +11,13 @@ const props = withDefaults(defineProps<{
 
 const { asSub } = toRefs(props)
 const uiStore = useUIStore()
-const { toggleShowAboutDialog, toggleShowFundDialog, toggleShowMarkdownHelpDialog } = uiStore
+const {
+  toggleShowAboutDialog,
+  toggleShowFundDialog,
+  toggleShowMarkdownHelpDialog,
+  toggleShowKeyboardShortcutsDialog,
+  toggleShowCommandPalette,
+} = uiStore
 
 function openAboutDialog() {
   toggleShowAboutDialog(true)
@@ -22,6 +29,14 @@ function openFundDialog() {
 
 function openMarkdownHelp() {
   toggleShowMarkdownHelpDialog(true)
+}
+
+function openCommandPalette() {
+  toggleShowCommandPalette(true)
+}
+
+function openKeyboardShortcuts() {
+  toggleShowKeyboardShortcutsDialog(true)
 }
 
 function openFeedback() {
@@ -39,7 +54,23 @@ function openReleases() {
     <MenubarSubTrigger>
       帮助
     </MenubarSubTrigger>
-    <MenubarSubContent>
+    <MenubarSubContent class="w-72">
+      <MenubarItem class="pr-2" @click="openCommandPalette()">
+        <Command class="mr-2 h-4 w-4 shrink-0" />
+        <span class="min-w-0 flex-1">命令面板</span>
+        <MenubarShortcut class="shrink-0 pl-4">
+          <span class="inline-flex items-center gap-0.5">
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ ctrlSign }}</kbd>
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ shiftSign }}</kbd>
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">P</kbd>
+          </span>
+        </MenubarShortcut>
+      </MenubarItem>
+      <MenubarItem @click="openKeyboardShortcuts()">
+        <Keyboard class="mr-2 h-4 w-4" />
+        键盘快捷键
+      </MenubarItem>
+      <MenubarSeparator />
       <MenubarItem @click="openMarkdownHelp()">
         <BookText class="mr-2 h-4 w-4" />
         语法帮助
@@ -66,7 +97,23 @@ function openReleases() {
   <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>帮助</MenubarTrigger>
-    <MenubarContent align="start">
+    <MenubarContent align="start" class="w-72">
+      <MenubarItem class="pr-2" @click="openCommandPalette()">
+        <Command class="mr-2 h-4 w-4 shrink-0" />
+        <span class="min-w-0 flex-1">命令面板</span>
+        <MenubarShortcut class="shrink-0 pl-4">
+          <span class="inline-flex items-center gap-0.5">
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ ctrlSign }}</kbd>
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ shiftSign }}</kbd>
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">P</kbd>
+          </span>
+        </MenubarShortcut>
+      </MenubarItem>
+      <MenubarItem @click="openKeyboardShortcuts()">
+        <Keyboard class="mr-2 h-4 w-4" />
+        键盘快捷键
+      </MenubarItem>
+      <MenubarSeparator />
       <MenubarItem @click="openMarkdownHelp()">
         <BookText class="mr-2 h-4 w-4" />
         语法帮助

--- a/apps/web/src/components/editor/editor-header/KeyboardShortcutsDialog.vue
+++ b/apps/web/src/components/editor/editor-header/KeyboardShortcutsDialog.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { Keyboard } from '@lucide/vue'
+import { computed } from 'vue'
+import CloudPanelDialog from '@/components/editor/editor-header/cloud-panel/CloudPanelDialog.vue'
+import { useCommandPalette } from '@/composables/useCommandPalette'
+import { KEYBOARD_SHORTCUT_CATEGORIES } from '@/configs/keyboard-shortcuts'
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const { paletteShortcutLabel } = useCommandPalette()
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (val: boolean) => emit(`update:open`, val),
+})
+</script>
+
+<template>
+  <CloudPanelDialog
+    v-model:open="dialogOpen"
+    title="键盘快捷键"
+    :description="`命令面板：${paletteShortcutLabel}`"
+    :icon="Keyboard"
+    size="2xl"
+  >
+    <div class="space-y-5 overflow-y-auto px-4 py-4 sm:px-6">
+      <section
+        v-for="category in KEYBOARD_SHORTCUT_CATEGORIES"
+        :key="category.title"
+        class="space-y-2"
+      >
+        <h3 class="text-sm font-medium text-foreground">
+          {{ category.title }}
+        </h3>
+        <div class="divide-y rounded-lg border">
+          <div
+            v-for="item in category.items"
+            :key="item.label"
+            class="flex items-center justify-between gap-4 px-3 py-2.5 text-sm"
+          >
+            <span class="text-muted-foreground">{{ item.label }}</span>
+            <span class="flex shrink-0 items-center gap-1">
+              <kbd
+                v-for="key in item.keys"
+                :key="key"
+                class="inline-flex min-w-6 items-center justify-center rounded border bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-foreground"
+              >
+                {{ key }}
+              </kbd>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+  </CloudPanelDialog>
+</template>

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -20,6 +20,7 @@ const AboutDialog = defineAsyncComponent(() => import('./AboutDialog.vue'))
 const FundDialog = defineAsyncComponent(() => import('./FundDialog.vue'))
 const EditorStateDialog = defineAsyncComponent(() => import('@/components/editor/dialogs/EditorStateDialog.vue'))
 const MarkdownHelpDialog = defineAsyncComponent(() => import('./MarkdownHelpDialog.vue'))
+const KeyboardShortcutsDialog = defineAsyncComponent(() => import('./KeyboardShortcutsDialog.vue'))
 const AccountDialog = defineAsyncComponent(() => import('./AccountDialog.vue'))
 const SyncDialog = defineAsyncComponent(() => import('./SyncDialog.vue'))
 const ShareDialog = defineAsyncComponent(() => import('./ShareDialog.vue'))
@@ -34,7 +35,7 @@ const { editorRefresh } = useEditorRefresh()
 const { editor } = storeToRefs(editorStore)
 const { output } = storeToRefs(renderStore)
 const { primaryColor } = storeToRefs(themeStore)
-const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog, copyMode } = storeToRefs(uiStore)
+const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowMarkdownHelpDialog, isShowKeyboardShortcutsDialog, copyMode } = storeToRefs(uiStore)
 
 const isCopying = ref(false)
 
@@ -296,6 +297,7 @@ function copyToWeChat() {
   <FundDialog v-if="isShowFundDialog" v-model:open="isShowFundDialog" />
   <EditorStateDialog v-if="isShowEditorStateDialog" v-model:open="isShowEditorStateDialog" />
   <MarkdownHelpDialog v-if="isShowMarkdownHelpDialog" v-model:open="isShowMarkdownHelpDialog" />
+  <KeyboardShortcutsDialog v-if="isShowKeyboardShortcutsDialog" v-model:open="isShowKeyboardShortcutsDialog" />
   <AccountDialog v-if="isShowAccountDialog" v-model:open="isShowAccountDialog" />
   <SyncDialog v-if="isShowSyncDialog" v-model:open="isShowSyncDialog" />
   <ShareDialog v-if="isShowShareDialog" v-model:open="isShowShareDialog" />

--- a/apps/web/src/composables/useCommandPalette.ts
+++ b/apps/web/src/composables/useCommandPalette.ts
@@ -76,7 +76,7 @@ export function useCommandPalette() {
         label: `切换深色模式`,
         group: `视图`,
         keywords: [`深色`, `浅色`, `主题`, `dark`, `light`, `theme`],
-        action: () => uiStore.toggleDark(),
+        action: () => { uiStore.toggleDark() },
       },
       {
         id: `toggle-style-panel`,
@@ -111,21 +111,21 @@ export function useCommandPalette() {
         label: `导入 Markdown`,
         group: `文件`,
         keywords: [`导入`, `import`, `markdown`, `md`],
-        action: () => uiStore.toggleShowImportMdDialog(true),
+        action: () => { uiStore.toggleShowImportMdDialog(true) },
       },
       {
         id: `template-dialog`,
         label: `模板管理`,
         group: `文件`,
         keywords: [`模板`, `template`],
-        action: () => uiStore.toggleShowTemplateDialog(true),
+        action: () => { uiStore.toggleShowTemplateDialog(true) },
       },
       {
         id: `editor-state`,
         label: `项目配置`,
         group: `文件`,
         keywords: [`配置`, `导入`, `导出`, `备份`, `settings`],
-        action: () => uiStore.toggleShowEditorStateDialog(true),
+        action: () => { uiStore.toggleShowEditorStateDialog(true) },
       },
       {
         id: `find`,
@@ -168,14 +168,14 @@ export function useCommandPalette() {
         label: `插入图片`,
         group: `插入`,
         keywords: [`图片`, `image`, `上传`, `图床`],
-        action: () => uiStore.toggleShowUploadImgDialog(true),
+        action: () => { uiStore.toggleShowUploadImgDialog(true) },
       },
       {
         id: `insert-table`,
         label: `插入表格`,
         group: `插入`,
         keywords: [`表格`, `table`],
-        action: () => uiStore.toggleShowInsertFormDialog(true),
+        action: () => { uiStore.toggleShowInsertFormDialog(true) },
       },
       {
         id: `insert-formula`,
@@ -189,7 +189,7 @@ export function useCommandPalette() {
         label: `插入组件`,
         group: `插入`,
         keywords: [`组件`, `component`, `块`],
-        action: () => uiStore.toggleShowComponentDialog(true),
+        action: () => { uiStore.toggleShowComponentDialog(true) },
       },
     ]
 
@@ -199,7 +199,7 @@ export function useCommandPalette() {
         label: `账户`,
         group: `云端`,
         keywords: [`账户`, `登录`, `account`, `login`],
-        action: () => uiStore.toggleShowAccountDialog(true),
+        action: () => { uiStore.toggleShowAccountDialog(true) },
       })
     }
 
@@ -209,7 +209,7 @@ export function useCommandPalette() {
         label: `云同步`,
         group: `云端`,
         keywords: [`同步`, `云`, `sync`, `cloud`],
-        action: () => uiStore.toggleShowSyncDialog(true),
+        action: () => { uiStore.toggleShowSyncDialog(true) },
       })
     }
 

--- a/apps/web/src/composables/useCommandPalette.ts
+++ b/apps/web/src/composables/useCommandPalette.ts
@@ -1,0 +1,235 @@
+import type { EditorView } from '@codemirror/view'
+import { ctrlSign, shiftSign } from '@md/shared/configs'
+import { useEditorDocumentActions } from '@/composables/useEditorDocumentActions'
+import { isAccountUiEnabled } from '@/services/account/config'
+import { isShareUiEnabled } from '@/services/share/client'
+import { isSyncUiEnabled } from '@/services/sync/client'
+import { useEditorStore } from '@/stores/editor'
+import { useUIStore } from '@/stores/ui'
+
+export interface PaletteCommand {
+  id: string
+  label: string
+  group: string
+  keywords: string[]
+  shortcut?: string[]
+  action: () => void | Promise<void>
+}
+
+export function useCommandPalette() {
+  const uiStore = useUIStore()
+  const editorStore = useEditorStore()
+  const { formatContent } = useEditorDocumentActions()
+
+  function withEditor(run: (view: EditorView) => void | Promise<void>) {
+    const view = editorStore.editor ? toRaw(editorStore.editor) as EditorView : null
+    if (!view)
+      return
+    void run(view)
+  }
+
+  function buildCommands(): PaletteCommand[] {
+    const commands: PaletteCommand[] = [
+      {
+        id: `palette-shortcuts`,
+        label: `键盘快捷键`,
+        group: `帮助`,
+        keywords: [`快捷键`, `keyboard`, `shortcut`, `帮助`],
+        action: () => {
+          uiStore.toggleShowCommandPalette(false)
+          uiStore.toggleShowKeyboardShortcutsDialog(true)
+        },
+      },
+      {
+        id: `palette-markdown-help`,
+        label: `语法帮助`,
+        group: `帮助`,
+        keywords: [`语法`, `markdown`, `帮助`, `syntax`],
+        action: () => {
+          uiStore.toggleShowCommandPalette(false)
+          uiStore.toggleShowMarkdownHelpDialog(true)
+        },
+      },
+      {
+        id: `view-edit`,
+        label: `视图：编辑`,
+        group: `视图`,
+        keywords: [`视图`, `编辑`, `edit`, `view`],
+        action: () => uiStore.setViewMode(`edit`),
+      },
+      {
+        id: `view-split`,
+        label: `视图：双屏`,
+        group: `视图`,
+        keywords: [`视图`, `双屏`, `split`, `view`],
+        action: () => uiStore.setViewMode(`split`),
+      },
+      {
+        id: `view-preview`,
+        label: `视图：预览`,
+        group: `视图`,
+        keywords: [`视图`, `预览`, `preview`, `view`],
+        action: () => uiStore.setViewMode(`preview`),
+      },
+      {
+        id: `toggle-dark`,
+        label: `切换深色模式`,
+        group: `视图`,
+        keywords: [`深色`, `浅色`, `主题`, `dark`, `light`, `theme`],
+        action: () => uiStore.toggleDark(),
+      },
+      {
+        id: `toggle-style-panel`,
+        label: `样式面板`,
+        group: `面板`,
+        keywords: [`样式`, `style`, `主题`, `面板`],
+        action: () => { uiStore.isOpenRightSlider = !uiStore.isOpenRightSlider },
+      },
+      {
+        id: `toggle-post-slider`,
+        label: `内容管理`,
+        group: `面板`,
+        keywords: [`内容`, `文档`, `文章`, `posts`, `管理`],
+        action: () => { uiStore.isOpenPostSlider = !uiStore.isOpenPostSlider },
+      },
+      {
+        id: `toggle-folder-panel`,
+        label: `本地文件夹`,
+        group: `面板`,
+        keywords: [`文件夹`, `本地`, `folder`, `local`],
+        action: () => { uiStore.isOpenFolderPanel = !uiStore.isOpenFolderPanel },
+      },
+      {
+        id: `open-css-editor`,
+        label: `自定义 CSS`,
+        group: `面板`,
+        keywords: [`css`, `样式`, `自定义`],
+        action: () => { uiStore.isShowCssEditor = true },
+      },
+      {
+        id: `import-markdown`,
+        label: `导入 Markdown`,
+        group: `文件`,
+        keywords: [`导入`, `import`, `markdown`, `md`],
+        action: () => uiStore.toggleShowImportMdDialog(true),
+      },
+      {
+        id: `template-dialog`,
+        label: `模板管理`,
+        group: `文件`,
+        keywords: [`模板`, `template`],
+        action: () => uiStore.toggleShowTemplateDialog(true),
+      },
+      {
+        id: `editor-state`,
+        label: `项目配置`,
+        group: `文件`,
+        keywords: [`配置`, `导入`, `导出`, `备份`, `settings`],
+        action: () => uiStore.toggleShowEditorStateDialog(true),
+      },
+      {
+        id: `find`,
+        label: `查找`,
+        group: `编辑`,
+        keywords: [`查找`, `搜索`, `find`, `search`],
+        shortcut: [ctrlSign, `F`],
+        action: () => withEditor((view) => {
+          const selection = view.state.selection.main
+          const selected = view.state.doc.sliceString(selection.from, selection.to).trim()
+          uiStore.openSearchTab(selected)
+          view.focus()
+        }),
+      },
+      {
+        id: `replace`,
+        label: `替换`,
+        group: `编辑`,
+        keywords: [`替换`, `replace`],
+        shortcut: [ctrlSign, `H`],
+        action: () => withEditor((view) => {
+          const selection = view.state.selection.main
+          const selected = view.state.doc.sliceString(selection.from, selection.to).trim()
+          uiStore.openSearchTab(selected, true)
+          view.focus()
+        }),
+      },
+      {
+        id: `format-doc`,
+        label: `格式化文档`,
+        group: `编辑`,
+        keywords: [`格式化`, `format`, `prettier`],
+        action: async () => {
+          await formatContent()
+          editorStore.editor?.focus()
+        },
+      },
+      {
+        id: `insert-image`,
+        label: `插入图片`,
+        group: `插入`,
+        keywords: [`图片`, `image`, `上传`, `图床`],
+        action: () => uiStore.toggleShowUploadImgDialog(true),
+      },
+      {
+        id: `insert-table`,
+        label: `插入表格`,
+        group: `插入`,
+        keywords: [`表格`, `table`],
+        action: () => uiStore.toggleShowInsertFormDialog(true),
+      },
+      {
+        id: `insert-formula`,
+        label: `插入公式`,
+        group: `插入`,
+        keywords: [`公式`, `formula`, `math`, `latex`],
+        action: () => uiStore.openFormulaEditor({ value: ``, displayMode: true }),
+      },
+      {
+        id: `insert-component`,
+        label: `插入组件`,
+        group: `插入`,
+        keywords: [`组件`, `component`, `块`],
+        action: () => uiStore.toggleShowComponentDialog(true),
+      },
+    ]
+
+    if (isAccountUiEnabled()) {
+      commands.push({
+        id: `open-account`,
+        label: `账户`,
+        group: `云端`,
+        keywords: [`账户`, `登录`, `account`, `login`],
+        action: () => uiStore.toggleShowAccountDialog(true),
+      })
+    }
+
+    if (isSyncUiEnabled()) {
+      commands.push({
+        id: `open-sync`,
+        label: `云同步`,
+        group: `云端`,
+        keywords: [`同步`, `云`, `sync`, `cloud`],
+        action: () => uiStore.toggleShowSyncDialog(true),
+      })
+    }
+
+    if (isShareUiEnabled()) {
+      commands.push({
+        id: `open-share`,
+        label: `分享预览`,
+        group: `云端`,
+        keywords: [`分享`, `share`, `预览`],
+        action: () => uiStore.openShareDialog(),
+      })
+    }
+
+    return commands
+  }
+
+  const paletteShortcutLabel = `${ctrlSign} ${shiftSign} P`
+
+  return {
+    buildCommands,
+    paletteShortcutLabel,
+  }
+}

--- a/apps/web/src/composables/useCommandPaletteHotkey.ts
+++ b/apps/web/src/composables/useCommandPaletteHotkey.ts
@@ -1,0 +1,24 @@
+import { useUIStore } from '@/stores/ui'
+
+/** 注册命令面板全局快捷键 Mod+Shift+P */
+export function useCommandPaletteHotkey() {
+  const uiStore = useUIStore()
+
+  function onKeydown(event: KeyboardEvent) {
+    if (!(event.metaKey || event.ctrlKey) || !event.shiftKey)
+      return
+    if (event.key.toLowerCase() !== `p`)
+      return
+
+    event.preventDefault()
+    uiStore.toggleShowCommandPalette(true)
+  }
+
+  onMounted(() => {
+    document.addEventListener(`keydown`, onKeydown)
+  })
+
+  onBeforeUnmount(() => {
+    document.removeEventListener(`keydown`, onKeydown)
+  })
+}

--- a/apps/web/src/configs/keyboard-shortcuts.ts
+++ b/apps/web/src/configs/keyboard-shortcuts.ts
@@ -1,0 +1,56 @@
+import { altSign, ctrlSign, shiftSign } from '@md/shared/configs'
+
+export interface ShortcutItem {
+  label: string
+  keys: string[]
+}
+
+export interface ShortcutCategory {
+  title: string
+  items: ShortcutItem[]
+}
+
+function mod(...keys: string[]) {
+  return [ctrlSign, ...keys]
+}
+
+export const KEYBOARD_SHORTCUT_CATEGORIES: ShortcutCategory[] = [
+  {
+    title: `通用`,
+    items: [
+      { label: `命令面板`, keys: mod(shiftSign, `P`) },
+      { label: `斜杠命令`, keys: [`/`] },
+      { label: `关闭搜索面板`, keys: [`Esc`] },
+    ],
+  },
+  {
+    title: `编辑`,
+    items: [
+      { label: `撤销`, keys: mod(`Z`) },
+      { label: `重做`, keys: mod(`Y`) },
+      { label: `复制`, keys: mod(`C`) },
+      { label: `粘贴`, keys: mod(`V`) },
+      { label: `查找`, keys: mod(`F`) },
+      { label: `替换`, keys: mod(`H`) },
+      { label: `格式化`, keys: [altSign, shiftSign, `F`] },
+    ],
+  },
+  {
+    title: `格式`,
+    items: [
+      { label: `加粗`, keys: mod(`B`) },
+      { label: `斜体`, keys: mod(`I`) },
+      { label: `删除线`, keys: mod(`D`) },
+      { label: `超链接`, keys: mod(`K`) },
+      { label: `行内代码`, keys: mod(`E`) },
+      { label: `标题 1`, keys: mod(`1`) },
+      { label: `标题 2`, keys: mod(`2`) },
+      { label: `标题 3`, keys: mod(`3`) },
+      { label: `标题 4`, keys: mod(`4`) },
+      { label: `标题 5`, keys: mod(`5`) },
+      { label: `标题 6`, keys: mod(`6`) },
+      { label: `无序列表`, keys: mod(`U`) },
+      { label: `有序列表`, keys: mod(`O`) },
+    ],
+  },
+]

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -157,6 +157,12 @@ export const useUIStore = defineStore(`ui`, () => {
   const isShowEditorStateDialog = ref(false)
   const toggleShowEditorStateDialog = useToggle(isShowEditorStateDialog)
 
+  const isShowKeyboardShortcutsDialog = ref(false)
+  const toggleShowKeyboardShortcutsDialog = useToggle(isShowKeyboardShortcutsDialog)
+
+  const isShowCommandPalette = ref(false)
+  const toggleShowCommandPalette = useToggle(isShowCommandPalette)
+
   // 组件对话框 — 打开时预展开的组件名（如 'MpProfile'）
   const componentDialogTarget = ref<string | null>(null)
 
@@ -271,6 +277,10 @@ export const useUIStore = defineStore(`ui`, () => {
     toggleShowMarkdownHelpDialog,
     isShowEditorStateDialog,
     toggleShowEditorStateDialog,
+    isShowKeyboardShortcutsDialog,
+    toggleShowKeyboardShortcutsDialog,
+    isShowCommandPalette,
+    toggleShowCommandPalette,
     componentDialogTarget,
     openComponentDialogWithTarget,
     aiDialogVisible,


### PR DESCRIPTION
## Summary

- Add a searchable command palette (`Ctrl/Cmd+Shift+P`) for quick access to panels, views, editor actions, and cloud features
- Add a keyboard shortcuts reference dialog under **Help → 键盘快捷键**
- Widen the Help menu and improve spacing between the command palette label and its shortcut keys

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [x] Open **Help → 命令面板** and verify the palette opens with searchable commands
- [x] Press `Ctrl/Cmd+Shift+P` and confirm the palette opens globally
- [x] Use arrow keys and Enter to run a command; Esc closes the palette
- [x] Open **Help → 键盘快捷键** and verify shortcut categories render correctly
- [x] Confirm Help menu width and shortcut spacing look reasonable on desktop and mobile hamburger menu

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits
- [x] Changes are scoped to the web app UI
- [x] No secrets or env files included
- [x] `vue-tsc` passes locally
