### PR TITLE
feat(web): add editor keyboard navigation and unit tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,8 @@
     "firefox:dev": "wxt -b firefox",
     "firefox:zip": "cross-env NODE_OPTIONS=--max-old-space-size=4096 wxt zip -b firefox",
     "type-check": "vue-tsc --build --force",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "postinstall": "wxt prepare"
   },
   "dependencies": {
@@ -86,6 +88,7 @@
     "vite": "^8.0.16",
     "vite-plugin-radar": "^0.11.0",
     "vite-plugin-vue-devtools": "^8.1.3",
+    "vitest": "^4.1.9",
     "vue-tsc": "^3.3.5",
     "wrangler": "^4.103.0",
     "wxt": "^0.20.26"

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Compartment, EditorState } from '@codemirror/state'
-import { EditorView, placeholder } from '@codemirror/view'
+import { Compartment, EditorState, Prec } from '@codemirror/state'
+import { EditorView, keymap, placeholder } from '@codemirror/view'
 import { markdownSetup, theme } from '@md/shared/editor'
 import { toBase64 } from '@md/shared/utils/fileHelpers'
 import imageCompression from 'browser-image-compression'
@@ -13,6 +13,7 @@ import { completeInitialPreviewBoot } from '@/composables/useInitialPreviewBoot'
 import { useLocalizedUploadHostOptions } from '@/composables/useLocalizedUploadHosts'
 import { useSlashCommand } from '@/composables/useSlashCommand'
 import { formatLocalDateTime } from '@/i18n/translate'
+import { jumpToAdjacentHeading } from '@/lib/markdown/headingNavigation'
 import { contentHasMath, loadMathJax, MATHJAX_READY_EVENT } from '@/lib/preview/mathjax'
 import { validateImageFile } from '@/lib/upload/validate-image'
 import { fileUpload } from '@/services/upload'
