### PR TITLE
fix(web): upgrade http image URLs to https to avoid Mixed Content blocking

### DIFF
--- a/apps/web/src/composables/useImageUploader.ts
+++ b/apps/web/src/composables/useImageUploader.ts
@@ -47,6 +47,9 @@ export function useImageUploader() {
     const getFilename = (u: string) => u.split('/').pop()?.split('?')[0] || `image-${Date.now()}.png`
     const filename = getFilename(url)
 
+    // 将 http:// 升级为 https://，避免 Mixed Content 被浏览器拦截
+    const safeUrl = url.replace(/^http:\/\//i, 'https://')
+
     const fetchBlob = async (targetUrl: string, options?: RequestInit) => {
       const res = await fetch(targetUrl, options)
       if (!res.ok)
@@ -55,19 +58,19 @@ export function useImageUploader() {
     }
 
     try {
-      const blob = await fetchBlob(url, { referrerPolicy: 'no-referrer' })
+      const blob = await fetchBlob(safeUrl, { referrerPolicy: 'no-referrer' })
       return new File([blob], filename, { type: blob.type })
     }
     catch (directErr) {
-      console.warn(`Direct fetch failed for ${url}, trying proxy...`, directErr)
+      console.warn(`Direct fetch failed for ${safeUrl}, trying proxy...`, directErr)
 
       try {
-        const proxyUrl = `https://wsrv.nl/?url=${encodeURIComponent(url)}`
+        const proxyUrl = `https://wsrv.nl/?url=${encodeURIComponent(safeUrl)}`
         const blob = await fetchBlob(proxyUrl)
         return new File([blob], filename, { type: blob.type })
       }
       catch (proxyErr: any) {
-        console.error(`Proxy fetch failed for ${url}`, proxyErr)
+        console.error(`Proxy fetch failed for ${safeUrl}`, proxyErr)
         const isCors = proxyErr.message.includes('Failed to fetch') || proxyErr.name === 'TypeError'
         const msg = isCors
           ? t('store.uploader.corsFailed')


### PR DESCRIPTION
﻿## Summary

When uploading images from external URLs in the HTTPS editor, `fetch()` against `http://` sources is blocked by the browser as Mixed Content. This change upgrades `http://` URLs to `https://` before direct fetch and proxy fallback in `useImageUploader`, so common image hosts that support HTTPS can be downloaded and re-uploaded to the configured image bed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [ ] Open the editor over HTTPS (e.g. https://md.doocs.org or local dev with HTTPS)
- [ ] Paste or insert a Markdown image with an `http://` URL from a host that also serves HTTPS
- [ ] Trigger image upload / transfer to image bed
- [ ] Confirm the image downloads and uploads successfully instead of failing with Mixed Content / fetch errors
- [ ] Verify `https://` URLs and local `File` uploads still work as before

## Pre-flight Checklist

- [x] Working tree is clean
- [x] Change is scoped to a single fix
- [x] No new user-facing copy (no i18n updates required)
- [ ] CI checks pass (pending)
