### PR TITLE
fix(web): prevent aria-hidden focus warnings when opening modals

### DIFF
--- a/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
+++ b/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dialog'
 import { Textarea } from '@/components/ui/textarea'
 import { buildAIHeaders, resolveEndpointUrl } from '@/composables/useAIFetch'
+import { prepareModalOverlayFocus } from '@/lib/a11y/dialog-focus'
 import { copyPlain } from '@/lib/browser/clipboard'
 import { store } from '@/storage'
 import useAIImageConfigStore from '@/stores/aiImageConfig'
@@ -436,6 +437,7 @@ watch(previewImageUrl, async (imageUrl) => {
   if (!imageUrl)
     return
 
+  prepareModalOverlayFocus()
   await nextTick()
   previewOverlayRef.value?.focus()
 })

--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -4,7 +4,6 @@ import { Check, CheckSquare, Download, Edit3, Ellipsis, Eye, Plus, X } from '@lu
 import { exportMergedTheme } from '@md/core'
 import { themeMap } from '@md/shared'
 import { getThemeLabel } from '@/composables/useLocalizedStyleOptions'
-import { blurFocusOutsideDialog } from '@/lib/a11y/dialog-focus'
 import { copyPlain } from '@/lib/browser/clipboard'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCssEditorStore } from '@/stores/cssEditor'
@@ -638,7 +637,7 @@ function exportCurrentTheme() {
 
   <!-- 查看内置主题对话框 -->
   <Dialog v-model:open="isOpenViewThemeDialog">
-    <DialogContent class="sm:max-w-4xl max-h-[90vh] flex flex-col" @open-auto-focus="blurFocusOutsideDialog">
+    <DialogContent class="sm:max-w-4xl max-h-[90vh] flex flex-col">
       <DialogHeader>
         <DialogTitle>{{ t('cssEditor.viewBuiltinTitle') }}</DialogTitle>
         <DialogDescription>

--- a/apps/web/src/components/shared/confirm-dialog/ConfirmDialog.vue
+++ b/apps/web/src/components/shared/confirm-dialog/ConfirmDialog.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 import {
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogOverlay,
-  AlertDialogPortal,
-  AlertDialogRoot,
-} from 'reka-ui'
-import {
+  AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -21,44 +17,40 @@ const confirmStore = useConfirmStore()
 </script>
 
 <template>
-  <AlertDialogRoot v-model:open="confirmStore.isOpen">
-    <AlertDialogPortal>
-      <AlertDialogOverlay
-        class="fixed inset-0 z-[999] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
-      />
-      <AlertDialogContent
-        class="fixed left-1/2 top-1/2 z-[1000] grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 sm:rounded-lg"
-      >
-        <AlertDialogHeader>
-          <AlertDialogTitle class="text-lg font-semibold">
-            {{ confirmStore.title }}
-          </AlertDialogTitle>
-          <AlertDialogDescription v-if="confirmStore.description">
-            {{ confirmStore.description }}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel
-            :class="cn(
-              buttonVariants({ variant: 'outline' }),
-              'mt-2 sm:mt-0',
-            )"
-            @click="confirmStore.handleCancel()"
-          >
-            {{ confirmStore.cancelText }}
-          </AlertDialogCancel>
-          <AlertDialogAction
-            :class="cn(
-              buttonVariants(),
-              confirmStore.destructive
-                && 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-            )"
-            @click="confirmStore.handleConfirm()"
-          >
-            {{ confirmStore.confirmText }}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialogPortal>
-  </AlertDialogRoot>
+  <AlertDialog v-model:open="confirmStore.isOpen">
+    <AlertDialogContent
+      overlay-class="z-[999]"
+      class="z-[1000]"
+    >
+      <AlertDialogHeader>
+        <AlertDialogTitle class="text-lg font-semibold">
+          {{ confirmStore.title }}
+        </AlertDialogTitle>
+        <AlertDialogDescription v-if="confirmStore.description">
+          {{ confirmStore.description }}
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel
+          :class="cn(
+            buttonVariants({ variant: 'outline' }),
+            'mt-2 sm:mt-0',
+          )"
+          @click="confirmStore.handleCancel()"
+        >
+          {{ confirmStore.cancelText }}
+        </AlertDialogCancel>
+        <AlertDialogAction
+          :class="cn(
+            buttonVariants(),
+            confirmStore.destructive
+              && 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          )"
+          @click="confirmStore.handleConfirm()"
+        >
+          {{ confirmStore.confirmText }}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
 </template>