@@ -455,7 +456,12 @@ function createFormTextArea(dom: HTMLDivElement) {
       markdownSetup({
         onSearch: openSearchWithSelection,
         onReplace: openReplaceWithSelection,
+        onGoToLine: () => uiStore.requestGoToLine(),
       }),
+      Prec.high(keymap.of([
+        { key: `Mod-Alt-ArrowUp`, run: view => jumpToAdjacentHeading(view, `prev`) },
+        { key: `Mod-Alt-ArrowDown`, run: view => jumpToAdjacentHeading(view, `next`) },
+      ])),
       placeholderCompartment.of(editorPlaceholder()),
       themeCompartment.of(theme(isDark.value)),
       EditorView.updateListener.of((update) => {

--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -16,6 +16,12 @@ import {
 } from '@/components/ui/tooltip'
 import { useSyncFooterMeta } from '@/composables/useSyncStatusMeta'
 import { formatRelativeTime } from '@/lib/format/relative-time'
+import {
+  clampGoToLineValue,
+  findOutlineFocusIndex,
+  jumpToLine,
+  moveOutlineFocusIndex,
+} from '@/lib/markdown/headingNavigation'
 import { computeHeadingBreadcrumbs, extractMarkdownHeadings } from '@/lib/markdown/headings'
 import { isAccountUiEnabled } from '@/services/account/config'
 import { isShareUiEnabled } from '@/services/share/client'
@@ -162,13 +168,8 @@ function goToLine() {
   const view = editor.value
   if (!view)
     return
-  const target = Math.max(1, Math.min(Number.parseInt(goToLineInput.value) || 1, totalLines.value))
-  const line = view.state.doc.line(target)
-  view.dispatch({
-    selection: { anchor: line.from },
-    scrollIntoView: true,
-  })
-  view.focus()
+  const target = clampGoToLineValue(goToLineInput.value, totalLines.value)
+  jumpToLine(view as EditorView, target)
   isGoToLineActive.value = false
   updateCursorInfo(view as EditorView, { rebuildHeadings: true })
 }
@@ -186,6 +187,7 @@ const breadcrumbs = ref<MarkdownHeading[]>([])
 const allHeadings = ref<MarkdownHeading[]>([])
 const isOutlineOpen = ref(false)
 const outlineScrollRef = ref<HTMLElement | null>(null)
+const outlineFocusIndex = ref(-1)
 
 function updateCursorInfo(view: EditorView, options: { rebuildHeadings?: boolean } = {}) {
   const state = view.state
@@ -255,8 +257,11 @@ function jumpToHeadingAndClose(line: number) {
 
 watch(isOutlineOpen, (open) => {
   if (open) {
+    syncOutlineFocusIndex()
     nextTick(() => {
-      const el = outlineScrollRef.value?.querySelector(`[data-active="true"]`)
+      outlineScrollRef.value?.focus()
+      const el = outlineScrollRef.value?.querySelector(`[data-outline-index="${outlineFocusIndex.value}"]`)
+        ?? outlineScrollRef.value?.querySelector(`[data-active="true"]`)
       el?.scrollIntoView({ block: `nearest` })
     })
   }
@@ -266,13 +271,59 @@ function jumpToHeading(line: number) {
   const view = editor.value
   if (!view)
     return
-  const target = view.state.doc.line(line)
-  view.dispatch({
-    selection: { anchor: target.from },
-    scrollIntoView: true,
-  })
-  view.focus()
+  jumpToLine(view as EditorView, line)
   updateCursorInfo(view as EditorView)
+}
+
+watch(() => uiStore.goToLineRequest, () => {
+  if (isGoToLineActive.value)
+    return
+  openGoToLine()
+})
+
+function syncOutlineFocusIndex() {
+  outlineFocusIndex.value = findOutlineFocusIndex(allHeadings.value, activeHeadingLine.value)
+}
+
+function scrollOutlineFocusIntoView() {
+  nextTick(() => {
+    const container = outlineScrollRef.value
+    if (!container || outlineFocusIndex.value < 0)
+      return
+    const el = container.querySelector(`[data-outline-index="${outlineFocusIndex.value}"]`)
+    el?.scrollIntoView({ block: `nearest` })
+  })
+}
+
+function handleOutlineKeydown(event: KeyboardEvent) {
+  if (allHeadings.value.length === 0)
+    return
+
+  const key = event.key
+  if (key === `Escape`) {
+    isOutlineOpen.value = false
+    editor.value?.focus()
+    event.preventDefault()
+    return
+  }
+
+  if (key === `Enter`) {
+    const item = allHeadings.value[outlineFocusIndex.value]
+    if (item)
+      jumpToHeadingAndClose(item.line)
+    event.preventDefault()
+    return
+  }
+
+  if (key === `ArrowUp` || key === `ArrowDown` || key === `Home` || key === `End`) {
+    outlineFocusIndex.value = moveOutlineFocusIndex(
+      allHeadings.value,
+      outlineFocusIndex.value,
+      key,
+    )
+    scrollOutlineFocusIntoView()
+    event.preventDefault()
+  }
 }
 
 // 上次保存时间
@@ -454,19 +505,33 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
             </TooltipContent>
           </Tooltip>
         </PopoverTriggerPrimitive>
-        <PopoverContent side="top" :side-offset="8" align="center" class="w-72 p-0">
+        <PopoverContent
+          side="top"
+          :side-offset="8"
+          align="center"
+          class="w-72 p-0"
+        >
           <div class="flex items-center justify-between border-b px-3 py-2">
             <span class="text-xs font-medium tracking-wide text-muted-foreground">{{ t('footer.outline') }}</span>
             <span class="text-[10px] tabular-nums text-muted-foreground/50">{{ t('footer.headingCount', { count: allHeadings.length }) }}</span>
           </div>
-          <div ref="outlineScrollRef" class="max-h-72 overflow-y-auto overflow-x-hidden py-1">
+          <div
+            ref="outlineScrollRef"
+            tabindex="-1"
+            class="max-h-72 overflow-y-auto overflow-x-hidden py-1 outline-none"
+            @keydown.stop="handleOutlineKeydown"
+          >
             <template v-if="allHeadings.length > 0">
               <button
-                v-for="item in allHeadings"
+                v-for="(item, index) in allHeadings"
                 :key="item.line"
+                :data-outline-index="index"
                 :data-active="activeHeadingLine === item.line"
                 class="group flex w-full items-start px-2 py-1 text-left text-[13px] transition-colors hover:bg-accent"
-                :class="activeHeadingLine === item.line ? 'bg-accent/60' : ''"
+                :class="[
+                  activeHeadingLine === item.line ? 'bg-accent/60' : '',
+                  outlineFocusIndex === index ? 'bg-accent/40 ring-1 ring-primary/30' : '',
+                ]"
                 :style="{ paddingLeft: `${8 + (item.level - 1) * 16}px` }"
                 @click="jumpToHeadingAndClose(item.line)"
               >

--- a/apps/web/src/configs/keyboard-shortcuts.ts
+++ b/apps/web/src/configs/keyboard-shortcuts.ts
@@ -35,7 +35,16 @@ export function buildKeyboardShortcutCategories(): ShortcutCategory[] {
         { label: t(`menu.paste`), keys: mod(`V`) },
         { label: t(`menu.find`), keys: mod(`F`) },
         { label: t(`menu.replace`), keys: mod(`H`) },
+        { label: t(`keyboard.goToLine`), keys: mod(`G`) },
         { label: t(`menu.formatContent`), keys: [altSign, shiftSign, `F`] },
+      ],
+    },
+    {
+      title: t(`keyboard.category.navigation`),
+      items: [
+        { label: t(`keyboard.previousHeading`), keys: mod(altSign, `↑`) },
+        { label: t(`keyboard.nextHeading`), keys: mod(altSign, `↓`) },
+        { label: t(`keyboard.outlineNavigate`), keys: [`↑`, `↓`, `Enter`, `Esc`] },
       ],
     },
     {

--- a/apps/web/src/i18n/messages/en-US/chrome.ts
+++ b/apps/web/src/i18n/messages/en-US/chrome.ts
@@ -111,8 +111,13 @@ export default {
       general: `General`,
       edit: `Edit`,
       format: `Format`,
+      navigation: `Navigation`,
     },
     slashCommand: `Slash command`,
     closeSearchPanel: `Close search panel`,
+    goToLine: `Go to line`,
+    previousHeading: `Previous heading`,
+    nextHeading: `Next heading`,
+    outlineNavigate: `Outline panel navigation`,
   },
 }

--- a/apps/web/src/i18n/messages/zh-CN/chrome.ts
+++ b/apps/web/src/i18n/messages/zh-CN/chrome.ts
@@ -111,8 +111,13 @@ export default {
       general: `通用`,
       edit: `编辑`,
       format: `格式`,
+      navigation: `导航`,
     },
     slashCommand: `斜杠命令`,
     closeSearchPanel: `关闭搜索面板`,
+    goToLine: `跳转到行`,
+    previousHeading: `上一个标题`,
+    nextHeading: `下一个标题`,
+    outlineNavigate: `大纲面板导航`,
   },
 }

--- a/apps/web/src/lib/markdown/headingNavigation.test.ts
+++ b/apps/web/src/lib/markdown/headingNavigation.test.ts
@@ -1,0 +1,53 @@
+import type { MarkdownHeading } from './headings'
+import { describe, expect, it } from 'vitest'
+import {
+  clampGoToLineValue,
+  findAdjacentHeadingLine,
+  findOutlineFocusIndex,
+  moveOutlineFocusIndex,
+} from './headingNavigation'
+
+const headings: MarkdownHeading[] = [
+  { title: `Intro`, level: 1, line: 1 },
+  { title: `Setup`, level: 2, line: 5 },
+  { title: `Usage`, level: 2, line: 12 },
+  { title: `Tips`, level: 3, line: 20 },
+]
+
+describe(`clampGoToLineValue`, () => {
+  it(`clamps invalid and out-of-range values`, () => {
+    expect(clampGoToLineValue(``, 10)).toBe(1)
+    expect(clampGoToLineValue(`0`, 10)).toBe(1)
+    expect(clampGoToLineValue(`99`, 10)).toBe(10)
+    expect(clampGoToLineValue(`4`, 10)).toBe(4)
+  })
+})
+
+describe(`findAdjacentHeadingLine`, () => {
+  it(`finds previous heading`, () => {
+    expect(findAdjacentHeadingLine(headings, 15, `prev`)).toBe(12)
+    expect(findAdjacentHeadingLine(headings, 5, `prev`)).toBe(1)
+    expect(findAdjacentHeadingLine(headings, 1, `prev`)).toBeNull()
+  })
+
+  it(`finds next heading`, () => {
+    expect(findAdjacentHeadingLine(headings, 1, `next`)).toBe(5)
+    expect(findAdjacentHeadingLine(headings, 12, `next`)).toBe(20)
+    expect(findAdjacentHeadingLine(headings, 20, `next`)).toBeNull()
+  })
+})
+
+describe(`outline focus helpers`, () => {
+  it(`resolves active outline index`, () => {
+    expect(findOutlineFocusIndex(headings, 1)).toBe(0)
+    expect(findOutlineFocusIndex(headings, 15)).toBe(2)
+    expect(findOutlineFocusIndex(headings, 20)).toBe(3)
+  })
+
+  it(`moves outline focus with keyboard keys`, () => {
+    expect(moveOutlineFocusIndex(headings, 2, `ArrowUp`)).toBe(1)
+    expect(moveOutlineFocusIndex(headings, 2, `ArrowDown`)).toBe(3)
+    expect(moveOutlineFocusIndex(headings, 2, `Home`)).toBe(0)
+    expect(moveOutlineFocusIndex(headings, 2, `End`)).toBe(3)
+  })
+})

--- a/apps/web/src/lib/markdown/headingNavigation.ts
+++ b/apps/web/src/lib/markdown/headingNavigation.ts
@@ -1,0 +1,98 @@
+import type { EditorView } from '@codemirror/view'
+import type { MarkdownHeading } from './headings'
+import { extractMarkdownHeadings } from './headings'
+
+export type HeadingDirection = 'prev' | 'next'
+export type OutlineMoveKey = 'ArrowUp' | 'ArrowDown' | 'Home' | 'End'
+
+export function clampGoToLineValue(raw: string, totalLines: number): number {
+  const parsed = Number.parseInt(raw, 10)
+  const line = Number.isFinite(parsed) && parsed > 0 ? parsed : 1
+  return Math.max(1, Math.min(line, Math.max(totalLines, 1)))
+}
+
+export function findAdjacentHeadingLine(
+  headings: MarkdownHeading[],
+  currentLine: number,
+  direction: HeadingDirection,
+): number | null {
+  if (headings.length === 0)
+    return null
+
+  if (direction === `prev`) {
+    let candidate: number | null = null
+    for (const heading of headings) {
+      if (heading.line < currentLine)
+        candidate = heading.line
+      else
+        break
+    }
+    return candidate
+  }
+
+  for (const heading of headings) {
+    if (heading.line > currentLine)
+      return heading.line
+  }
+  return null
+}
+
+export function findOutlineFocusIndex(headings: MarkdownHeading[], activeLine: number): number {
+  if (headings.length === 0)
+    return -1
+
+  let index = 0
+  for (let i = 0; i < headings.length; i++) {
+    if (headings[i].line <= activeLine)
+      index = i
+    else
+      break
+  }
+  return index
+}
+
+export function moveOutlineFocusIndex(
+  headings: MarkdownHeading[],
+  currentIndex: number,
+  key: OutlineMoveKey,
+): number {
+  if (headings.length === 0)
+    return -1
+
+  const lastIndex = headings.length - 1
+  const safeIndex = currentIndex < 0 ? 0 : Math.min(currentIndex, lastIndex)
+
+  switch (key) {
+    case `ArrowUp`:
+      return Math.max(0, safeIndex - 1)
+    case `ArrowDown`:
+      return Math.min(lastIndex, safeIndex + 1)
+    case `Home`:
+      return 0
+    case `End`:
+      return lastIndex
+    default:
+      return safeIndex
+  }
+}
+
+export function jumpToLine(view: EditorView, lineNumber: number): boolean {
+  const target = clampGoToLineValue(String(lineNumber), view.state.doc.lines)
+  const line = view.state.doc.line(target)
+  view.dispatch({
+    selection: { anchor: line.from },
+    scrollIntoView: true,
+  })
+  view.focus()
+  return true
+}
+
+export function jumpToAdjacentHeading(view: EditorView, direction: HeadingDirection): boolean {
+  const headings = extractMarkdownHeadings(view.state.doc)
+  const currentLine = view.state.doc.lineAt(view.state.selection.main.head).number
+  const targetLine = findAdjacentHeadingLine(headings, currentLine, direction)
+  if (targetLine == null)
+    return false
+
+  return jumpToLine(view, targetLine)
+}

--- a/apps/web/src/lib/markdown/headings.test.ts
+++ b/apps/web/src/lib/markdown/headings.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { computeHeadingBreadcrumbs, extractMarkdownHeadings } from './headings'
+
+function mockDoc(lines: string[]) {
+  return {
+    lines: lines.length,
+    line: (n: number) => ({ text: lines[n - 1] ?? `` }),
+  }
+}
+
+describe(`extractMarkdownHeadings`, () => {
+  it(`extracts ATX headings`, () => {
+    const doc = mockDoc([
+      `# Title`,
+      `## Section`,
+      `plain text`,
+    ])
+    expect(extractMarkdownHeadings(doc)).toEqual([
+      { title: `Title`, level: 1, line: 1 },
+      { title: `Section`, level: 2, line: 2 },
+    ])
+  })
+
+  it(`ignores headings inside fenced code blocks`, () => {
+    const doc = mockDoc([
+      `# Real`,
+      `\`\`\``,
+      `# Not a heading`,
+      `\`\`\``,
+      `## After code`,
+    ])
+    expect(extractMarkdownHeadings(doc)).toEqual([
+      { title: `Real`, level: 1, line: 1 },
+      { title: `After code`, level: 2, line: 5 },
+    ])
+  })
+
+  it(`ignores headings inside front matter`, () => {
+    const doc = mockDoc([
+      `---`,
+      `title: "# Fake"`,
+      `---`,
+      `# Body`,
+    ])
+    expect(extractMarkdownHeadings(doc)).toEqual([
+      { title: `Body`, level: 1, line: 4 },
+    ])
+  })
+})
+
+describe(`computeHeadingBreadcrumbs`, () => {
+  const headings = [
+    { title: `A`, level: 1, line: 1 },
+    { title: `B`, level: 2, line: 5 },
+    { title: `C`, level: 2, line: 10 },
+    { title: `D`, level: 3, line: 15 },
+  ]
+
+  it(`builds nested breadcrumb stack`, () => {
+    expect(computeHeadingBreadcrumbs(headings, 12)).toEqual([
+      { title: `A`, level: 1, line: 1 },
+      { title: `C`, level: 2, line: 10 },
+    ])
+  })
+
+  it(`includes deeper heading when cursor is on it`, () => {
+    expect(computeHeadingBreadcrumbs(headings, 16)).toEqual([
+      { title: `A`, level: 1, line: 1 },
+      { title: `C`, level: 2, line: 10 },
+      { title: `D`, level: 3, line: 15 },
+    ])
+  })
+})

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -193,6 +193,13 @@ export const useUIStore = defineStore(`ui`, () => {
     searchTabRequest.value = null
   }
 
+  // 跳转行号（Footer 监听并打开输入框）
+  const goToLineRequest = ref(0)
+
+  function requestGoToLine() {
+    goToLineRequest.value++
+  }
+
   // ==================== 工具函数 ====================
   // 处理窗口大小变化
   let splitCollapsedByResize = false
@@ -292,6 +299,8 @@ export const useUIStore = defineStore(`ui`, () => {
     searchTabRequest,
     openSearchTab,
     clearSearchTabRequest,
+    goToLineRequest,
+    requestGoToLine,
 
     // ==================== Actions ====================
     toggleDark,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, `./src`),
+    },
+  },
+  test: {
+    environment: `node`,
+    include: [`src/**/*.test.ts`],
+  },
+})

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type-check": "pnpm type-check:web && pnpm type-check:packages",
     "type-check:web": "pnpm --filter @md/web exec vue-tsc --noEmit",
     "type-check:packages": "pnpm --filter @md/core --filter @md/shared --filter @md/api run type-check",
