### PR TITLE
fix(web): clear CodeMirror undo history when switching posts

### DIFF
--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Compartment, EditorState, Prec } from '@codemirror/state'
 import { EditorView, keymap, placeholder } from '@codemirror/view'
-import { markdownSetup, theme } from '@md/shared/editor'
+import { history, markdownSetup, replaceDocumentWithoutHistory, resetEditorHistory, theme } from '@md/shared/editor'
 import { toBase64 } from '@md/shared/utils/fileHelpers'
 import imageCompression from 'browser-image-compression'
 import { defineAsyncComponent } from 'vue'
@@ -74,6 +74,7 @@ const showEditor = computed(() => viewMode.value !== `preview`)
 const codeMirrorView = shallowRef<EditorView | null>(null)
 const themeCompartment = new Compartment()
 const placeholderCompartment = new Compartment()
+const historyCompartment = new Compartment()
 
 function editorPlaceholder() {
   return placeholder(t(`codemirror.contentPlaceholder`))
@@ -457,7 +458,9 @@ function createFormTextArea(dom: HTMLDivElement) {
         onSearch: openSearchWithSelection,
         onReplace: openReplaceWithSelection,
         onGoToLine: () => uiStore.requestGoToLine(),
+        withoutHistory: true,
       }),
+      historyCompartment.of(history()),
       Prec.high(keymap.of([
         { key: `Mod-Alt-ArrowUp`, run: view => jumpToAdjacentHeading(view, `prev`) },
         { key: `Mod-Alt-ArrowDown`, run: view => jumpToAdjacentHeading(view, `next`) },
@@ -508,19 +511,23 @@ async function preloadMathJaxIfNeeded(content: string) {
 
 let postSwitchGeneration = 0
 
-function commitEditorContentToPost() {
+function flushEditorContentToPostAtIndex(index: number) {
   clearTimeout(changeTimer.value)
   changeTimer.value = undefined
-  if (!codeMirrorView.value)
+  if (!codeMirrorView.value || index < 0)
     return
 
   const value = codeMirrorView.value.state.doc.toString()
-  const post = posts.value[currentPostIndex.value]
+  const post = posts.value[index]
   if (!post || value === post.content)
     return
 
   post.updateDatetime = new Date()
   post.content = value
+}
+
+function commitEditorContentToPost() {
+  flushEditorContentToPostAtIndex(currentPostIndex.value)
 }
 
 onMounted(() => {
@@ -573,21 +580,17 @@ watch(locale, () => {
 })
 
 function syncEditorToPostContent(content: string) {
-  if (!codeMirrorView.value)
+  const view = codeMirrorView.value
+  if (!view)
     return
 
-  const currentContent = codeMirrorView.value.state.doc.toString()
+  const currentContent = view.state.doc.toString()
   if (currentContent === content)
     return
 
   const generation = ++postSwitchGeneration
-  codeMirrorView.value.dispatch({
-    changes: {
-      from: 0,
-      to: codeMirrorView.value.state.doc.length,
-      insert: content,
-    },
-  })
+  replaceDocumentWithoutHistory(view, content)
+  resetEditorHistory(view, historyCompartment)
   void preloadMathJaxIfNeeded(content).then(() => {
     if (generation !== postSwitchGeneration)
       return
@@ -595,8 +598,11 @@ function syncEditorToPostContent(content: string) {
   })
 }
 
-watch(currentPostIndex, () => {
-  const post = posts.value[currentPostIndex.value]
+watch(currentPostIndex, (newIndex, oldIndex) => {
+  if (oldIndex !== undefined && oldIndex >= 0)
+    flushEditorContentToPostAtIndex(oldIndex)
+
+  const post = posts.value[newIndex]
   if (!post)
     return
   syncEditorToPostContent(post.content)

--- a/packages/shared/src/editor/history.ts
+++ b/packages/shared/src/editor/history.ts
@@ -1,0 +1,18 @@
+import type { Compartment } from '@codemirror/state'
+import type { EditorView } from '@codemirror/view'
+import { history } from '@codemirror/commands'
+import { Transaction } from '@codemirror/state'
+
+export { history }
+
+export function replaceDocumentWithoutHistory(view: EditorView, content: string) {
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: content },
+    annotations: Transaction.addToHistory.of(false),
+  })
+}
+
+export function resetEditorHistory(view: EditorView, historyCompartment: Compartment) {
+  view.dispatch({ effects: historyCompartment.reconfigure([]) })
+  view.dispatch({ effects: historyCompartment.reconfigure(history()) })
+}

--- a/packages/shared/src/editor/index.ts
+++ b/packages/shared/src/editor/index.ts
@@ -1,6 +1,7 @@
 export * from './basicSetup'
 export * from './css'
 export * from './format'
+export * from './history'
 export * from './javascript'
 export * from './markdown'
 export * from './themes'

--- a/packages/shared/src/editor/markdown.ts
+++ b/packages/shared/src/editor/markdown.ts
@@ -39,6 +39,8 @@ interface MarkdownKeymapOptions {
   onReplace?: (view: EditorView) => void
   onGoToLine?: (view: EditorView) => void
   placeholder?: string
+  /** 为 true 时不注入 history()，由调用方通过 Compartment 管理（便于切换文档时清空撤销栈） */
+  withoutHistory?: boolean
 }
 
 /**
@@ -101,11 +103,11 @@ export function markdownKeymap(options?: MarkdownKeymapOptions) {
  *
  */
 export function markdownSetup(options?: MarkdownKeymapOptions) {
-  const { placeholder: placeholderText } = options || {}
+  const { placeholder: placeholderText, withoutHistory } = options || {}
 
   return [
     // 基础功能
-    history(),
+    ...(withoutHistory ? [] : [history()]),
     highlightSelectionMatches(),
     closeBrackets(),
 


### PR DESCRIPTION
## Summary

- Clear CodeMirror undo history when switching posts so Ctrl+Z no longer restores the previous article's content
- Manage `history()` via a Compartment and replace document content without recording it in the undo stack
- Flush pending editor edits to the leaving post before switching to avoid losing unsaved changes

## Related Issue

Closes #1726

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] Open an existing article, create a new article, press Ctrl+Z — content stays on the new article
- [x] Type in the new article, press Ctrl+Z — only edits within the current article are undone
- [x] Switch between articles after editing — pending edits are saved to the correct post
- [x] `pnpm web dev` starts without unresolved `@codemirror/commands` dependency errors

## Pre-flight Checklist

- [x] Changes are scoped to the undo-on-post-switch bug
- [x] Commit message follows Conventional Commits (English)
- [x] ESLint pre-commit hook passed
- [ ] CI checks pending
