### PR TITLE
feat(theme): add plain MdNice-style theme

### DIFF
--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -110,7 +110,7 @@ const isOpenAddDialog = ref(false)
 
 const addInputVal = ref(``)
 // 新建方案时选择的基础主题
-const baseThemeForNew = ref<'blank' | 'default' | 'grace' | 'simple'>('blank')
+const baseThemeForNew = ref<'blank' | 'default' | 'grace' | 'plain' | 'simple'>('blank')
 
 async function addTab() {
   if (!(addInputVal.value).trim()) {
@@ -181,7 +181,7 @@ function addHandler() {
 }
 
 const isOpenViewThemeDialog = ref(false)
-const selectedViewTheme = ref<'default' | 'grace' | 'simple'>('default')
+const selectedViewTheme = ref<'default' | 'grace' | 'plain' | 'simple'>('default')
 
 const contextMenuTargetId = ref<string | null>(null)
 const showContextMenu = ref(false)
@@ -596,6 +596,9 @@ function exportCurrentTheme() {
                 <SelectItem value="simple">
                   {{ t('cssEditor.basedSimple') }}
                 </SelectItem>
+                <SelectItem value="plain">
+                  {{ t('cssEditor.basedPlain') }}
+                </SelectItem>
               </SelectContent>
             </Select>
             <p class="text-xs text-muted-foreground">
@@ -663,6 +666,9 @@ function exportCurrentTheme() {
               </SelectItem>
               <SelectItem value="simple">
                 {{ getThemeLabel(t, 'simple') }}
+              </SelectItem>
+              <SelectItem value="plain">
+                {{ getThemeLabel(t, 'plain') }}
               </SelectItem>
             </SelectContent>
           </Select>

--- a/apps/web/src/i18n/messages/en-US/common.ts
+++ b/apps/web/src/i18n/messages/en-US/common.ts
@@ -188,6 +188,7 @@ export default {
       default: { label: `Classic`, desc: `` },
       grace: { label: `Grace`, desc: `{'@'}brzhang` },
       simple: { label: `Simple`, desc: `{'@'}okooo5km` },
+      plain: { label: `Plain`, desc: `MdNice style` },
     },
     fontFamily: {
       sansSerif: { label: `Sans`, desc: `Font123Abc` },

--- a/apps/web/src/i18n/messages/en-US/editor.ts
+++ b/apps/web/src/i18n/messages/en-US/editor.ts
@@ -391,6 +391,7 @@ export default {
     basedClassic: `Based on Classic theme`,
     basedGrace: `Based on Grace theme`,
     basedSimple: `Based on Simple theme`,
+    basedPlain: `Based on Plain theme`,
     newTitle: `New custom CSS`,
     newDescription: `Enter a scheme name and choose an initial template`,
     schemeName: `Scheme name`,

--- a/apps/web/src/i18n/messages/zh-CN/common.ts
+++ b/apps/web/src/i18n/messages/zh-CN/common.ts
@@ -188,6 +188,7 @@ export default {
       default: { label: `经典`, desc: `` },
       grace: { label: `优雅`, desc: `{'@'}brzhang` },
       simple: { label: `简洁`, desc: `{'@'}okooo5km` },
+      plain: { label: `朴素`, desc: `MdNice 风格` },
     },
     fontFamily: {
       sansSerif: { label: `无衬线`, desc: `字体123Abc` },

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -391,6 +391,7 @@ export default {
     basedClassic: `基于经典主题`,
     basedGrace: `基于优雅主题`,
     basedSimple: `基于简洁主题`,
+    basedPlain: `基于朴素主题`,
     newTitle: `新建自定义 CSS`,
     newDescription: `请输入方案名称，并选择初始模板`,
     schemeName: `方案名称`,

--- a/packages/mcp-server/src/config-options.ts
+++ b/packages/mcp-server/src/config-options.ts
@@ -25,6 +25,7 @@ export const themeOptions = [
   { value: `default`, label: `经典`, desc: `` },
   { value: `grace`, label: `优雅`, desc: `@brzhang` },
   { value: `simple`, label: `简洁`, desc: `@okooo5km` },
+  { value: `plain`, label: `朴素`, desc: `MdNice 风格` },
 ] as const
 
 export const fontFamilyOptions = [

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -22,10 +22,10 @@ const headingStyleEnum = z.enum([`default`, `color-only`, `border-bottom`, `bord
 export const renderMarkdownInputSchema = {
   markdown: z.string().describe(`The Markdown source text to render.`),
   theme: z
-    .enum([`default`, `grace`, `simple`])
+    .enum([`default`, `grace`, `plain`, `simple`])
     .optional()
     .default(`default`)
-    .describe(`Visual theme to apply. One of: default (经典), grace (优雅), simple (简洁).`),
+    .describe(`Visual theme to apply. One of: default (经典), grace (优雅), plain (朴素), simple (简洁).`),
   primaryColor: z
     .string()
     .regex(/^#[0-9A-F]{6}$/i, `Must be a valid 6-digit hex color`)
@@ -336,7 +336,7 @@ server.registerTool(
   },
   () => jsonText({
     options: [
-      { name: `theme`, type: `'default' | 'grace' | 'simple'`, default: `default`, description: `Visual theme.` },
+      { name: `theme`, type: `'default' | 'grace' | 'plain' | 'simple'`, default: `default`, description: `Visual theme.` },
       { name: `primaryColor`, type: `string (hex)`, default: `#0F4C81`, description: `Primary accent color via --md-primary-color.` },
       { name: `fontFamily`, type: `string`, default: `system sans-serif stack`, description: `CSS font-family. See list_fonts.` },
       { name: `fontSize`, type: `string (px)`, default: `16px`, description: `Base font size. See list_font_sizes.` },

--- a/packages/mcp-server/src/render-article.ts
+++ b/packages/mcp-server/src/render-article.ts
@@ -55,6 +55,7 @@ const baseCSSContent = loadCSSFile(`base.css`)
 const themeMap: Record<string, string> = {
   default: loadCSSFile(`default.css`),
   grace: loadCSSFile(`grace.css`),
+  plain: loadCSSFile(`plain.css`),
   simple: loadCSSFile(`simple.css`),
 }
 

--- a/packages/shared/src/configs/theme-css/index.ts
+++ b/packages/shared/src/configs/theme-css/index.ts
@@ -6,6 +6,7 @@
 import baseCSS from './base.css?raw'
 import defaultCSS from './default.css?raw'
 import graceCSS from './grace.css?raw'
+import plainCSS from './plain.css?raw'
 import simpleCSS from './simple.css?raw'
 
 /**
@@ -19,6 +20,7 @@ export const baseCSSContent = baseCSS
 export const themeMap = {
   default: defaultCSS,
   grace: graceCSS,
+  plain: plainCSS,
   simple: simpleCSS,
 } as const
 

--- a/packages/shared/src/configs/theme-css/plain.css
+++ b/packages/shared/src/configs/theme-css/plain.css
@@ -1,0 +1,148 @@
+/**
+ * MD 朴素主题
+ * 参考墨滴（MdNice）默认排版：居中标题、两端对齐正文、少装饰
+ */
+
+/* ==================== 标题 ==================== */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  display: block;
+  margin: 2em 8px 1em;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  text-shadow: none;
+  text-align: center;
+  color: #333333;
+  font-weight: bold;
+  line-height: 1.8;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  font-size: calc(var(--md-font-size) * 1.2);
+}
+
+h2 {
+  font-size: calc(var(--md-font-size) * 1.15);
+}
+
+h3 {
+  font-size: calc(var(--md-font-size) * 1.1);
+}
+
+h4,
+h5,
+h6 {
+  font-size: var(--md-font-size);
+}
+
+/* ==================== 段落 ==================== */
+p {
+  margin: 1em 8px;
+  text-align: justify;
+  line-height: 1.8;
+  letter-spacing: 0.08em;
+  color: #333333;
+}
+
+/* ==================== 引用块 ==================== */
+blockquote {
+  font-style: normal;
+  padding: 0.5em 1em;
+  margin: 1em 8px;
+  border: none;
+  border-left: 3px solid #cccccc;
+  border-radius: 0;
+  background: none;
+  color: #333333;
+}
+
+blockquote > p {
+  letter-spacing: 0.08em;
+  color: #333333;
+}
+
+/* ==================== 行内代码 ==================== */
+.codespan {
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  border: none;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 3px;
+  box-shadow: none;
+}
+
+/* ==================== 代码块 ==================== */
+pre.code__pre,
+.hljs.code__pre {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: none;
+}
+
+pre.code__pre > code,
+.hljs.code__pre > code {
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+}
+
+/* ==================== 图片 ==================== */
+img {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+figcaption,
+.md-figcaption {
+  text-align: center;
+  color: #888888;
+  font-size: 0.85em;
+}
+
+/* ==================== 列表 ==================== */
+ol,
+ul {
+  padding-left: 1.5em;
+  margin: 1em 8px;
+  line-height: 1.8;
+  letter-spacing: 0.08em;
+  color: #333333;
+}
+
+ul {
+  list-style: disc;
+}
+
+li {
+  margin: 0.3em 0;
+  color: #333333;
+}
+
+/* ==================== 分隔线 ==================== */
+hr {
+  height: 1px;
+  border: none;
+  margin: 2em 8px;
+  background: #e5e5e5;
+}
+
+/* ==================== 链接 ==================== */
+a {
+  color: #576b95;
+  text-decoration: none;
+}
+
+/* ==================== 强调 ==================== */
+strong {
+  font-weight: bold;
+  color: #333333;
+}
+
+em {
+  font-style: italic;
+}

--- a/packages/shared/src/configs/theme.ts
+++ b/packages/shared/src/configs/theme.ts
@@ -20,6 +20,11 @@ export const themeOptionsMap = {
     value: `simple`,
     desc: `@okooo5km`,
   },
+  plain: {
+    label: `朴素`,
+    value: `plain`,
+    desc: `MdNice 风格`,
+  },
 }
 
 export const themeOptions: IConfigOption<ThemeName>[] = [
@@ -37,5 +42,10 @@ export const themeOptions: IConfigOption<ThemeName>[] = [
     label: `简洁`,
     value: `simple`,
     desc: `@okooo5km`,
+  },
+  {
+    label: `朴素`,
+    value: `plain`,
+    desc: `MdNice 风格`,
   },
 ]


### PR DESCRIPTION
## Summary

Adds a built-in **朴素 (Plain)** theme inspired by MdNice default typography:

- Centered headings with no background/border decoration
- Justified body text with relaxed line-height and letter-spacing
- Minimal blockquote, list, and link styling suitable for WeChat articles

**Why pasted MdNice CSS did not work:** MdNice themes target `#nice { ... }` and nested selectors. doocs/md uses a different system — built-in themes are element-level CSS (`h1`, `p`, …) merged with `default` and scoped to `#output` via juice. Custom CSS in the editor also needs `#output` scope (or bare element selectors), not `#nice`.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change

## Test Procedure

- [x] `pnpm run type-check` passes
- [ ] In **Style → Theme**, select **朴素 / Plain** and verify preview matches plain MdNice-like layout
- [ ] Export/copy to WeChat and confirm headings are centered, paragraphs justified

## Pre-flight Checklist

- [x] zh-CN and en-US i18n updated
- [x] MCP `list_themes` / `render_markdown` include `plain`
- [x] CSS editor theme viewer includes plain
- [ ] CI checks pending
