### PR TITLE
fix(preview): unblock boot loader when async diagrams fail

### DIFF
--- a/apps/web/src/i18n/messages/en-US/store.ts
+++ b/apps/web/src/i18n/messages/en-US/store.ts
@@ -84,6 +84,12 @@ export default {
   diagram: {
     downloadSvg: `Download as SVG`,
     downloadPng: `Download as PNG`,
+    mermaidLoading: `Loading Mermaid…`,
+    mermaidError: `Mermaid render failed: {detail}`,
+    plantumlLoading: `Loading PlantUML diagram…`,
+    plantumlError: `Failed to load PlantUML diagram`,
+    infographicLoading: `Loading infographic…`,
+    infographicError: `Infographic render failed: {detail}`,
   },
   popup: {
     mustRead: `Before you start`,

--- a/apps/web/src/i18n/messages/zh-CN/store.ts
+++ b/apps/web/src/i18n/messages/zh-CN/store.ts
@@ -84,6 +84,12 @@ export default {
   diagram: {
     downloadSvg: `下载为 SVG`,
     downloadPng: `下载为 PNG`,
+    mermaidLoading: `正在加载 Mermaid...`,
+    mermaidError: `Mermaid 渲染失败: {detail}`,
+    plantumlLoading: `正在加载 PlantUML 图表...`,
+    plantumlError: `PlantUML 图表加载失败`,
+    infographicLoading: `正在加载 Infographic...`,
+    infographicError: `Infographic 渲染失败: {detail}`,
   },
   popup: {
     mustRead: `使用必读`,

--- a/apps/web/src/lib/preview/preview-ready.test.ts
+++ b/apps/web/src/lib/preview/preview-ready.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { MD_DIAGRAM_STATE, MD_DIAGRAM_STATE_ATTR } from '@md/core'
+import { describe, expect, it } from 'vitest'
+import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from './preview-ready'
+
+function diagram(className: string, state: string, innerHTML: string) {
+  const el = document.createElement(`div`)
+  el.className = className
+  el.setAttribute(MD_DIAGRAM_STATE_ATTR, state)
+  el.innerHTML = innerHTML
+  return el
+}
+
+describe(`waitForPreviewReady`, () => {
+  it(`resolves immediately when async diagrams failed`, async () => {
+    const output = document.createElement(`div`)
+    output.id = `output`
+    output.append(
+      diagram(`mermaid-diagram`, MD_DIAGRAM_STATE.error, `<div>Mermaid render failed: syntax error</div>`),
+      diagram(`plantuml-diagram`, MD_DIAGRAM_STATE.error, `<div>Failed to load PlantUML diagram</div>`),
+      diagram(`infographic-diagram`, MD_DIAGRAM_STATE.error, `<div>Infographic render failed: invalid</div>`),
+    )
+    document.body.append(output)
+
+    const started = Date.now()
+    const ready = await waitForPreviewReady(20_000)
+    const elapsed = Date.now() - started
+
+    expect(ready).toBe(true)
+    expect(elapsed).toBeLessThan(1_000)
+
+    output.remove()
+  })
+
+  it(`waits while diagrams are still loading`, async () => {
+    const output = document.createElement(`div`)
+    output.id = `output`
+    output.append(diagram(`mermaid-diagram`, MD_DIAGRAM_STATE.loading, `Loading Mermaid…`))
+    document.body.append(output)
+
+    const readyPromise = waitForPreviewReady(500)
+    await new Promise(resolve => setTimeout(resolve, 100))
+    output.firstElementChild?.setAttribute(MD_DIAGRAM_STATE_ATTR, MD_DIAGRAM_STATE.ready)
+    output.firstElementChild!.innerHTML = `<svg><path /></svg>`
+
+    const ready = await readyPromise
+    expect(ready).toBe(true)
+
+    output.remove()
+  })
+})
+
+describe(`stripUnresolvedAsyncPlaceholders`, () => {
+  it(`removes loading placeholders but keeps failure messages`, () => {
+    const root = document.createElement(`div`)
+    root.append(
+      diagram(`mermaid-diagram`, MD_DIAGRAM_STATE.loading, `Loading Mermaid…`),
+      diagram(`mermaid-diagram`, MD_DIAGRAM_STATE.error, `<div>Mermaid render failed: syntax error</div>`),
+      diagram(`plantuml-diagram`, MD_DIAGRAM_STATE.error, `<div>Failed to load PlantUML diagram</div>`),
+      diagram(`infographic-diagram`, MD_DIAGRAM_STATE.error, `<div>Infographic render failed: invalid</div>`),
+      diagram(`mermaid-diagram`, MD_DIAGRAM_STATE.ready, `<svg><path /></svg>`),
+    )
+
+    stripUnresolvedAsyncPlaceholders(root)
+
+    expect(root.children).toHaveLength(4)
+    expect(root.textContent).toContain(`Mermaid render failed`)
+    expect(root.textContent).toContain(`Failed to load PlantUML diagram`)
+    expect(root.textContent).toContain(`Infographic render failed`)
+    expect(root.textContent).not.toContain(`Loading Mermaid`)
+  })
+})

--- a/apps/web/src/lib/preview/preview-ready.ts
+++ b/apps/web/src/lib/preview/preview-ready.ts
@@ -1,8 +1,14 @@
-import { hydratePendingInfographicDiagrams } from '@md/core'
+import {
+  hydratePendingInfographicDiagrams,
+  isAsyncDiagramPending,
+  MD_DIAGRAM_STATE,
+  MD_DIAGRAM_STATE_ATTR,
+} from '@md/core'
 import { nextTick } from 'vue'
 
 const PREVIEW_READY_TIMEOUT_MS = 20_000
 const PREVIEW_POLL_INTERVAL_MS = 250
+const ASYNC_DIAGRAM_SELECTOR = `.mermaid-diagram, .plantuml-diagram, .infographic-diagram`
 
 export interface WaitForPreviewReadyOptions {
   themeMode?: `light` | `dark`
@@ -17,15 +23,8 @@ function resolveInfographicOptions(options?: WaitForPreviewReadyOptions) {
 }
 
 function isDiagramStillLoading(output: HTMLElement): boolean {
-  for (const el of output.querySelectorAll<HTMLElement>(`.mermaid-diagram, .plantuml-diagram, .infographic-diagram`)) {
-    if (el.querySelector(`svg, img`))
-      continue
-
-    const text = el.textContent ?? ``
-    if (text.includes(`正在加载`) || text.includes(`加载失败`))
-      return true
-
-    if (el.classList.contains(`mermaid-diagram`) || el.classList.contains(`infographic-diagram`))
+  for (const el of output.querySelectorAll<HTMLElement>(ASYNC_DIAGRAM_SELECTOR)) {
+    if (isAsyncDiagramPending(el))
       return true
   }
 
@@ -75,12 +74,11 @@ export async function waitForPreviewReady(
 
 /** 移除仍未渲染完成的占位内容，避免复制/导出时出现「正在加载…」文案 */
 export function stripUnresolvedAsyncPlaceholders(root: ParentNode) {
-  root.querySelectorAll<HTMLElement>(`.mermaid-diagram, .plantuml-diagram, .infographic-diagram`).forEach((el) => {
+  root.querySelectorAll<HTMLElement>(ASYNC_DIAGRAM_SELECTOR).forEach((el) => {
     if (el.querySelector(`svg, img`))
       return
 
-    const text = el.textContent ?? ``
-    if (text.includes(`正在加载`) || text.includes(`加载失败`))
+    if (el.getAttribute(MD_DIAGRAM_STATE_ATTR) === MD_DIAGRAM_STATE.loading)
       el.remove()
   })
 

--- a/apps/web/src/stores/render.ts
+++ b/apps/web/src/stores/render.ts
@@ -1,5 +1,6 @@
 import { initRenderer } from '@md/core'
 import { postProcessHtml, renderMarkdown } from '@md/core/utils'
+import { t } from '@/i18n/translate'
 import { useCustomComponentStore } from './customComponent'
 import { useThemeStore } from './theme'
 import { useUIStore } from './ui'
@@ -44,6 +45,15 @@ export const useRenderStore = defineStore(`render`, () => {
   // 获取渲染器
   const getRenderer = () => renderer
 
+  const buildDiagramMessages = () => ({
+    mermaidLoading: t(`store.diagram.mermaidLoading`),
+    mermaidError: t(`store.diagram.mermaidError`),
+    plantumlLoading: t(`store.diagram.plantumlLoading`),
+    plantumlError: t(`store.diagram.plantumlError`),
+    infographicLoading: t(`store.diagram.infographicLoading`),
+    infographicError: t(`store.diagram.infographicError`),
+  })
+
   // 提取标题
   const extractTitles = () => {
     const div = document.createElement(`div`)
@@ -85,6 +95,7 @@ export const useRenderStore = defineStore(`render`, () => {
       isShowLineNumber: themeStore.isShowLineNumber,
       themeMode,
       components: componentStore.registry,
+      diagramMessages: buildDiagramMessages(),
     })
 
     // 渲染 Markdown

--- a/packages/core/src/extensions/infographic.ts
+++ b/packages/core/src/extensions/infographic.ts
@@ -1,11 +1,20 @@
+import type { DiagramMessages } from '@md/shared/types'
 import type { MarkedExtension, Token } from 'marked'
 import type { InfographicToken } from '../types/marked-tokens'
 import { asDiagramToken, asTextTokenRenderer, isCodeToken } from '../types/marked-tokens'
+import {
+  diagramStateAttr,
+  formatDiagramMessage,
+  MD_DIAGRAM_STATE,
+  MD_DIAGRAM_STATE_ATTR,
+  resolveDiagramMessages,
+} from '../utils/asyncDiagramState'
 import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 
 interface InfographicOptions {
   themeMode?: 'dark' | 'light'
+  diagramMessages?: DiagramMessages
 }
 
 type InfographicOptionsSource = InfographicOptions | (() => InfographicOptions | undefined)
@@ -79,17 +88,21 @@ function svgElementToHtml(svg: SVGElement | Node): string {
 
 function applySvgByCacheKey(cacheKey: string, svgHtml: string) {
   const el = document.getElementById(`${INFOGRAPHIC_ID_PREFIX}${cacheKey}`)
-  if (el)
+  if (el) {
     el.innerHTML = svgHtml
+    el.setAttribute(MD_DIAGRAM_STATE_ATTR, MD_DIAGRAM_STATE.ready)
+  }
 }
 
-function showInfographicError(containerId: string, error: unknown) {
+function showInfographicError(containerId: string, error: unknown, messages?: DiagramMessages) {
   const container = document.getElementById(containerId)
   if (!container)
     return
 
-  const message = error instanceof Error ? error.message : String(error)
-  container.innerHTML = `<div style="color: red; padding: 10px; border: 1px solid red;">Infographic 渲染失败: ${message}</div>`
+  const detail = error instanceof Error ? error.message : String(error)
+  const resolved = resolveDiagramMessages(messages)
+  container.innerHTML = `<div style="color: red; padding: 10px; border: 1px solid red;">${formatDiagramMessage(resolved.infographicError, detail)}</div>`
+  container.setAttribute(MD_DIAGRAM_STATE_ATTR, MD_DIAGRAM_STATE.error)
 }
 
 async function renderInfographic(containerId: string, code: string, cacheKey: string, options?: InfographicOptions) {
@@ -157,7 +170,7 @@ async function renderInfographic(containerId: string, code: string, cacheKey: st
   }
   catch (error) {
     console.error(`Failed to render Infographic:`, error)
-    showInfographicError(containerId, error)
+    showInfographicError(containerId, error, options?.diagramMessages)
   }
   finally {
     offscreenContainer.remove()
@@ -174,8 +187,7 @@ export function hydratePendingInfographicDiagrams(root: ParentNode, options?: In
     if (el.querySelector(`svg, img`))
       return
 
-    const text = el.textContent ?? ``
-    if (text.includes(`渲染失败`))
+    if (el.getAttribute(MD_DIAGRAM_STATE_ATTR) === MD_DIAGRAM_STATE.error)
       return
 
     const id = el.id
@@ -229,7 +241,8 @@ export function markedInfographic(options?: InfographicOptionsSource): MarkedExt
           const id = `${INFOGRAPHIC_ID_PREFIX}${cacheKey}`
           void renderInfographic(id, code, cacheKey, currentOptions)
 
-          return `<!--infographic-start--><div id="${id}" class="${className}" style="width: 100%;">正在加载 Infographic...</div><!--infographic-end-->`
+          const messages = resolveDiagramMessages(currentOptions?.diagramMessages)
+          return `<!--infographic-start--><div id="${id}" class="${className}" style="width: 100%;" ${diagramStateAttr(MD_DIAGRAM_STATE.loading)}>${messages.infographicLoading}</div><!--infographic-end-->`
         }),
       },
     ],

--- a/packages/core/src/extensions/mermaid.ts
+++ b/packages/core/src/extensions/mermaid.ts
@@ -1,10 +1,28 @@
+import type { DiagramMessages } from '@md/shared/types'
 import type { MarkedExtension, Token } from 'marked'
 import type { MermaidToken } from '../types/marked-tokens'
 import { asDiagramToken, asTextTokenRenderer, isCodeToken } from '../types/marked-tokens'
+import {
+  diagramStateAttr,
+  formatDiagramMessage,
+  MD_DIAGRAM_STATE,
+  MD_DIAGRAM_STATE_ATTR,
+  resolveDiagramMessages,
+} from '../utils/asyncDiagramState'
 import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 
 let initPromise: Promise<typeof import('mermaid')['default']> | null = null
+type DiagramMessagesSource = DiagramMessages | (() => DiagramMessages | undefined)
+
+let diagramMessagesSource: DiagramMessagesSource | undefined
+
+function getDiagramMessages(): DiagramMessages {
+  const resolved = typeof diagramMessagesSource === `function`
+    ? diagramMessagesSource()
+    : diagramMessagesSource
+  return resolveDiagramMessages(resolved)
+}
 
 export async function initializeMermaid() {
   return getMermaid()
@@ -33,6 +51,7 @@ function renderMermaid(id: string, code: string, cacheKey: string) {
     const el = document.getElementById(id)
     if (el) {
       el.innerHTML = svg
+      el.setAttribute(MD_DIAGRAM_STATE_ATTR, MD_DIAGRAM_STATE.ready)
     }
   }
 
@@ -40,7 +59,10 @@ function renderMermaid(id: string, code: string, cacheKey: string) {
     console.error('Failed to render Mermaid:', error)
     const el = document.getElementById(id)
     if (el) {
-      el.innerHTML = `<div style="color: red; padding: 10px; border: 1px solid red;">Mermaid 渲染失败: ${error instanceof Error ? error.message : String(error)}</div>`
+      const detail = error instanceof Error ? error.message : String(error)
+      const messages = getDiagramMessages()
+      el.innerHTML = `<div style="color: red; padding: 10px; border: 1px solid red;">${formatDiagramMessage(messages.mermaidError, detail)}</div>`
+      el.setAttribute(MD_DIAGRAM_STATE_ATTR, MD_DIAGRAM_STATE.error)
     }
   }
 
@@ -50,7 +72,8 @@ function renderMermaid(id: string, code: string, cacheKey: string) {
     .catch(handleError)
 }
 
-export function markedMermaid(): MarkedExtension {
+export function markedMermaid(messagesSource?: DiagramMessagesSource): MarkedExtension {
+  diagramMessagesSource = messagesSource
   const className = 'mermaid-diagram'
 
   return {
@@ -85,7 +108,8 @@ export function markedMermaid(): MarkedExtension {
           const id = `mermaid-${cacheKey}`
           renderMermaid(id, code, cacheKey)
 
-          return `<!--mermaid-start--><div id="${id}" class="${className}">正在加载 Mermaid...</div><!--mermaid-end-->`
+          const messages = getDiagramMessages()
+          return `<!--mermaid-start--><div id="${id}" class="${className}" ${diagramStateAttr(MD_DIAGRAM_STATE.loading)}>${messages.mermaidLoading}</div><!--mermaid-end-->`
         }),
       },
     ],

--- a/packages/core/src/extensions/plantuml.ts
+++ b/packages/core/src/extensions/plantuml.ts
@@ -1,7 +1,14 @@
+import type { DiagramMessages } from '@md/shared/types'
 import type { MarkedExtension, Token } from 'marked'
 import type { PlantUMLToken } from '../types/marked-tokens'
 import { deflateSync } from 'fflate'
 import { asDiagramToken, asTextTokenRenderer, isCodeToken } from '../types/marked-tokens'
+import {
+  diagramStateAttr,
+  isSvgMarkup,
+  MD_DIAGRAM_STATE,
+  resolveDiagramMessages,
+} from '../utils/asyncDiagramState'
 import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 
@@ -35,6 +42,8 @@ export interface PlantUMLOptions {
   styles?: {
     container?: Record<string, string | number>
   }
+  /** 异步图表文案（Web 端按 locale 注入） */
+  getDiagramMessages?: () => DiagramMessages | undefined
 }
 
 /**
@@ -143,10 +152,12 @@ function encodePlantUML(plantumlCode: string): string {
   }
 }
 
+type ResolvedPlantUMLOptions = Required<Omit<PlantUMLOptions, 'getDiagramMessages'>> & Pick<PlantUMLOptions, 'getDiagramMessages'>
+
 /**
  * 生成 PlantUML 图片 URL
  */
-function generatePlantUMLUrl(code: string, options: Required<PlantUMLOptions>): string {
+function generatePlantUMLUrl(code: string, options: Pick<ResolvedPlantUMLOptions, 'serverUrl' | 'format'>): string {
   const encoded = encodePlantUML(code)
   const formatPath = options.format === `svg` ? `svg` : `png`
   return `${options.serverUrl}/${formatPath}/${encoded}`
@@ -155,8 +166,13 @@ function generatePlantUMLUrl(code: string, options: Required<PlantUMLOptions>): 
 /**
  * 渲染 PlantUML 图表
  */
-function renderPlantUMLDiagram(token: Pick<PlantUMLToken, 'text'>, options: Required<PlantUMLOptions>, cacheKey: string): string {
+function renderPlantUMLDiagram(
+  token: Pick<PlantUMLToken, 'text'>,
+  options: ResolvedPlantUMLOptions,
+  cacheKey: string,
+): string {
   const { text: code } = token
+  const messages = resolveDiagramMessages(options.getDiagramMessages?.())
 
   // 检查代码是否包含 PlantUML 标记
   const finalCode = (!code.trim().includes(`@start`) || !code.trim().includes(`@end`))
@@ -170,10 +186,11 @@ function renderPlantUMLDiagram(token: Pick<PlantUMLToken, 'text'>, options: Requ
     const placeholder = `plantuml-${cacheKey}`
 
     // 异步获取SVG内容并替换
-    fetchSvgContent(imageUrl).then((svgContent) => {
+    fetchSvgContent(imageUrl, messages.plantumlError).then((svgContent) => {
       const placeholderElement = document.querySelector(`[data-placeholder="${placeholder}"]`) as HTMLElement
       if (placeholderElement) {
-        const html = createPlantUMLHTML(imageUrl, options, svgContent)
+        const isError = !isSvgMarkup(svgContent)
+        const html = createPlantUMLHTML(imageUrl, options, svgContent, isError)
         placeholderElement.outerHTML = html
         svgCache.set(cacheKey, html)
       }
@@ -185,8 +202,8 @@ function renderPlantUMLDiagram(token: Pick<PlantUMLToken, 'text'>, options: Requ
           .join(`; `)
       : ``
 
-    return `<div class="${options.className}" style="${containerStyles}" data-placeholder="${placeholder}">
-      <div style="color: #666; font-style: italic;">正在加载PlantUML图表...</div>
+    return `<div class="${options.className}" style="${containerStyles}" data-placeholder="${placeholder}" ${diagramStateAttr(MD_DIAGRAM_STATE.loading)}>
+      <div style="color: #666; font-style: italic;">${messages.plantumlLoading}</div>
     </div>`
   }
 
@@ -196,7 +213,7 @@ function renderPlantUMLDiagram(token: Pick<PlantUMLToken, 'text'>, options: Requ
 /**
  * 获取SVG内容
  */
-async function fetchSvgContent(svgUrl: string): Promise<string> {
+async function fetchSvgContent(svgUrl: string, errorMessage: string): Promise<string> {
   try {
     const response = await fetch(svgUrl)
     if (!response.ok) {
@@ -214,14 +231,19 @@ async function fetchSvgContent(svgUrl: string): Promise<string> {
   }
   catch (error) {
     console.warn(`Failed to fetch SVG content from ${svgUrl}:`, error)
-    return `<div style="color: #666; font-style: italic;">PlantUML图表加载失败</div>`
+    return `<div style="color: #666; font-style: italic;">${errorMessage}</div>`
   }
 }
 
 /**
  * 创建 PlantUML HTML 元素
  */
-function createPlantUMLHTML(imageUrl: string, options: Required<PlantUMLOptions>, svgContent?: string): string {
+function createPlantUMLHTML(
+  imageUrl: string,
+  options: ResolvedPlantUMLOptions,
+  svgContent?: string,
+  isError = false,
+): string {
   const containerStyles = options.styles.container
     ? Object.entries(options.styles.container)
         .map(([key, value]) => `${key.replace(/([A-Z])/g, `-$1`).toLowerCase()}: ${value}`)
@@ -230,13 +252,14 @@ function createPlantUMLHTML(imageUrl: string, options: Required<PlantUMLOptions>
 
   // 如果有SVG内容，直接嵌入
   if (svgContent) {
-    return `<div class="${options.className}" style="${containerStyles}">
+    const state = isError ? MD_DIAGRAM_STATE.error : MD_DIAGRAM_STATE.ready
+    return `<div class="${options.className}" style="${containerStyles}" ${diagramStateAttr(state)}>
       ${svgContent}
     </div>`
   }
 
   // 否则使用图片链接
-  return `<div class="${options.className}" style="${containerStyles}">
+  return `<div class="${options.className}" style="${containerStyles}" ${diagramStateAttr(MD_DIAGRAM_STATE.ready)}>
     <img src="${imageUrl}" alt="PlantUML Diagram" style="max-width: 100%; height: auto;" />
   </div>`
 }
@@ -245,11 +268,12 @@ function createPlantUMLHTML(imageUrl: string, options: Required<PlantUMLOptions>
  * PlantUML marked 扩展
  */
 export function markedPlantUML(options: PlantUMLOptions = {}): MarkedExtension {
-  const resolvedOptions: Required<PlantUMLOptions> = {
+  const resolvedOptions: ResolvedPlantUMLOptions = {
     serverUrl: options.serverUrl || `https://www.plantuml.com/plantuml`,
     format: options.format || `svg`,
     className: options.className || `plantuml-diagram`,
     inlineSvg: options.inlineSvg || false,
+    getDiagramMessages: options.getDiagramMessages,
     styles: {
       container: {
         textAlign: `center`,

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -455,11 +455,15 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   markdownParser.use(markedAlert({}))
   markdownParser.use(MDKatex({ nonStandard: true }, true))
   markdownParser.use(markedFootnotes())
-  markdownParser.use(markedMermaid())
+  markdownParser.use(markedMermaid(() => opts.diagramMessages))
   markdownParser.use(markedPlantUML({
     inlineSvg: true, // 启用SVG内嵌，适用于微信公众号
+    getDiagramMessages: () => opts.diagramMessages,
   }))
-  markdownParser.use(markedInfographic(() => ({ themeMode: opts.themeMode })))
+  markdownParser.use(markedInfographic(() => ({
+    themeMode: opts.themeMode,
+    diagramMessages: opts.diagramMessages,
+  })))
   markdownParser.use(markedRuby())
 
   return {

--- a/packages/core/src/utils/asyncDiagramState.test.ts
+++ b/packages/core/src/utils/asyncDiagramState.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_DIAGRAM_MESSAGES,
+  formatDiagramMessage,
+  isAsyncDiagramPending,
+  MD_DIAGRAM_STATE,
+  MD_DIAGRAM_STATE_ATTR,
+} from './asyncDiagramState'
+
+function diagram(className: string, attrs: Record<string, string>, innerHTML: string) {
+  const el = document.createElement(`div`)
+  el.className = className
+  for (const [key, value] of Object.entries(attrs))
+    el.setAttribute(key, value)
+  el.innerHTML = innerHTML
+  return el
+}
+
+describe(`isAsyncDiagramPending`, () => {
+  it(`treats loading state as pending regardless of text language`, () => {
+    const el = diagram(`mermaid-diagram`, { [MD_DIAGRAM_STATE_ATTR]: MD_DIAGRAM_STATE.loading }, `Loading Mermaid…`)
+    expect(isAsyncDiagramPending(el)).toBe(true)
+  })
+
+  it(`treats error state as settled`, () => {
+    const el = diagram(
+      `mermaid-diagram`,
+      { [MD_DIAGRAM_STATE_ATTR]: MD_DIAGRAM_STATE.error },
+      `Mermaid render failed: syntax error`,
+    )
+    expect(isAsyncDiagramPending(el)).toBe(false)
+  })
+
+  it(`treats rendered svg as settled`, () => {
+    const el = diagram(`mermaid-diagram`, { [MD_DIAGRAM_STATE_ATTR]: MD_DIAGRAM_STATE.loading }, `<svg><path /></svg>`)
+    expect(isAsyncDiagramPending(el)).toBe(false)
+  })
+})
+
+describe(`formatDiagramMessage`, () => {
+  it(`replaces detail placeholder`, () => {
+    expect(formatDiagramMessage(DEFAULT_DIAGRAM_MESSAGES.mermaidError, `bad syntax`))
+      .toBe(`Mermaid 渲染失败: bad syntax`)
+  })
+})

--- a/packages/core/src/utils/asyncDiagramState.ts
+++ b/packages/core/src/utils/asyncDiagramState.ts
@@ -1,0 +1,51 @@
+import type { DiagramMessages } from '@md/shared/types'
+
+export const MD_DIAGRAM_STATE_ATTR = `data-md-diagram-state`
+
+export const MD_DIAGRAM_STATE = {
+  loading: `loading`,
+  error: `error`,
+  ready: `ready`,
+} as const
+
+export type MdDiagramState = typeof MD_DIAGRAM_STATE[keyof typeof MD_DIAGRAM_STATE]
+
+export const DEFAULT_DIAGRAM_MESSAGES: DiagramMessages = {
+  mermaidLoading: `正在加载 Mermaid...`,
+  mermaidError: `Mermaid 渲染失败: {detail}`,
+  plantumlLoading: `正在加载 PlantUML 图表...`,
+  plantumlError: `PlantUML 图表加载失败`,
+  infographicLoading: `正在加载 Infographic...`,
+  infographicError: `Infographic 渲染失败: {detail}`,
+}
+
+export function diagramStateAttr(state: MdDiagramState): string {
+  return `${MD_DIAGRAM_STATE_ATTR}="${state}"`
+}
+
+export function resolveDiagramMessages(messages?: DiagramMessages): DiagramMessages {
+  return messages ?? DEFAULT_DIAGRAM_MESSAGES
+}
+
+export function formatDiagramMessage(template: string, detail: string): string {
+  return template.replace(`{detail}`, detail)
+}
+
+export function isSvgMarkup(content: string): boolean {
+  return content.trimStart().startsWith(`<svg`)
+}
+
+/** 异步图表占位是否仍在等待渲染（与文案语言无关） */
+export function isAsyncDiagramPending(el: Element): boolean {
+  if (!(el instanceof HTMLElement))
+    return false
+
+  if (el.querySelector(`svg, img`))
+    return false
+
+  const state = el.getAttribute(MD_DIAGRAM_STATE_ATTR)
+  if (state === MD_DIAGRAM_STATE.error || state === MD_DIAGRAM_STATE.ready)
+    return false
+
+  return true
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { initializeMermaid } from '../extensions/mermaid'
+export * from './asyncDiagramState'
 export * from './basicHelpers'
 export * from './languages'
 export * from './markdownHelpers'

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -6,6 +6,17 @@ import type { ComponentRegistry } from './component'
  * 主题样式通过 CSS 注入，不再通过 JS 对象传递
  * 注意：isUseIndent 和 isUseJustify 现在通过 CSS 变量系统处理，不需要传递给渲染器
  */
+export interface DiagramMessages {
+  mermaidLoading: string
+  /** 支持 `{detail}` 占位符 */
+  mermaidError: string
+  plantumlLoading: string
+  plantumlError: string
+  infographicLoading: string
+  /** 支持 `{detail}` 占位符 */
+  infographicError: string
+}
+
 export interface IOpts {
   legend?: string
   citeStatus?: boolean
@@ -15,6 +26,8 @@ export interface IOpts {
   themeMode?: 'light' | 'dark'
   /** 自定义组件注册表 */
   components?: ComponentRegistry
+  /** 异步图表加载/失败文案（Web 端按 locale 注入） */
+  diagramMessages?: DiagramMessages
 }
 
 export interface IConfigOption<VT = string> {


### PR DESCRIPTION
## Summary

- Fix the initial boot loader waiting up to 20 seconds when Mermaid, PlantUML, or Infographic rendering fails.
- Replace Chinese text-based async diagram detection with locale-agnostic `data-md-diagram-state` markers (`loading` / `error` / `ready`).
- Inject localized diagram loading/error messages from the web renderer via `IOpts.diagramMessages` (zh-CN / en-US).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cosmetic / docs / workflow

## Test Procedure

- [x] `pnpm test` in `packages/core` (16 tests)
- [x] `pnpm test` in `apps/web` (13 tests)
- [x] `pnpm type-check` in `packages/core` and `apps/web`
- [ ] Manual: open a document with invalid Mermaid/PlantUML/Infographic blocks, refresh the page, confirm the boot loader dismisses promptly while error messages remain visible in the preview

## Pre-flight Checklist

- [x] Conventional commit message in English
- [x] Feature branch created (not committed on `main`)
- [x] zh-CN and en-US i18n strings added together
- [x] Unit tests added for pending detection and placeholder stripping
