### PR TITLE
fix(infographic): stabilize preview, share export, and theme colors

### DIFF
--- a/apps/web/src/components/editor/PreviewPanel.vue
+++ b/apps/web/src/components/editor/PreviewPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { DiagramDownloadOverlay } from '@/lib/preview/diagram-download'
-import { highlightPendingBlocks, hljs } from '@md/core'
+import { highlightPendingBlocks, hljs, hydratePendingInfographicDiagrams } from '@md/core'
 import { setupDiagramDownloadOverlay } from '@/lib/preview/diagram-download'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
@@ -16,7 +16,7 @@ const renderStore = useRenderStore()
 const uiStore = useUIStore()
 
 const { output } = storeToRefs(renderStore)
-const { isMobile, viewMode, previewDevice } = storeToRefs(uiStore)
+const { isDark, isMobile, viewMode, previewDevice } = storeToRefs(uiStore)
 
 const effectivePreviewWidth = computed(() => {
   if (isMobile.value)
@@ -26,13 +26,25 @@ const effectivePreviewWidth = computed(() => {
 
 const previewRef = useTemplateRef<HTMLDivElement>(`previewRef`)
 
-watch(output, () => {
-  nextTick(() => {
-    const outputElement = document.getElementById(`output`)
-    if (outputElement) {
-      highlightPendingBlocks(hljs, outputElement)
-    }
+function hydratePreviewDiagrams() {
+  const outputElement = document.getElementById(`output`)
+  if (!outputElement)
+    return
+
+  highlightPendingBlocks(hljs, outputElement)
+  hydratePendingInfographicDiagrams(outputElement, {
+    themeMode: isDark.value ? `dark` : `light`,
   })
+}
+
+watch(output, () => {
+  nextTick(hydratePreviewDiagrams)
+})
+
+watch(viewMode, () => {
+  if (viewMode.value === `edit`)
+    return
+  nextTick(hydratePreviewDiagrams)
 })
 
 let diagramOverlay: DiagramDownloadOverlay | null = null
@@ -54,6 +66,7 @@ onMounted(() => {
     const outputEl = document.getElementById(`output`)
     if (outputEl) {
       diagramOverlay = setupDiagramDownloadOverlay(outputEl)
+      hydratePreviewDiagrams()
     }
   })
 })

--- a/apps/web/src/lib/preview/preview-ready.ts
+++ b/apps/web/src/lib/preview/preview-ready.ts
@@ -1,8 +1,19 @@
+import { hydratePendingInfographicDiagrams } from '@md/core'
+import { nextTick } from 'vue'
+
 const PREVIEW_READY_TIMEOUT_MS = 20_000
 const PREVIEW_POLL_INTERVAL_MS = 250
 
+export interface WaitForPreviewReadyOptions {
+  themeMode?: `light` | `dark`
+}
+
 function delay(ms: number) {
   return new Promise<void>(resolve => window.setTimeout(resolve, ms))
+}
+
+function resolveInfographicOptions(options?: WaitForPreviewReadyOptions) {
+  return options?.themeMode ? { themeMode: options.themeMode } : undefined
 }
 
 function isDiagramStillLoading(output: HTMLElement): boolean {
@@ -34,19 +45,32 @@ function isMathStillLoading(output: HTMLElement): boolean {
 }
 
 /** 等待预览区异步图表与公式渲染完成；超时返回 false */
-export async function waitForPreviewReady(timeoutMs = PREVIEW_READY_TIMEOUT_MS): Promise<boolean> {
+export async function waitForPreviewReady(
+  timeoutMs = PREVIEW_READY_TIMEOUT_MS,
+  options?: WaitForPreviewReadyOptions,
+): Promise<boolean> {
+  // 等待 Vue 将 renderStore.output 同步到 #output，避免检测到旧 DOM 后提前返回
+  await nextTick()
+  await nextTick()
+
   const output = document.getElementById(`output`)
   if (!output)
     return false
 
+  const infographicOptions = resolveInfographicOptions(options)
   const deadline = Date.now() + timeoutMs
+
   while (Date.now() < deadline) {
+    hydratePendingInfographicDiagrams(output, infographicOptions)
+
     if (!isDiagramStillLoading(output) && !isMathStillLoading(output))
       return true
+
     await delay(PREVIEW_POLL_INTERVAL_MS)
   }
 
-  return false
+  hydratePendingInfographicDiagrams(output, infographicOptions)
+  return !isDiagramStillLoading(output) && !isMathStillLoading(output)
 }
 
 /** 移除仍未渲染完成的占位内容，避免复制/导出时出现「正在加载…」文案 */

--- a/apps/web/src/services/export/html-content.ts
+++ b/apps/web/src/services/export/html-content.ts
@@ -1,9 +1,15 @@
+import { hydratePendingInfographicDiagrams } from '@md/core'
+
 /** 获取 HTML 内容 */
-export function getHtmlContent(): string {
+export function getHtmlContent(options?: { themeMode?: `light` | `dark` }): string {
   const element = document.querySelector(`#output`)
   if (!element)
     return ``
   const clone = element.cloneNode(true) as HTMLElement
   clone.querySelectorAll(`.diagram-download-bar`).forEach(el => el.remove())
+  hydratePendingInfographicDiagrams(
+    clone,
+    options?.themeMode ? { themeMode: options.themeMode } : undefined,
+  )
   return clone.innerHTML
 }

--- a/apps/web/src/services/share/capture-snapshot.ts
+++ b/apps/web/src/services/share/capture-snapshot.ts
@@ -1,4 +1,4 @@
-import { waitForPreviewReady } from '@/lib/preview/preview-ready'
+import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from '@/lib/preview/preview-ready'
 import { getHtmlContent, getShareExportStyles } from '@/services/export'
 import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
@@ -11,18 +11,24 @@ export async function captureShareSnapshot(): Promise<{ bodyHtml: string, styles
   const uiStore = useUIStore()
   const content = editorStore.getContent()
   const rerenderForLight = uiStore.isDark
+  const shareThemeMode = `light` as const
 
-  if (rerenderForLight) {
-    renderStore.render(content, { themeMode: `light` })
-    await waitForPreviewReady()
-  }
-  else {
-    await waitForPreviewReady()
-  }
+  if (rerenderForLight)
+    renderStore.render(content, { themeMode: shareThemeMode })
+
+  const ready = await waitForPreviewReady(undefined, { themeMode: shareThemeMode })
 
   try {
+    let bodyHtml = getHtmlContent({ themeMode: shareThemeMode })
+    if (!ready) {
+      const wrapper = document.createElement(`div`)
+      wrapper.innerHTML = bodyHtml
+      stripUnresolvedAsyncPlaceholders(wrapper)
+      bodyHtml = wrapper.innerHTML
+    }
+
     return {
-      bodyHtml: getHtmlContent(),
+      bodyHtml,
       stylesHtml: await getShareExportStyles(),
     }
   }

--- a/packages/core/src/extensions/infographic.ts
+++ b/packages/core/src/extensions/infographic.ts
@@ -12,13 +12,106 @@ type InfographicOptionsSource = InfographicOptions | (() => InfographicOptions |
 
 // key -> svg（LRU 缓存，上限 50 条）
 const svgCache = createSVGCache(50)
+const pendingMeta = new Map<string, { code: string, options?: InfographicOptions }>()
+const inFlight = new Set<string>()
 
 const RE_INFOGRAPHIC_START = /^```infographic/m
 const RE_INFOGRAPHIC_BLOCK = /^```infographic\r?\n([\s\S]*?)\r?\n```/
+const INFOGRAPHIC_ID_PREFIX = `infographic-`
+const OFFSCREEN_ROOT_ID = `md-infographic-offscreen-root`
+const OFFSCREEN_WIDTH = `800px`
+
+const INFOGRAPHIC_LIGHT_COLORS = {
+  theme: `default` as const,
+  colorBg: `#ffffff`,
+  colorText: `#262626`,
+  svgBackground: `transparent`,
+}
+
+const INFOGRAPHIC_DARK_COLORS = {
+  theme: `dark` as const,
+  colorBg: `#1f1f1f`,
+  colorText: `#ffffff`,
+  svgBackground: `#1f1f1f`,
+}
+
+function resolveInfographicTheme(options?: InfographicOptions) {
+  const palette = options?.themeMode === `dark` ? INFOGRAPHIC_DARK_COLORS : INFOGRAPHIC_LIGHT_COLORS
+
+  let colorPrimary: string | undefined
+  if (typeof window !== `undefined`) {
+    colorPrimary = getComputedStyle(document.documentElement)
+      .getPropertyValue(`--md-primary-color`)
+      .trim() || undefined
+  }
+
+  return {
+    theme: palette.theme,
+    svgBackground: palette.svgBackground,
+    themeConfig: {
+      colorPrimary,
+      colorBg: palette.colorBg,
+      colorText: palette.colorText,
+    },
+  }
+}
+
+function resolveOptions(options?: InfographicOptionsSource): InfographicOptions | undefined {
+  return typeof options === `function` ? options() : options
+}
+
+function getOffscreenRoot(): HTMLDivElement {
+  let root = document.getElementById(OFFSCREEN_ROOT_ID) as HTMLDivElement | null
+  if (!root) {
+    root = document.createElement(`div`)
+    root.id = OFFSCREEN_ROOT_ID
+    root.style.cssText = `position:fixed;left:-9999px;top:0;width:${OFFSCREEN_WIDTH};visibility:hidden;pointer-events:none;overflow:hidden;`
+    document.body.appendChild(root)
+  }
+  return root
+}
+
+function svgElementToHtml(svg: SVGElement | Node): string {
+  const wrapper = document.createElement(`div`)
+  wrapper.replaceChildren(svg)
+  return wrapper.innerHTML
+}
+
+function applySvgByCacheKey(cacheKey: string, svgHtml: string) {
+  const el = document.getElementById(`${INFOGRAPHIC_ID_PREFIX}${cacheKey}`)
+  if (el)
+    el.innerHTML = svgHtml
+}
+
+function showInfographicError(containerId: string, error: unknown) {
+  const container = document.getElementById(containerId)
+  if (!container)
+    return
+
+  const message = error instanceof Error ? error.message : String(error)
+  container.innerHTML = `<div style="color: red; padding: 10px; border: 1px solid red;">Infographic 渲染失败: ${message}</div>`
+}
 
 async function renderInfographic(containerId: string, code: string, cacheKey: string, options?: InfographicOptions) {
-  if (typeof window === 'undefined')
+  if (typeof window === `undefined`)
     return
+
+  pendingMeta.set(cacheKey, { code, options })
+
+  const cached = svgCache.get(cacheKey)
+  if (cached) {
+    applySvgByCacheKey(cacheKey, cached)
+    return
+  }
+
+  if (inFlight.has(cacheKey))
+    return
+
+  inFlight.add(cacheKey)
+
+  const offscreenContainer = document.createElement(`div`)
+  offscreenContainer.style.width = OFFSCREEN_WIDTH
+  getOffscreenRoot().appendChild(offscreenContainer)
 
   try {
     const { Infographic, setDefaultFont, setFontExtendFactor, exportToSVG } = await import('@antv/infographic')
@@ -26,84 +119,90 @@ async function renderInfographic(containerId: string, code: string, cacheKey: st
     setFontExtendFactor(1.1)
     setDefaultFont('-apple-system-font, "system-ui", "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", Arial, sans-serif')
 
-    const findContainer = (retries = 5, delay = 100) => {
-      const container = document.getElementById(containerId)
-      if (container) {
-        const isDark = options?.themeMode === 'dark'
+    const { theme, svgBackground, themeConfig } = resolveInfographicTheme(options)
 
-        // 从 CSS 变量中读取主题颜色
-        const root = document.documentElement
-        const computedStyle = getComputedStyle(root)
-        const primaryColor = computedStyle.getPropertyValue('--md-primary-color').trim()
-        const backgroundColor = computedStyle.getPropertyValue('--background').trim()
-
-        // 转换 HSL 格式
-        const toHSLString = (variant: string) => {
-          const vars = variant.split(' ')
-          if (vars.length === 3)
-            return `hsl(${vars.join(', ')})`
-          if (vars.length === 4)
-            return `hsla(${vars.join(', ')})`
-          return ''
-        }
-
-        const instance = new Infographic({
-          container,
-          svg: {
-            style: {
-              width: '100%',
-              height: '100%',
-              background: isDark ? '#000' : 'transparent',
-            },
-            background: false,
+    await new Promise<void>((resolve, reject) => {
+      const instance = new Infographic({
+        container: offscreenContainer,
+        svg: {
+          style: {
+            width: `100%`,
+            height: `100%`,
+            background: svgBackground,
           },
-          theme: isDark ? 'dark' : 'default',
-          themeConfig: {
-            colorPrimary: primaryColor || undefined,
-            colorBg: toHSLString(backgroundColor) || undefined,
-          },
-        })
+          background: false,
+        },
+        theme,
+        themeConfig,
+      })
 
-        instance.on('loaded', ({ node }) => {
-          exportToSVG(node, { removeIds: true }).then((svg) => {
-            container.replaceChildren(svg)
-            svgCache.set(cacheKey, container.innerHTML)
+      instance.on(`loaded`, ({ node }) => {
+        exportToSVG(node, { removeIds: true })
+          .then((svg) => {
+            const svgHtml = svgElementToHtml(svg)
+            svgCache.set(cacheKey, svgHtml)
+            applySvgByCacheKey(cacheKey, svgHtml)
+            resolve()
           })
-        })
+          .catch(reject)
+      })
 
+      try {
         instance.render(code)
-
-        return
       }
-
-      if (retries > 0) {
-        setTimeout(findContainer, delay, retries - 1, delay)
+      catch (error) {
+        reject(error)
       }
-    }
-
-    findContainer()
+    })
   }
   catch (error) {
-    console.error('Failed to render Infographic:', error)
-    const container = document.getElementById(containerId)
-    if (container) {
-      container.innerHTML = `<div style="color: red; padding: 10px; border: 1px solid red;">Infographic 渲染失败: ${error instanceof Error ? error.message : String(error)}</div>`
-    }
+    console.error(`Failed to render Infographic:`, error)
+    showInfographicError(containerId, error)
+  }
+  finally {
+    offscreenContainer.remove()
+    inFlight.delete(cacheKey)
   }
 }
 
-function resolveOptions(options?: InfographicOptionsSource): InfographicOptions | undefined {
-  return typeof options === 'function' ? options() : options
+/** 预览区 DOM 更新后，将缓存 SVG 写入占位节点或重试未完成的渲染 */
+export function hydratePendingInfographicDiagrams(root: ParentNode, options?: InfographicOptions) {
+  if (typeof window === `undefined`)
+    return
+
+  root.querySelectorAll<HTMLElement>(`.infographic-diagram`).forEach((el) => {
+    if (el.querySelector(`svg, img`))
+      return
+
+    const text = el.textContent ?? ``
+    if (text.includes(`渲染失败`))
+      return
+
+    const id = el.id
+    if (!id?.startsWith(INFOGRAPHIC_ID_PREFIX))
+      return
+
+    const cacheKey = id.slice(INFOGRAPHIC_ID_PREFIX.length)
+    const cached = svgCache.get(cacheKey)
+    if (cached) {
+      el.innerHTML = cached
+      return
+    }
+
+    const meta = pendingMeta.get(cacheKey)
+    if (meta)
+      void renderInfographic(id, meta.code, cacheKey, options ?? meta.options)
+  })
 }
 
 export function markedInfographic(options?: InfographicOptionsSource): MarkedExtension {
-  const className = 'infographic-diagram'
+  const className = `infographic-diagram`
 
   return {
     extensions: [
       {
-        name: 'infographic',
-        level: 'block',
+        name: `infographic`,
+        level: `block`,
         start(src: string) {
           return src.match(RE_INFOGRAPHIC_START)?.index
         },
@@ -111,7 +210,7 @@ export function markedInfographic(options?: InfographicOptionsSource): MarkedExt
           const match = RE_INFOGRAPHIC_BLOCK.exec(src)
           if (match) {
             return {
-              type: 'infographic',
+              type: `infographic`,
               raw: match[0],
               text: match[1].trim(),
             }
@@ -120,25 +219,23 @@ export function markedInfographic(options?: InfographicOptionsSource): MarkedExt
         renderer: asTextTokenRenderer((token: InfographicToken) => {
           const code = token.text
           const currentOptions = resolveOptions(options)
-          const cacheKey = simpleHash(`${code}-${currentOptions?.themeMode || 'light'}`)
+          const cacheKey = simpleHash(`${code}-${currentOptions?.themeMode || `light`}-v2`)
 
-          // 有缓存直接返回
           const cached = svgCache.get(cacheKey)
           if (cached) {
             return `<!--infographic-start--><div class="${className}" style="width: 100%;">${cached}</div><!--infographic-end-->`
           }
 
-          // 没有缓存，触发渲染
-          const id = `infographic-${cacheKey}`
-          renderInfographic(id, code, cacheKey, currentOptions)
+          const id = `${INFOGRAPHIC_ID_PREFIX}${cacheKey}`
+          void renderInfographic(id, code, cacheKey, currentOptions)
 
           return `<!--infographic-start--><div id="${id}" class="${className}" style="width: 100%;">正在加载 Infographic...</div><!--infographic-end-->`
         }),
       },
     ],
     walkTokens(token: Token) {
-      if (isCodeToken(token) && token.lang === 'infographic') {
-        asDiagramToken<InfographicToken>(token, 'infographic')
+      if (isCodeToken(token) && token.lang === `infographic`) {
+        asDiagramToken<InfographicToken>(token, `infographic`)
       }
     },
   }


### PR DESCRIPTION
## Summary

- Render Infographic charts offscreen and hydrate pending placeholders after preview DOM updates, so charts appear reliably in split/preview mode.
- Wait for Vue DOM sync and Infographic hydration before capturing share snapshots, and apply cached SVG when exporting HTML.
- Use explicit light/dark theme palettes (background and text colors) instead of reading `--background` from the page, fixing invisible white-on-white text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [ ] Open a document with ` ```infographic ` blocks in split/preview mode and confirm charts render (not stuck on "正在加载 Infographic...").
- [ ] Switch between edit/split/preview and dark/light mode; confirm Infographic text remains readable.
- [ ] Generate a share preview link and verify shared HTML shows rendered Infographic SVG without loading placeholders or invisible text.
- [ ] Run `pnpm web build` and `pnpm run type-check`.

## Pre-flight Checklist

- [x] Follows Conventional Commits for the commit message
- [x] Changes are scoped to Infographic preview/share rendering
- [ ] Manually verified in the web app (reviewer or author)