-    "test": "pnpm --filter @md/core test",
+    "test": "pnpm --filter @md/core test && pnpm --filter @md/web test",
     "postinstall": "simple-git-hooks",
     "inspector": "pnpx node-modules-inspector",
     "utools:package": "node ./scripts/package-utools.mjs",

--- a/packages/shared/src/editor/markdown.ts
+++ b/packages/shared/src/editor/markdown.ts
@@ -37,6 +37,7 @@ function insertTabAtCursor(view: EditorView): boolean {
 interface MarkdownKeymapOptions {
   onSearch?: (view: EditorView) => void
   onReplace?: (view: EditorView) => void
+  onGoToLine?: (view: EditorView) => void
   placeholder?: string
 }
 
@@ -47,7 +48,7 @@ interface MarkdownKeymapOptions {
  * @param options.onSearch - 搜索回调（可选）
  */
 export function markdownKeymap(options?: MarkdownKeymapOptions) {
-  const { onSearch, onReplace } = options || {}
+  const { onSearch, onReplace, onGoToLine } = options || {}
 
   return keymap.of([
     // Tab 键在光标位置插入缩进
@@ -83,8 +84,9 @@ export function markdownKeymap(options?: MarkdownKeymapOptions) {
     // 格式化
     { key: `Shift-Alt-f`, run: (view: EditorView) => { formatMarkdown(view); return true } },
 
-    // 阻止 Mod-g（避免触发 CodeMirror 内置搜索）
-    { key: `Mod-g`, run: () => true },
+    ...(onGoToLine
+      ? [{ key: `Mod-g`, run: (view: EditorView) => { onGoToLine(view); return true } }]
+      : [{ key: `Mod-g`, run: () => true }]),
   ])
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: 9.0.0
-        version: 9.0.0(@typescript-eslint/rule-tester@8.60.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 9.0.0(@typescript-eslint/rule-tester@8.60.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.0
@@ -135,7 +135,7 @@ importers:
         version: 5.28.5(esbuild@0.28.1)(webpack-cli@7.0.3)
       '@vscode/vsce':
         specifier: ^3.9.2
-        version: 3.9.2
+        version: 3.9.2(supports-color@5.5.0)
       ts-loader:
         specifier: ^9.6.1
         version: 9.6.1(typescript@6.0.3)(webpack@5.107.2)
@@ -325,7 +325,10 @@ importers:
         version: 0.11.0(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vite-plugin-vue-devtools:
         specifier: ^8.1.3
-        version: 8.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(supports-color@5.5.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.5
         version: 3.3.5(typescript@6.0.3)
@@ -334,7 +337,7 @@ importers:
         version: 4.103.0(@cloudflare/workers-types@4.20260621.1)
       wxt:
         specifier: ^0.20.26
-        version: 0.20.26(@types/node@26.0.0)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(less@4.6.6)(rolldown@1.0.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.20.26(@types/node@26.0.0)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(less@4.6.6)(rolldown@1.0.3)(supports-color@5.5.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   packages/config: {}
 
@@ -407,7 +410,7 @@ importers:
     dependencies:
       express:
         specifier: ^5.2.1
-        version: 5.2.1
+        version: 5.2.1(supports-color@5.5.0)
       form-data:
         specifier: 4.0.6
         version: 4.0.6
@@ -416,7 +419,7 @@ importers:
         version: 7.2.0
       http-proxy-middleware:
         specifier: ^4.1.1
-        version: 4.1.1
+        version: 4.1.1(supports-color@5.5.0)
       multer:
         specifier: ^2.2.0
         version: 2.2.0
@@ -465,7 +468,7 @@ importers:
         version: 6.5.3(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1(patch_hash=57e68d979309f5b8fe1e0feeb48eebdd7b795ba743cb4ae887bd0b8aca17001f))
       axios:
         specifier: ^1.18.0
-        version: 1.18.0
+        version: 1.18.0(supports-color@5.5.0)
       marked:
         specifier: ^18.0.5
         version: 18.0.5
@@ -7205,17 +7208,17 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@antfu/eslint-config@9.0.0(@typescript-eslint/rule-tester@8.60.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
+  '@antfu/eslint-config@9.0.0(@typescript-eslint/rule-tester@8.60.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.6.0
       '@e18e/eslint-plugin': 0.4.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.5.0(jiti@2.7.0))
-      '@eslint/markdown': 8.0.2
+      '@eslint/markdown': 8.0.2(supports-color@5.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
-      '@vitest/eslint-plugin': 1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
+      '@vitest/eslint-plugin': 1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       ansis: 4.3.1
       cac: 7.0.0
       eslint: 10.5.0(jiti@2.7.0)
@@ -7225,24 +7228,24 @@ snapshots:
       eslint-plugin-antfu: 3.2.3(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.60.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-import-lite: 0.6.0(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-jsdoc: 62.9.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-jsdoc: 62.9.0(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)
       eslint-plugin-jsonc: 3.2.0(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-n: 18.1.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-no-only-tests: 3.4.0
       eslint-plugin-perfectionist: 5.9.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-pnpm: 1.6.1(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-regexp: 3.1.0(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-toml: 1.4.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-toml: 1.4.0(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)
       eslint-plugin-unicorn: 64.0.0(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-vue: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-vue: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0))
       eslint-plugin-yml: 3.4.0(eslint@10.5.0(jiti@2.7.0))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.38)(eslint@10.5.0(jiti@2.7.0))
       globals: 17.6.0
       local-pkg: 1.2.1
       parse-gitignore: 2.0.0
       toml-eslint-parser: 1.0.3
-      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))
+      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)
       yaml-eslint-parser: 2.0.0
     optionalDependencies:
       eslint-plugin-format: 2.0.1(eslint@10.5.0(jiti@2.7.0))
@@ -7667,7 +7670,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -7707,13 +7710,13 @@ snapshots:
       lru-cache: 5.1.1
       semver: 7.8.5
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
       '@babel/traverse': 7.29.7
       semver: 7.8.5
@@ -7738,7 +7741,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -7751,9 +7754,9 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7
@@ -7782,48 +7785,48 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@5.5.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8391,12 +8394,12 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/markdown@8.0.2':
+  '@eslint/markdown@8.0.2(supports-color@5.5.0)':
     dependencies:
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-frontmatter: 2.0.1
       mdast-util-gfm: 3.1.0
       mdast-util-math: 3.0.0
@@ -8742,7 +8745,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.26
       jose: 6.2.3
@@ -8927,18 +8930,18 @@ snapshots:
     dependencies:
       '@secretlint/types': 10.2.2
 
-  '@secretlint/config-loader@10.2.2':
+  '@secretlint/config-loader@10.2.2(supports-color@5.5.0)':
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
       ajv: 8.20.0
       debug: 4.4.3(supports-color@5.5.0)
-      rc-config-loader: 4.1.4
+      rc-config-loader: 4.1.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/core@10.2.2':
+  '@secretlint/core@10.2.2(supports-color@5.5.0)':
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/types': 10.2.2
@@ -8947,11 +8950,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/formatter@10.2.2':
+  '@secretlint/formatter@10.2.2(supports-color@5.5.0)':
     dependencies:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
-      '@textlint/linter-formatter': 15.7.1
+      '@textlint/linter-formatter': 15.7.1(supports-color@5.5.0)
       '@textlint/module-interop': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 5.6.2
@@ -8963,11 +8966,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/node@10.2.2':
+  '@secretlint/node@10.2.2(supports-color@5.5.0)':
     dependencies:
-      '@secretlint/config-loader': 10.2.2
-      '@secretlint/core': 10.2.2
-      '@secretlint/formatter': 10.2.2
+      '@secretlint/config-loader': 10.2.2(supports-color@5.5.0)
+      '@secretlint/core': 10.2.2(supports-color@5.5.0)
+      '@secretlint/formatter': 10.2.2(supports-color@5.5.0)
       '@secretlint/profiler': 10.2.2
       '@secretlint/source-creator': 10.2.2
       '@secretlint/types': 10.2.2
@@ -9154,7 +9157,7 @@ snapshots:
 
   '@textlint/ast-node-types@15.7.1': {}
 
-  '@textlint/linter-formatter@15.7.1':
+  '@textlint/linter-formatter@15.7.1(supports-color@5.5.0)':
     dependencies:
       '@azu/format-text': 1.0.2
       '@azu/style-format': 1.0.1
@@ -9393,12 +9396,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
       eslint: 10.5.0(jiti@2.7.0)
@@ -9421,7 +9424,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
@@ -9435,8 +9438,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -9483,7 +9486,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
@@ -9588,13 +9591,13 @@ snapshots:
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@6.0.3)
 
-  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.5.0(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
       typescript: 6.0.3
       vitest: 4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -9692,10 +9695,10 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.9.2':
+  '@vscode/vsce@3.9.2(supports-color@5.5.0)':
     dependencies:
       '@azure/identity': 4.13.1
-      '@secretlint/node': 10.2.2
+      '@secretlint/node': 10.2.2(supports-color@5.5.0)
       '@secretlint/secretlint-formatter-sarif': 10.2.2
       '@secretlint/secretlint-rule-no-dotenv': 10.2.2
       '@secretlint/secretlint-rule-preset-recommend': 10.2.2
@@ -9715,7 +9718,7 @@ snapshots:
       minimatch: 10.2.5
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@5.5.0)
       semver: 7.8.5
       tmp: 0.2.7
       typed-rest-client: 1.8.11
@@ -9730,26 +9733,26 @@ snapshots:
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
-  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7)':
+  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@vue/babel-helper-vue-transform-on': 1.5.0
-      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.7)
+      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.7(supports-color@5.5.0))
       '@vue/shared': 3.5.38
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.29.7)':
+  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/parser': 7.29.7
@@ -9992,7 +9995,7 @@ snapshots:
 
   adm-zip@0.5.17: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
@@ -10107,11 +10110,11 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
-  axios@1.18.0:
+  axios@1.18.0(supports-color@5.5.0):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@5.5.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -10188,7 +10191,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -10362,12 +10365,12 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
-  chrome-launcher@1.2.0:
+  chrome-launcher@1.2.0(supports-color@5.5.0):
     dependencies:
       '@types/node': 26.0.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 2.0.2
+      lighthouse-logger: 2.0.2(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11084,7 +11087,7 @@ snapshots:
     dependencies:
       eslint: 10.5.0(jiti@2.7.0)
 
-  eslint-plugin-jsdoc@62.9.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-jsdoc@62.9.0(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0):
     dependencies:
       '@es-joy/jsdoccomment': 0.86.0
       '@es-joy/resolve.exports': 1.2.0
@@ -11166,7 +11169,7 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-toml@1.4.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-toml@1.4.0(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0):
     dependencies:
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -11197,13 +11200,13 @@ snapshots:
       semver: 7.8.5
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.5.0(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
 
-  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))):
+  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       eslint: 10.5.0(jiti@2.7.0)
@@ -11211,11 +11214,11 @@ snapshots:
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.4
       semver: 7.8.5
-      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))
+      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)
       xml-name-validator: 4.0.0
     optionalDependencies:
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0)(typescript@6.0.3)
 
   eslint-plugin-yml@3.4.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
@@ -11357,13 +11360,13 @@ snapshots:
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@5.5.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -11373,7 +11376,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -11384,8 +11387,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -11463,7 +11466,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -11719,7 +11722,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@4.1.1:
+  http-proxy-middleware@4.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       httpxy: 0.5.3
@@ -11729,9 +11732,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@5.5.0):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@5.5.0)
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -12090,7 +12093,7 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
-  lighthouse-logger@2.0.2:
+  lighthouse-logger@2.0.2(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       marky: 1.3.0
@@ -12271,14 +12274,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@5.5.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@5.5.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -12293,7 +12296,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -12311,7 +12314,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -12320,7 +12323,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12330,7 +12333,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12339,14 +12342,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -12362,7 +12365,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
@@ -12617,7 +12620,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@5.5.0):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@5.5.0)
@@ -13238,7 +13241,7 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  rc-config-loader@4.1.4:
+  rc-config-loader@4.1.4(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       js-yaml: 4.2.0
@@ -13430,7 +13433,7 @@ snapshots:
 
   round-polygon@0.6.7: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -13477,11 +13480,11 @@ snapshots:
 
   scule@1.3.0: {}
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@5.5.0):
     dependencies:
       '@secretlint/config-creator': 10.2.2
