### PR TITLE
feat(share): let Pro users set share link expiration

### DIFF
--- a/apps/api/src/share-types.ts
+++ b/apps/api/src/share-types.ts
@@ -17,6 +17,9 @@ export interface ShareHtmlSnapshot {
 
 export type SharePasswordMode = `none` | `custom` | `auto`
 
+/** Pro 可选：1 天 / 7 天 / 30 天 / 永不过期；免费用户固定 1 天 */
+export type ShareExpiresMode = `1d` | `7d` | `30d` | `never`
+
 export interface CreateShareRequest {
   /** 前端文章 id，同一用户同一篇文章重复分享时链接不变 */
   postId: string
@@ -26,6 +29,8 @@ export interface CreateShareRequest {
   passwordMode?: SharePasswordMode
   /** passwordMode=custom 时必填 */
   password?: string
+  /** 链接有效期，Pro 用户可选；免费用户忽略并固定 1 天 */
+  expiresMode?: ShareExpiresMode
 }
 
 export interface CreateShareResponse {

--- a/apps/api/src/share.ts
+++ b/apps/api/src/share.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono'
-import type { CreateShareRequest, ShareHtmlSnapshot } from './share-types'
+import type { CreateShareRequest, ShareExpiresMode, ShareHtmlSnapshot } from './share-types'
 import type { Env } from './types'
 import { getCookie, setCookie } from 'hono/cookie'
 import { getUserById } from './db'
@@ -38,6 +38,12 @@ import { sanitizeHtmlSnapshot, sanitizeStylesSnapshot, SHARE_PAGE_CSP } from './
 const MAX_SNAPSHOT_BYTES = 2 * 1024 * 1024
 const MAX_POST_ID_LENGTH = 64
 const SHARE_EXPIRE_MS = 24 * 60 * 60 * 1000
+const SHARE_EXPIRE_MS_BY_MODE: Record<ShareExpiresMode, number | null> = {
+  '1d': SHARE_EXPIRE_MS,
+  '7d': 7 * SHARE_EXPIRE_MS,
+  '30d': 30 * SHARE_EXPIRE_MS,
+  'never': null,
+}
 const UNLOCK_ATTEMPT_LIMIT = 20
 
 async function deriveShareId(userId: string, postId: string): Promise<string> {
@@ -80,6 +86,23 @@ function parsePostId(value: unknown): string | null {
   if (!postId || postId.length > MAX_POST_ID_LENGTH)
     return null
   return postId
+}
+
+function parseShareExpiresMode(value: unknown): ShareExpiresMode | null {
+  if (value === `1d` || value === `7d` || value === `30d` || value === `never`)
+    return value
+  return null
+}
+
+function resolveShareExpiresAt(
+  body: CreateShareRequest,
+  plan: ReturnType<typeof getEffectivePlan>,
+  now: number,
+): number | null {
+  const requested = parseShareExpiresMode(body.expiresMode) ?? `1d`
+  const mode: ShareExpiresMode = plan === `pro` ? requested : `1d`
+  const delta = SHARE_EXPIRE_MS_BY_MODE[mode]
+  return delta == null ? null : now + delta
 }
 
 function buildShareUrl(c: Context<{ Bindings: Env, Variables: { userId: string } }>, id: string): string {
@@ -286,7 +309,7 @@ export async function createShareHandler(c: Context<{ Bindings: Env, Variables: 
   const existing = await getShareByUserAndPostId(c.env.DB, userId, postId)
 
   const now = Date.now()
-  const expiresAt = now + SHARE_EXPIRE_MS
+  const expiresAt = resolveShareExpiresAt(body, plan, now)
   const title = typeof body.title === `string` ? body.title.trim().slice(0, 200) : ``
   const id = existing?.id ?? await deriveShareId(userId, postId)
 

--- a/apps/web/src/components/editor/editor-header/ShareDialog.vue
+++ b/apps/web/src/components/editor/editor-header/ShareDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
-import type { ShareListItem, SharePasswordMode } from '@/services/share/types'
+import type { ShareExpiresMode, ShareListItem, SharePasswordMode } from '@/services/share/types'
 import { Check, Clock, Copy, ExternalLink, Eye, Globe, Inbox, KeyRound, Loader2, LogIn, RefreshCw, Share2, Sparkles, Trash2 } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed, ref, watch } from 'vue'
@@ -35,6 +35,11 @@ interface PasswordOption {
   icon: Component
 }
 
+interface ExpiresOption {
+  value: ShareExpiresMode
+  label: string
+}
+
 const { t } = useI18n()
 const authStore = useAuthStore()
 const postStore = usePostStore()
@@ -63,6 +68,13 @@ const passwordOptions = computed<PasswordOption[]>(() => [
   },
 ])
 
+const expiresOptions = computed<ExpiresOption[]>(() => [
+  { value: `1d`, label: t(`share.expiresMode.1d`) },
+  { value: `7d`, label: t(`share.expiresMode.7d`) },
+  { value: `30d`, label: t(`share.expiresMode.30d`) },
+  { value: `never`, label: t(`share.expiresMode.never`) },
+])
+
 const { isLoggedIn, user } = storeToRefs(authStore)
 const { shareDialogInitialTab } = storeToRefs(uiStore)
 const { locale } = storeToRefs(localeStore)
@@ -85,6 +97,7 @@ const dialogOpen = computed({
 
 const shareClient = new ShareClient(() => authStore.token)
 const passwordMode = ref<SharePasswordMode>(`none`)
+const expiresMode = ref<ShareExpiresMode>(`1d`)
 const customPassword = ref(``)
 const isSubmitting = ref(false)
 const submitStage = ref(``)
@@ -97,6 +110,8 @@ const copiedLink = ref(false)
 const copiedPassword = ref(false)
 
 const expiresLabel = computed(() => {
+  if (expiresAt.value == null && shareUrl.value)
+    return t(`share.permanent`)
   if (!expiresAt.value)
     return ``
   return t(`share.expiresAt`, { date: new Date(expiresAt.value).toLocaleString(locale.value) })
@@ -110,6 +125,7 @@ const canSubmit = computed(() => {
 
 function resetForm() {
   passwordMode.value = `none`
+  expiresMode.value = `1d`
   customPassword.value = ``
   shareUrl.value = ``
   sharePassword.value = ``
@@ -238,6 +254,7 @@ async function createShare() {
       htmlSnapshot,
       passwordMode: passwordMode.value,
       ...(passwordMode.value === `custom` ? { password: customPassword.value.trim() } : {}),
+      ...(isProUser.value ? { expiresMode: expiresMode.value } : {}),
     })
     shareUrl.value = result.url
     expiresAt.value = result.expiresAt
@@ -358,7 +375,10 @@ watch(isProUser, (pro) => {
         <template v-if="!shareUrl">
           <div class="space-y-4 px-4 py-4 sm:px-6">
             <div class="flex flex-wrap gap-2">
-              <span class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground">
+              <span
+                v-if="!isProUser"
+                class="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground"
+              >
                 <Clock class="size-3.5" />
                 {{ t('share.expiresIn1Day') }}
               </span>
@@ -368,6 +388,24 @@ watch(isProUser, (pro) => {
               >
                 {{ t('share.limitPerDay') }}
               </span>
+            </div>
+
+            <div v-if="isProUser" class="space-y-2">
+              <Label class="text-sm">{{ t('share.expiresLabel') }}</Label>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  v-for="option in expiresOptions"
+                  :key="option.value"
+                  type="button"
+                  class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+                  :class="expiresMode === option.value
+                    ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
+                    : 'text-muted-foreground hover:bg-muted/50'"
+                  @click="expiresMode = option.value"
+                >
+                  {{ option.label }}
+                </button>
+              </div>
             </div>
 
             <div class="space-y-2">

--- a/apps/web/src/i18n/messages/en-US/dialog.ts
+++ b/apps/web/src/i18n/messages/en-US/dialog.ts
@@ -9,6 +9,13 @@ export default {
     tabManage: `My Shares`,
     expiresIn1Day: `Expires in 1 day`,
     limitPerDay: `2 per day`,
+    expiresLabel: `Link validity`,
+    expiresMode: {
+      '1d': `1 day`,
+      '7d': `7 days`,
+      '30d': `30 days`,
+      'never': `Never expires`,
+    },
     passwordLabel: `Access password`,
     passwordMode: {
       public: {

--- a/apps/web/src/i18n/messages/zh-CN/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-CN/dialog.ts
@@ -9,6 +9,13 @@ export default {
     tabManage: `我的分享`,
     expiresIn1Day: `1 天后过期`,
     limitPerDay: `2 次/天`,
+    expiresLabel: `链接有效期`,
+    expiresMode: {
+      '1d': `1 天`,
+      '7d': `7 天`,
+      '30d': `30 天`,
+      'never': `永不过期`,
+    },
     passwordLabel: `访问密码`,
     passwordMode: {
       public: {

--- a/apps/web/src/services/share/types.ts
+++ b/apps/web/src/services/share/types.ts
@@ -5,12 +5,15 @@ export interface ShareHtmlSnapshot {
 
 export type SharePasswordMode = `none` | `custom` | `auto`
 
+export type ShareExpiresMode = `1d` | `7d` | `30d` | `never`
+
 export interface CreateShareRequest {
   postId: string
   title?: string
   htmlSnapshot: ShareHtmlSnapshot
   passwordMode?: SharePasswordMode
   password?: string
+  expiresMode?: ShareExpiresMode
 }
 
 export interface CreateShareResponse {


### PR DESCRIPTION
## Summary

- Allow Pro users to choose share link validity when generating preview links: 1 day, 7 days, 30 days, or never expires
- Free users remain limited to 1-day expiration; API ignores custom `expiresMode` for non-Pro plans
- Add compact expiry selector in the share dialog and i18n strings for zh-CN / en-US

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [ ] Sign in as a Pro user, open Share Preview, and verify expiry options (1 day / 7 days / 30 days / Never expires)
- [ ] Generate a share with each expiry mode and confirm the result page and My Shares list show the correct expiry or "Never expires"
- [ ] Sign in as a free user and confirm only the 1-day badge is shown with no expiry selector
- [ ] Deploy or run API locally and confirm `POST /share` respects `expiresMode` for Pro users

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits
- [x] i18n updated for both zh-CN and en-US
- [ ] Manually tested in the web app