--- a/apps/web/src/components/shared/panel-dialog/PanelDialog.vue
+++ b/apps/web/src/components/shared/panel-dialog/PanelDialog.vue
@@ -8,7 +8,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { blurFocusInsideDialogOnClose, blurFocusOutsideDialog } from '@/lib/a11y/dialog-focus'
 import { cn } from '@/lib/utils'
 
 const props = withDefaults(defineProps<{
@@ -47,19 +46,11 @@ const dialogContentClass = computed(() => cn(
 function onUpdate(val: boolean) {
   emit(`update:open`, val)
 }
-
-function onCloseAutoFocus(event: Event) {
-  blurFocusInsideDialogOnClose(event)
-}
 </script>
 
 <template>
   <Dialog :open="props.open" @update:open="onUpdate">
-    <DialogContent
-      :class="dialogContentClass"
-      @open-auto-focus="blurFocusOutsideDialog"
-      @close-auto-focus="onCloseAutoFocus"
-    >
+    <DialogContent :class="dialogContentClass">
       <div
         aria-hidden="true"
         class="mx-auto mt-2 mb-1 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/25 sm:hidden"

--- a/apps/web/src/components/ui/alert-dialog/AlertDialog.vue
+++ b/apps/web/src/components/ui/alert-dialog/AlertDialog.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import type { AlertDialogEmits, AlertDialogProps } from 'reka-ui'
 import { AlertDialogRoot, useForwardPropsEmits } from 'reka-ui'
+import { useModalOpenFocusBlur } from '@/lib/a11y/dialog-focus'
 
 const props = defineProps<AlertDialogProps>()
 const emits = defineEmits<AlertDialogEmits>()
 
 const forwarded = useForwardPropsEmits(props, emits)
+
+useModalOpenFocusBlur(() => props.open)
 </script>
 
 <template>

--- a/apps/web/src/components/ui/alert-dialog/AlertDialogContent.vue
+++ b/apps/web/src/components/ui/alert-dialog/AlertDialogContent.vue
@@ -8,27 +8,37 @@ import {
   AlertDialogPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
+import { useDialogContentA11yBindings } from '@/lib/a11y/dialog-focus'
 import { cn } from '@/lib/utils'
 
-const props = defineProps<AlertDialogContentProps & { class?: HTMLAttributes[`class`] }>()
+const props = defineProps<AlertDialogContentProps & {
+  class?: HTMLAttributes[`class`]
+  overlayClass?: HTMLAttributes[`class`]
+}>()
 const emits = defineEmits<AlertDialogContentEmits>()
 
 const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
+  const { class: _, overlayClass: __, ...delegated } = props
 
   return delegated
 })
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
+const contentBindings = useDialogContentA11yBindings(forwarded)
 </script>
 
 <template>
   <AlertDialogPortal>
     <AlertDialogOverlay
-      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80"
+      :class="
+        cn(
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+          props.overlayClass,
+        )
+      "
     />
     <AlertDialogContent
-      v-bind="forwarded"
+      v-bind="contentBindings"
       :class="
         cn(
           'fixed left-1/2 top-1/2 z-200 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 sm:rounded-lg',

--- a/apps/web/src/components/ui/dialog/Dialog.vue
+++ b/apps/web/src/components/ui/dialog/Dialog.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import type { DialogRootEmits, DialogRootProps } from 'reka-ui'
 import { DialogRoot, useForwardPropsEmits } from 'reka-ui'
+import { useModalOpenFocusBlur } from '@/lib/a11y/dialog-focus'
 
 const props = defineProps<DialogRootProps>()
 const emits = defineEmits<DialogRootEmits>()
 
 const forwarded = useForwardPropsEmits(props, emits)
+
+useModalOpenFocusBlur(() => props.open)
 </script>
 
 <template>

--- a/apps/web/src/components/ui/dialog/DialogContent.vue
+++ b/apps/web/src/components/ui/dialog/DialogContent.vue
@@ -10,6 +10,7 @@ import {
   DialogPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
+import { useDialogContentA11yBindings } from '@/lib/a11y/dialog-focus'
 import { cn } from '@/lib/utils'
 
 const props = defineProps<DialogContentProps & { class?: HTMLAttributes[`class`] }>()
@@ -22,6 +23,7 @@ const delegatedProps = computed(() => {
 })
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
+const contentBindings = useDialogContentA11yBindings(forwarded)
 </script>
 
 <template>
@@ -30,7 +32,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-200 bg-black/80"
     />
     <DialogContent
-      v-bind="forwarded"
+      v-bind="contentBindings"
       :class="
         cn(
           'fixed left-1/2 top-1/2 z-200 grid w-[90vw] max-w-md sm:max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 sm:rounded-lg',

--- a/apps/web/src/components/ui/dialog/DialogScrollContent.vue
+++ b/apps/web/src/components/ui/dialog/DialogScrollContent.vue
@@ -10,6 +10,7 @@ import {
   DialogPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
+import { useDialogContentA11yBindings } from '@/lib/a11y/dialog-focus'
 import { cn } from '@/lib/utils'
 
 const props = defineProps<DialogContentProps & { class?: HTMLAttributes[`class`] }>()
@@ -22,6 +23,7 @@ const delegatedProps = computed(() => {
 })
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
+const contentBindings = useDialogContentA11yBindings(forwarded)
 </script>
 
 <template>
@@ -30,13 +32,13 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 grid place-items-center overflow-y-auto bg-black/80"
     >
       <DialogContent
+        v-bind="contentBindings"
         :class="
           cn(
             'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg md:w-full',
             props.class,
           )
         "
-        v-bind="forwarded"
         @pointer-down-outside="(event) => {
           const originalEvent = event.detail.originalEvent;
           const target = originalEvent.target as HTMLElement;

--- a/apps/web/src/lib/a11y/dialog-focus.test.ts
+++ b/apps/web/src/lib/a11y/dialog-focus.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  blurFocusedElementsOutside,
+  blurFocusInsideDialogOnClose,
+  blurFocusOutsideDialog,
+  blurRetainedPageFocus,
+} from './dialog-focus'
+
+function button(label: string) {
+  const el = document.createElement(`button`)
+  el.type = `button`
+  el.textContent = label
+  document.body.append(el)
+  return el
+}
+
+function cmContent() {
+  const el = document.createElement(`div`)
+  el.className = `cm-content`
+  el.setAttribute(`contenteditable`, `true`)
+  document.body.append(el)
+  return el
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  document.body.focus()
+})
+
+describe(`blurRetainedPageFocus`, () => {
+  it(`blurs the active element`, () => {
+    const trigger = button(`trigger`)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    blurRetainedPageFocus(false)
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it(`blurs focus restored after menu close`, async () => {
+    const trigger = button(`trigger`)
+    trigger.focus()
+
+    blurRetainedPageFocus()
+    trigger.focus()
+
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it(`does not blur focus inside an open dialog`, () => {
+    const dialog = document.createElement(`div`)
+    dialog.setAttribute(`role`, `dialog`)
+    const input = document.createElement(`input`)
+    dialog.append(input)
+    document.body.append(dialog)
+    input.focus()
+
+    blurRetainedPageFocus(false)
+    expect(document.activeElement).toBe(input)
+  })
+
+  it(`no-ops when focus is already on body`, () => {
+    document.body.focus()
+    blurRetainedPageFocus(false)
+    expect(document.activeElement).toBe(document.body)
+  })
+})
+
+describe(`blurFocusedElementsOutside`, () => {
+  it(`blurs focus outside the container`, () => {
+    const dialog = document.createElement(`div`)
+    const editor = cmContent()
+    document.body.append(dialog)
+    editor.focus()
+
+    blurFocusedElementsOutside(dialog)
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it(`blurs focus restored to a trigger outside the container`, async () => {
+    const dialog = document.createElement(`div`)
+    const trigger = button(`trigger`)
+    document.body.append(dialog)
+
+    blurFocusedElementsOutside(dialog)
+    trigger.focus()
+
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it(`does not blur focus inside the container`, () => {
+    const dialog = document.createElement(`div`)
+    const input = document.createElement(`input`)
+    dialog.append(input)
+    document.body.append(dialog)
+    input.focus()
+
+    blurFocusedElementsOutside(dialog)
+    expect(document.activeElement).toBe(input)
+  })
+
+  it(`does not blur CodeMirror inside the container`, () => {
+    const dialog = document.createElement(`div`)
+    const editor = cmContent()
+    dialog.append(editor)
+    document.body.append(dialog)
+    editor.focus()
+
+    blurFocusedElementsOutside(dialog)
+    expect(document.activeElement).toBe(editor)
+  })
+})
+
+function dialogEvent(dialog: HTMLElement): Event {
+  return { currentTarget: dialog } as unknown as Event
+}
+
+describe(`blurFocusOutsideDialog`, () => {
+  it(`blurs elements outside the dialog element`, () => {
+    const dialog = document.createElement(`div`)
+    const trigger = button(`trigger`)
+    document.body.append(dialog)
+    trigger.focus()
+
+    blurFocusOutsideDialog(dialogEvent(dialog))
+    expect(document.activeElement).toBe(document.body)
+  })
+})
+
+describe(`blurFocusInsideDialogOnClose`, () => {
+  it(`blurs focus inside the dialog`, () => {
+    const dialog = document.createElement(`div`)
+    const input = document.createElement(`input`)
+    dialog.append(input)
+    document.body.append(dialog)
+    input.focus()
+
+    blurFocusInsideDialogOnClose(dialogEvent(dialog))
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it(`does not blur focus outside the dialog`, () => {
+    const dialog = document.createElement(`div`)
+    const trigger = button(`trigger`)
+    document.body.append(dialog)
+    trigger.focus()
+
+    blurFocusInsideDialogOnClose(dialogEvent(dialog))
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/apps/web/src/lib/a11y/dialog-focus.ts
+++ b/apps/web/src/lib/a11y/dialog-focus.ts
@@ -1,17 +1,92 @@
-/** Blur focus on triggers outside the dialog so aria-hidden ancestors do not retain focus. */
-export function blurFocusOutsideDialog(event: Event) {
-  const active = document.activeElement
-  const dialog = event.currentTarget
-  if (active instanceof HTMLElement && dialog instanceof HTMLElement && !dialog.contains(active))
-    active.blur()
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, mergeProps, toValue, watch } from 'vue'
+
+function isFocusablePageElement(el: Element | null): el is HTMLElement {
+  return el instanceof HTMLElement && el !== document.body
 }
 
+function shouldBlurPageFocus(el: HTMLElement) {
+  return !el.closest(`[role="dialog"]`)
+}
+
+function blurActivePageFocus() {
+  const active = document.activeElement
+  if (!isFocusablePageElement(active) || !shouldBlurPageFocus(active))
+    return
+
+  active.blur()
+}
+
+function runDeferredPageFocusBlur(run: () => void) {
+  run()
+  queueMicrotask(run)
+  requestAnimationFrame(run)
+}
+
+/** Blur the currently focused page element (e.g. CodeMirror, menu trigger). */
+export function blurRetainedPageFocus(defer = true) {
+  const blur = () => blurActivePageFocus()
+
+  if (defer)
+    runDeferredPageFocusBlur(blur)
+  else
+    blur()
+}
+
+/** Blur focused elements outside `container` so aria-hidden ancestors do not retain focus. */
+export function blurFocusedElementsOutside(container: HTMLElement) {
+  const blurOutside = () => {
+    const active = document.activeElement
+    if (isFocusablePageElement(active) && !container.contains(active))
+      active.blur()
+
+    for (const el of document.querySelectorAll<HTMLElement>(`.cm-content`)) {
+      if (!container.contains(el) && el === document.activeElement)
+        el.blur()
+    }
+  }
+
+  runDeferredPageFocusBlur(blurOutside)
+}
+
+/** Blur focus outside the dialog; run before any custom `open-auto-focus` handler. */
+export function blurFocusOutsideDialog(event: Event) {
+  const dialog = event.currentTarget
+  if (dialog instanceof HTMLElement)
+    blurFocusedElementsOutside(dialog)
+}
+
+/** Blur focus inside the dialog before focus is restored to the trigger. */
 export function blurFocusInsideDialogOnClose(event: Event) {
   const active = document.activeElement
-  if (!(active instanceof HTMLElement) || active === document.body)
+  if (!isFocusablePageElement(active))
     return
 
   const dialog = event.currentTarget
   if (dialog instanceof HTMLElement && dialog.contains(active))
     active.blur()
+}
+
+/** Blur page focus before focusing a teleported modal overlay (non-reka-ui). */
+export function prepareModalOverlayFocus() {
+  blurRetainedPageFocus()
+}
+
+/** Bind before forwarded props so consumer handlers run after the blur. */
+export const dialogContentA11yHandlers = {
+  onOpenAutoFocus: blurFocusOutsideDialog,
+  onCloseAutoFocus: blurFocusInsideDialogOnClose,
+}
+
+/** Merge a11y handlers with forwarded props (Vue disallows duplicate `v-bind`). */
+export function useDialogContentA11yBindings(forwarded: MaybeRefOrGetter<Record<string, unknown>>) {
+  return computed(() => mergeProps(dialogContentA11yHandlers, toValue(forwarded)))
+}
+
+/** Blur editor focus as soon as a modal root opens (before aria-hidden). */
+export function useModalOpenFocusBlur(open: MaybeRefOrGetter<boolean | undefined>) {
+  watch(() => toValue(open), (isOpen) => {
+    if (isOpen)
+      blurRetainedPageFocus()
+  }, { immediate: true, flush: `post` })
 }


### PR DESCRIPTION
﻿## Summary

- Centralize modal focus management in `dialog-focus.ts` with deferred blur for CodeMirror and menu triggers
- Wire a11y handlers into `Dialog` / `AlertDialog` wrappers and `ConfirmDialog` (previously bypassed reka-ui wrappers)
- Add `dialog-focus.test.ts` unit tests and handle custom image preview overlay focus

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] Focus CodeMirror, open Account / Settings / Import dialogs — no `aria-hidden` console warning
- [x] Open post-slider `...` menu → Batch import — no warning on dropdown trigger
- [x] Trigger global confirm dialog (batch delete) — no warning
- [x] `pnpm exec vitest run src/lib/a11y/dialog-focus.test.ts`
- [x] `pnpm web build`

## Pre-flight Checklist

- [x] Changes are focused on a single concern
- [x] Self-tested locally
- [x] No secrets committed