-      '@secretlint/formatter': 10.2.2
-      '@secretlint/node': 10.2.2
+      '@secretlint/formatter': 10.2.2(supports-color@5.5.0)
+      '@secretlint/node': 10.2.2(supports-color@5.5.0)
       '@secretlint/profiler': 10.2.2
       debug: 4.4.3(supports-color@5.5.0)
       globby: 14.1.0
@@ -13491,7 +13494,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -13512,7 +13515,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14268,7 +14271,7 @@ snapshots:
     dependencies:
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vite-plugin-vue-devtools@8.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+  vite-plugin-vue-devtools@8.1.3(supports-color@5.5.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-core': 8.1.3(vue@3.5.38(typescript@6.0.3))
       '@vue/devtools-kit': 8.1.3
@@ -14276,20 +14279,20 @@ snapshots:
       sirv: 3.0.2
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      vite-plugin-vue-inspector: 6.0.0(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite-plugin-vue-inspector: 6.0.0(supports-color@5.5.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@6.0.0(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-vue-inspector@6.0.0(supports-color@5.5.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@5.5.0)
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@5.5.0))
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@5.5.0))
       '@vue/compiler-dom': 3.5.38
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -14348,7 +14351,7 @@ snapshots:
     dependencies:
       vue: 3.5.38(typescript@6.0.3)
 
