### PR TITLE
build(deps): bump dompurify to 3.4.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   core-js: ^3.49.0
   cross-spawn@<7: ^7.0.6
   crypto-browserify: npm:empty-module@0.0.2
-  dompurify@<3.4.0: ^3.4.8
+  dompurify: ^3.4.11
   esbuild: '>=0.28.1'
   flatted@<3.4.0: ^3.4.2
   glob@<8: ^13.0.6
@@ -3622,9 +3622,6 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
@@ -9262,8 +9259,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10640,10 +10637,6 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
-
-  dompurify@3.4.10:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
 
   dompurify@3.4.11:
     optionalDependencies:
@@ -12202,7 +12195,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.47.1
       katex: 0.16.47
       khroma: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ overrides:
   core-js: ^3.49.0
   cross-spawn@<7: ^7.0.6
   crypto-browserify: npm:empty-module@0.0.2
-  dompurify@<3.4.0: ^3.4.8
+  dompurify: ^3.4.11
   esbuild: '>=0.28.1'
   flatted@<3.4.0: ^3.4.2
   glob@<8: ^13.0.6


### PR DESCRIPTION
## Summary

Upgrade `dompurify` to `^3.4.11` via pnpm override to address [GHSA-cmwh-pvxp-8882](https://github.com/advisories/GHSA-cmwh-pvxp-8882) (Dependabot alert [#310](https://github.com/doocs/md/security/dependabot/310)).

The vulnerability allows permanent `ALLOWED_ATTR` pollution when `setConfig()` is used together with an `uponSanitizeAttribute` hook. `mermaid@11.15.0` was still pulling in `dompurify@3.4.10` as a transitive dependency.

## Type of Change

- [x] Bug fix (security dependency upgrade)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [x] `pnpm install` — lockfile resolves all `dompurify` references to `3.4.11` (including `mermaid`)
- [ ] CI checks (lint, type-check, build)

## Pre-flight Checklist

- [x] Changes are focused on a single concern
- [x] No secrets or credentials committed
- [x] Commit message follows Conventional Commits (English)
