### PR TITLE
feat(share): show sharer name in share page footer

### DIFF
--- a/apps/api/src/share-gate-page.ts
+++ b/apps/api/src/share-gate-page.ts
@@ -1,4 +1,6 @@
+import type { ShareFooterAuthor } from './share-page'
 import { sharePageFaviconLink } from './share-head'
+import { buildShareAuthorHtml } from './share-page'
 import { sharePageCspMeta } from './share-sanitize'
 
 function escapeHtml(text: string): string {
@@ -12,7 +14,7 @@ function escapeHtml(text: string): string {
 export function buildShareGateHtml(
   shareId: string,
   title: string,
-  options: { error?: `invalid` | `rate_limited` } = {},
+  options: { error?: `invalid` | `rate_limited`, author?: ShareFooterAuthor } = {},
 ): string {
   const safeTitle = escapeHtml(title || `Markdown 分享`)
   const errorMessage = options.error === `rate_limited`
@@ -107,7 +109,6 @@ export function buildShareGateHtml(
       font-size: 12px;
       color: #999;
     }
-    .footer a { color: inherit; }
   </style>
 </head>
 <body>
@@ -121,7 +122,7 @@ export function buildShareGateHtml(
       <button type="submit">查看内容</button>
     </form>
     <div class="footer">
-      由 <a href="https://md.doocs.org" target="_blank" rel="noopener noreferrer">doocs/md</a> 分享
+      ${options.author ? buildShareAuthorHtml(options.author) : `由 doocs/md 分享`}
     </div>
   </div>
 </body>

--- a/apps/api/src/share-page.ts
+++ b/apps/api/src/share-page.ts
@@ -10,8 +10,11 @@ function escapeHtml(text: string): string {
 }
 
 export const SHARE_VIEW_COUNT_PLACEHOLDER = `{{SHARE_VIEW_COUNT}}`
+export const SHARE_AUTHOR_PLACEHOLDER = `{{SHARE_AUTHOR}}`
 
-const SHARE_DOOCS_URL = `https://github.com/doocs/md`
+export interface ShareFooterAuthor {
+  displayName: string
+}
 
 const SHARE_FOOTER_STYLES = `
     .share-footer {
@@ -33,9 +36,8 @@ const SHARE_FOOTER_STYLES = `
       line-height: 1.6;
       color: #888;
     }
-    .share-footer-copy a {
+    .share-footer-author {
       color: #555;
-      text-decoration: none;
       font-weight: 500;
     }
     .share-footer-divider {
@@ -49,18 +51,27 @@ const SHARE_FOOTER_STYLES = `
       letter-spacing: 0.02em;
     }`
 
-function buildShareFooterHtml(viewCount: number | string): string {
+export function buildShareAuthorHtml(author: ShareFooterAuthor): string {
+  const safeName = escapeHtml(author.displayName)
+  return `由 ${safeName} 分享`
+}
+
+function buildShareFooterHtml(authorHtml: string, viewCount: number | string): string {
   const count = typeof viewCount === `string`
     ? viewCount
     : String(Math.max(0, Math.floor(viewCount)))
 
   return `<div class="share-footer">
       <p class="share-footer-inner">
-        <span class="share-footer-copy">Copyright © <a href="${SHARE_DOOCS_URL}" target="_blank" rel="noopener noreferrer">Doocs</a>. All rights reserved.</span>
+        <span class="share-footer-author">${authorHtml}</span>
         <span class="share-footer-divider" aria-hidden="true">·</span>
         <span class="share-footer-meta">阅读 ${count} 次</span>
       </p>
     </div>`
+}
+
+function buildShareFooterWithPlaceholders(): string {
+  return buildShareFooterHtml(SHARE_AUTHOR_PLACEHOLDER, SHARE_VIEW_COUNT_PLACEHOLDER)
 }
 
 export function buildSharePageHtml(
@@ -107,7 +118,7 @@ export function buildSharePageHtml(
     <div class="share-content">
     ${bodyHtml}
     </div>
-    ${buildShareFooterHtml(SHARE_VIEW_COUNT_PLACEHOLDER)}
+    ${buildShareFooterWithPlaceholders()}
   </div>
 </body>
 </html>`
@@ -115,23 +126,34 @@ export function buildSharePageHtml(
 
 const LEGACY_FOOTER_RE = /<div class="share-footer">[\s\S]*?<\/div>/
 
-/** 将快照 HTML 中的阅读数占位符替换为当前值（兼容旧版 footer） */
-export function injectShareViewCount(html: string, viewCount: number): string {
-  const safeCount = Math.max(0, Math.floor(viewCount))
-  const countText = String(safeCount)
+function ensureShareFooterStyles(html: string): string {
+  if (html.includes(`.share-footer-author {`))
+    return html
+  return html.replace(`</style>`, `${SHARE_FOOTER_STYLES}\n  </style>`)
+}
 
-  let next = html.includes(SHARE_VIEW_COUNT_PLACEHOLDER)
-    ? html.replaceAll(SHARE_VIEW_COUNT_PLACEHOLDER, countText)
-    : html
+/** 将快照 HTML 中的 footer 占位符替换为分享者与阅读数（兼容旧版 footer） */
+export function injectShareFooter(
+  html: string,
+  author: ShareFooterAuthor,
+  viewCount: number,
+): string {
+  const authorHtml = buildShareAuthorHtml(author)
+  const countText = String(Math.max(0, Math.floor(viewCount)))
 
-  if (next.includes(`share-footer-inner`))
-    return next
+  let next = html
+  if (next.includes(SHARE_AUTHOR_PLACEHOLDER))
+    next = next.replaceAll(SHARE_AUTHOR_PLACEHOLDER, authorHtml)
+  if (next.includes(SHARE_VIEW_COUNT_PLACEHOLDER))
+    next = next.replaceAll(SHARE_VIEW_COUNT_PLACEHOLDER, countText)
 
-  if (!LEGACY_FOOTER_RE.test(next))
-    return next
+  const needsLegacyFooter = next.includes(`share-footer-copy`)
+    || (next.includes(`share-footer`) && !next.includes(`share-footer-author`))
 
-  next = next.replace(LEGACY_FOOTER_RE, buildShareFooterHtml(safeCount))
-  if (!next.includes(`.share-footer-inner {`))
-    next = next.replace(`</style>`, `${SHARE_FOOTER_STYLES}\n  </style>`)
+  if (needsLegacyFooter && LEGACY_FOOTER_RE.test(next)) {
+    next = next.replace(LEGACY_FOOTER_RE, buildShareFooterHtml(authorHtml, countText))
+    next = ensureShareFooterStyles(next)
+  }
+
   return next
 }

--- a/apps/api/src/share.ts
+++ b/apps/api/src/share.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import type { ShareFooterAuthor } from './share-page'
 import type { CreateShareRequest, ShareExpiresMode, ShareHtmlSnapshot } from './share-types'
 import type { Env } from './types'
 import { getCookie, setCookie } from 'hono/cookie'
@@ -21,7 +22,7 @@ import {
   updateShareContent,
 } from './share-db'
 import { buildShareGateHtml } from './share-gate-page'
-import { buildSharePageHtml, injectShareViewCount } from './share-page'
+import { buildSharePageHtml, injectShareFooter } from './share-page'
 import {
   generateSharePassword,
   hashSharePassword,
@@ -359,6 +360,16 @@ export async function createShareHandler(c: Context<{ Bindings: Env, Variables: 
   })
 }
 
+async function resolveShareAuthor(db: D1Database, userId: string): Promise<ShareFooterAuthor> {
+  const user = await getUserById(db, userId)
+  if (!user)
+    return { displayName: `未知用户` }
+
+  return {
+    displayName: user.name?.trim() || user.login,
+  }
+}
+
 export async function viewShareHandler(c: Context<{ Bindings: Env }>) {
   const id = c.req.param(`shareId`)
   if (!id || !SHARE_ID_RE.test(id))
@@ -376,13 +387,17 @@ export async function viewShareHandler(c: Context<{ Bindings: Env }>) {
     if (!unlocked) {
       const error = c.req.query(`error`)
       const gateError = error === `rate_limited` || error === `invalid` ? error : undefined
-      return shareHtml(c, buildShareGateHtml(id, share.title, { error: gateError }))
+      const author = await resolveShareAuthor(c.env.DB, share.user_id)
+      return shareHtml(c, buildShareGateHtml(id, share.title, { error: gateError, author }))
     }
   }
 
-  const viewCount = await incrementShareViewCount(c.env.DB, id)
+  const [viewCount, author] = await Promise.all([
+    incrementShareViewCount(c.env.DB, id),
+    resolveShareAuthor(c.env.DB, share.user_id),
+  ])
 
-  return shareHtml(c, injectShareViewCount(share.html, viewCount))
+  return shareHtml(c, injectShareFooter(share.html, author, viewCount))
 }
 
 export async function unlockShareHandler(c: Context<{ Bindings: Env }>) {


### PR DESCRIPTION
## Summary

- Replace the share page copyright footer with plain-text sharer attribution (e.g. "由 张三 分享")
- Resolve sharer display name from the user profile at view time (name, or GitHub login as fallback)
- Apply the same attribution on password-protected share gate pages
- Migrate legacy footers on view for existing share snapshots

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [ ] Open an existing share link and verify the footer shows sharer name and view count without a hyperlink
- [ ] Create a new share and confirm the footer renders correctly after first view
- [ ] Open a password-protected share gate page and verify sharer name appears in the footer
- [ ] Confirm legacy shares with the old copyright footer are upgraded on view

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits
- [ ] Manually tested on deployed Worker