-  vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)):
+  vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.5.0(jiti@2.7.0)
@@ -14406,11 +14409,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
-  web-ext-run@0.2.4:
+  web-ext-run@0.2.4(supports-color@5.5.0):
     dependencies:
       '@babel/runtime': 7.28.2
       '@devicefarmer/adbkit': 3.3.8
-      chrome-launcher: 1.2.0
+      chrome-launcher: 1.2.0(supports-color@5.5.0)
       debounce: 1.2.1
       es6-error: 4.1.1
       firefox-profile: 4.7.0
@@ -14608,7 +14611,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.26(@types/node@26.0.0)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(less@4.6.6)(rolldown@1.0.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  wxt@0.20.26(@types/node@26.0.0)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(less@4.6.6)(rolldown@1.0.3)(supports-color@5.5.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0
@@ -14651,7 +14654,7 @@ snapshots:
       unimport: 6.3.0(rolldown@1.0.3)
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      web-ext-run: 0.2.4
+      web-ext-run: 0.2.4(supports-color@5.5.0)
     optionalDependencies:
       eslint: 10.5.0(jiti@2.7.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Add editor keyboard navigation: **Mod-g** (go to line), **Mod-Alt-↑/↓** (previous/next heading), and outline panel keys (↑/↓/Home/End/Enter/Esc)
- Extract reusable helpers in `headingNavigation.ts` and add vitest coverage for `@md/web` (headings + navigation)
- Wire `onGoToLine` in shared `markdownKeymap`; update shortcuts dialog i18n (zh-CN / en-US)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] `pnpm test` (core + web, 22 tests)
- [x] `pnpm --filter @md/web exec vue-tsc --noEmit`
- [ ] Manual: `Mod-g` opens footer go-to-line input
- [ ] Manual: `Mod-Alt-↑/↓` jumps between Markdown headings
- [ ] Manual: outline popover keyboard navigation works without double-step on arrow keys

## Pre-flight Checklist

- [x] Conventional commit on feature branch (not `main`)
- [x] i18n updated for both locales
- [x] No secrets or local-only config committed
