### PR TITLE
fix(core): prevent MathJax from corrupting editor LaTeX on reload

### DIFF
--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -680,7 +680,7 @@ defineExpose({
       <div
         id="editor"
         ref="editorRef"
-        class="codemirror-container"
+        class="codemirror-container mathjax-ignore"
       />
     </EditorContextMenu>
   </div>

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -5,11 +5,11 @@ import { asKatexRenderer } from '../types/marked-tokens'
 import { escapeHtml } from '../utils/basicHelpers'
 import {
   blockLatexRule,
-  blockRule,
   findInlineKatexStart,
   inlineLatexRule,
   inlineRule,
   inlineRuleNonStandard,
+  matchBlockKatex,
 } from '../utils/mathDetection'
 import { ensureMathJaxLoaded, isMathJaxReady } from '../utils/mathjax'
 
@@ -101,8 +101,12 @@ function blockKatex(_options: MarkedKatexOptions | undefined, renderer: KatexRen
   return {
     name: `blockKatex`,
     level: `block` as const,
+    start(src: string) {
+      const index = src.search(/^\s{0,3}\${1,2}/m)
+      return index === -1 ? undefined : index
+    },
     tokenizer(src: string) {
-      const match = src.match(blockRule)
+      const match = matchBlockKatex(src)
       if (match) {
         return {
           type: `blockKatex`,

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -272,7 +272,8 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       const text = this.parser.parseInline(tokens)
       const isFigureImage = text.includes(`<figure`) && text.includes(`<img`)
       const isEmpty = text.trim() === ``
-      if (isFigureImage || isEmpty) {
+      const isKatexOnly = /^<section class="katex-block"[\s\S]*<\/section>\s*$/.test(text.trim())
+      if (isFigureImage || isEmpty || isKatexOnly) {
         return text
       }
       return styledContent(`p`, text)

--- a/packages/core/src/renderer/renderer.test.ts
+++ b/packages/core/src/renderer/renderer.test.ts
@@ -46,4 +46,26 @@ describe('initRenderer', () => {
     expect(output).toContain(`字数`)
     expect(output).toContain(`Hi`)
   })
+
+  it('renders single-line block formula as katex-block without paragraph wrapper', () => {
+    const renderer = initRenderer({})
+    const formula = `$$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
+    const { html } = renderMarkdown(formula, renderer)
+
+    expect(html).toContain(`katex-block`)
+    expect(html).toContain(`data-math-raw`)
+    expect(html).not.toMatch(/<p[^>]*>\s*<section class="katex-block"/)
+  })
+
+  it('renders list item followed by single-line block formula without paragraph wrapper', () => {
+    const renderer = initRenderer({})
+    const userMd = `1.比如识别段落之间带有编号的latex公式，如 
+
+$$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
+    const { html } = renderMarkdown(userMd, renderer)
+
+    expect(html).toContain(`data-math-raw`)
+    expect(html).toContain(`\\tag{1}`)
+    expect(html).not.toMatch(/<p[^>]*>\s*<section class="katex-block"/)
+  })
 })

--- a/packages/core/src/utils/mathDetection.test.ts
+++ b/packages/core/src/utils/mathDetection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  blockRuleMultiline,
+  blockRuleSingleLine,
+  contentHasMath,
+  inlineRuleNonStandard,
+  matchBlockKatex,
+} from './mathDetection'
+
+const singleLineFormula = `$$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
+const multilineFormula = `$$\nITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}\n$$`
+
+describe('mathDetection block rules', () => {
+  it('matches multiline block formula', () => {
+    expect(blockRuleMultiline.test(multilineFormula)).toBe(true)
+    expect(blockRuleSingleLine.test(multilineFormula)).toBe(false)
+  })
+
+  it('matches single-line block formula', () => {
+    expect(blockRuleSingleLine.test(singleLineFormula)).toBe(true)
+    expect(blockRuleMultiline.test(singleLineFormula)).toBe(false)
+  })
+
+  it('matchBlockKatex extracts latex from single-line block formula', () => {
+    const match = matchBlockKatex(singleLineFormula)
+    expect(match?.[2]?.trim()).toBe(`ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}`)
+  })
+
+  it('detects math in single-line block formula', () => {
+    expect(contentHasMath(singleLineFormula)).toBe(true)
+  })
+
+  it('inline rule still matches single-line formula when used directly', () => {
+    expect(singleLineFormula.match(inlineRuleNonStandard)?.[2]?.trim())
+      .toBe(`ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}`)
+  })
+})

--- a/packages/core/src/utils/mathDetection.ts
+++ b/packages/core/src/utils/mathDetection.ts
@@ -1,7 +1,27 @@
 export const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:？！。，：]|$)/
 export const inlineRuleNonStandard = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1/
-export const blockRule = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
-const blockRuleDetect = /^\s{0,3}(\${1,2})[ \t]*\n[\s\S]+?\n\s{0,3}\1[ \t]*(?:\n|$)/m
+/** 块级公式：换行写法 `$$\n...\n$$` */
+export const blockRuleMultiline = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
+/** 块级公式：单行写法 `$$...$$`（独占一行） */
+export const blockRuleSingleLine = /^\s{0,3}(\${1,2})([^\n$]+)\1[ \t]*(?:\n|$)/
+
+export function matchBlockKatex(src: string): RegExpMatchArray | null {
+  return src.match(blockRuleMultiline) ?? src.match(blockRuleSingleLine)
+}
+
+/** @deprecated 使用 matchBlockKatex；保留导出以兼容旧引用 */
+export const blockRule = blockRuleMultiline
+
+function contentHasBlockKatex(content: string): boolean {
+  for (let i = 0; i <= content.length; i++) {
+    if (i > 0 && content[i - 1] !== '\n')
+      continue
+    if (matchBlockKatex(content.slice(i)))
+      return true
+  }
+  return false
+}
+
 export const inlineLatexRule = /^\\\(([^\\]*(?:\\.[^\\]*)*?)\\\)/
 export const blockLatexRule = /^\\\[([^\\]*(?:\\.[^\\]*)*?)\\\]/
 
@@ -49,7 +69,7 @@ export function findInlineKatexStart(src: string, nonStandard: boolean, ruleReg:
  * 默认 nonStandard=true，与 renderer-impl 配置一致。
  */
 export function contentHasMath(content: string, nonStandard = true): boolean {
-  if (blockRuleDetect.test(content))
+  if (contentHasBlockKatex(content))
     return true
   if (blockLatexAnywhere.test(content))
     return true

--- a/packages/core/src/utils/mathjax.ts
+++ b/packages/core/src/utils/mathjax.ts
@@ -44,6 +44,13 @@ export function loadMathJax(): Promise<void> {
       MathJax: {
         tex: { tags: `ams` },
         svg: { fontCache: `none` },
+        // 仅通过 tex2svg 在预览区渲染；禁止扫描整页 DOM，否则会改写 CodeMirror 编辑区内的 $$...$$
+        startup: {
+          typeset: false,
+        },
+        options: {
+          ignoreHtmlClass: `mathjax-ignore`,
+        },
       },
     })
 


### PR DESCRIPTION
## Summary

After a page reload, single-line block LaTeX formulas (`$$...$$`) in the CodeMirror editor were corrupted into MathJax plain text (e.g. `(1)ITEi=Yi,1−Yi,0`). IndexedDB still held the correct source; corruption happened when MathJax auto-typeset the page and CodeMirror synced rendered DOM text back into the document.

This PR:
- Disables MathJax auto page typeset and marks the editor container with `mathjax-ignore` so preview math is rendered only via explicit `tex2svg` calls
- Parses single-line block formulas as `katex-block` (alongside existing multiline `$$\n...\n$$` support)
- Skips wrapping katex-only paragraphs in `<p>` tags
- Adds regression tests for math detection and rendering

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cosmetic / documentation / workflow

## Test Procedure

- [x] `pnpm exec vitest run src/utils/mathDetection.test.ts src/renderer/renderer.test.ts` in `packages/core` (12 tests pass)
- [x] Manual repro: enter `$$ITE_{i}=Y_{i,1}-Y_{i,0} \tag{1}$$` in the editor, reload the page — LaTeX source remains intact
- [x] Multiline block formulas (`$$\n...\n$$`) still render correctly in preview

## Pre-flight Checklist

- [x] Working tree is clean
- [x] Commit follows Conventional Commits (English)
- [x] Pre-commit ESLint hook passed
- [x] Added/updated tests for the fix
- [ ] CI checks pending after PR creation
