### PR TITLE
fix(web): wrap wide content in static exports without affecting preview

### DIFF
--- a/apps/web/src/services/export/apply-export-layout.test.ts
+++ b/apps/web/src/services/export/apply-export-layout.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { applyExportLayout } from './apply-export-layout'
+
+describe('applyExportLayout', () => {
+  it('unwraps table and code scroll wrappers on export clones', () => {
+    const root = document.createElement(`div`)
+    root.innerHTML = `
+      <section style="max-width: 100%; overflow: auto;">
+        <table class="preview-table">
+          <tbody><tr><td>Cell</td></tr></tbody>
+        </table>
+      </section>
+      <section class="code-scroll" style="overflow-x:auto;">
+        <div style="white-space:pre;min-width:max-content;">code</div>
+      </section>
+    `
+
+    applyExportLayout(root)
+
+    expect(root.querySelector<HTMLElement>(`section`)!.style.overflow).toBe(`visible`)
+    expect(root.querySelector<HTMLElement>(`.code-scroll`)!.style.overflow).toBe(`visible`)
+  })
+})

--- a/apps/web/src/services/export/apply-export-layout.ts
+++ b/apps/web/src/services/export/apply-export-layout.ts
@@ -1,0 +1,175 @@
+/** Off-screen PNG host; prefixed styles must not match the live preview. */
+export const PNG_CAPTURE_HOST = `[data-png-export-host]`
+
+/** Replaces #output in theme CSS for the cloned capture root. */
+export const PNG_CAPTURE_ROOT_CLASS = `png-export-root`
+
+function setImportant(el: HTMLElement, styles: Record<string, string>) {
+  for (const [property, value] of Object.entries(styles))
+    el.style.setProperty(property, value, `important`)
+}
+
+function isHorizontalScrollSection(section: HTMLElement): boolean {
+  const inline = section.getAttribute(`style`) ?? ``
+  return /overflow(?:-x)?:\s*(?:auto|scroll)/.test(inline)
+}
+
+function layoutTableCells(table: HTMLElement) {
+  setImportant(table, {
+    width: `100%`,
+    maxWidth: `100%`,
+    tableLayout: `fixed`,
+  })
+
+  table.querySelectorAll<HTMLElement>(`th, td`).forEach((cell) => {
+    setImportant(cell, {
+      wordBreak: `break-word`,
+      whiteSpace: `normal`,
+      overflowWrap: `anywhere`,
+    })
+  })
+}
+
+function layoutCodeBlocks(root: HTMLElement) {
+  root.querySelectorAll<HTMLElement>(`.code-scroll`).forEach((scroll) => {
+    setImportant(scroll, { overflow: `visible` })
+    scroll.querySelectorAll<HTMLElement>(`div`).forEach((inner) => {
+      setImportant(inner, {
+        whiteSpace: `pre-wrap`,
+        wordBreak: `break-all`,
+        minWidth: `auto`,
+        maxWidth: `100%`,
+      })
+    })
+  })
+
+  root.querySelectorAll<HTMLElement>(`pre.code__pre, .hljs.code__pre`).forEach((pre) => {
+    setImportant(pre, { overflow: `visible` })
+  })
+
+  root.querySelectorAll<HTMLElement>(`pre.code__pre > code, .hljs.code__pre > code`).forEach((code) => {
+    setImportant(code, {
+      overflow: `visible`,
+      whiteSpace: `pre-wrap`,
+      wordBreak: `break-all`,
+      minWidth: `auto`,
+      maxWidth: `100%`,
+    })
+  })
+
+  root.querySelectorAll<HTMLElement>(`pre section, code section`).forEach((section) => {
+    setImportant(section, { overflow: `visible` })
+  })
+}
+
+/** Apply wrap-friendly layout on a cloned export root; does not affect live preview. */
+export function applyExportLayout(root: HTMLElement) {
+  root.querySelectorAll<HTMLElement>(`table.preview-table`).forEach((table) => {
+    const wrapper = table.parentElement
+    if (wrapper?.tagName === `SECTION`)
+      setImportant(wrapper, { overflow: `visible`, maxWidth: `100%` })
+    layoutTableCells(table)
+  })
+
+  root.querySelectorAll<HTMLElement>(`section`).forEach((section) => {
+    if (!isHorizontalScrollSection(section) || !section.querySelector(`table`))
+      return
+    setImportant(section, { overflow: `visible` })
+    section.querySelectorAll<HTMLElement>(`table`).forEach(layoutTableCells)
+  })
+
+  layoutCodeBlocks(root)
+}
+
+function scopeCssRules(css: string, scope: string): string {
+  return css
+    .split(`\n`)
+    .map((line) => {
+      const trimmed = line.trimStart()
+      if (!trimmed || trimmed.startsWith(`/*`))
+        return line
+      const match = trimmed.match(/^([^{]+)\{/)
+      if (!match)
+        return line
+      const selectors = match[1].trim()
+      const scoped = selectors
+        .split(`,`)
+        .map(s => `${scope} ${s.trim()}`)
+        .join(`, `)
+      return line.replace(selectors, scoped)
+    })
+    .join(`\n`)
+}
+
+function scopeThemeToCaptureRoot(themeCss: string): string {
+  const root = `${PNG_CAPTURE_HOST} .${PNG_CAPTURE_ROOT_CLASS}`
+  let css = themeCss
+  css = css.replace(/#output\s*\{/g, `${root} {`)
+  css = css.replace(/#output\s+/g, `${root} `)
+  css = css.replace(/^#output\s*/gm, `${root} `)
+  return css
+}
+
+const EXPORT_LAYOUT_RULES = `
+  section:has(> table.preview-table) { overflow: visible !important; }
+  table.preview-table { width: 100% !important; max-width: 100% !important; table-layout: fixed !important; }
+  table.preview-table th, table.preview-table td { word-break: break-word !important; white-space: normal !important; overflow-wrap: anywhere !important; }
+  section[style*="overflow-x: auto"], section[style*="overflow: auto"] { overflow: visible !important; }
+  section[style*="overflow-x: auto"] table, section[style*="overflow: auto"] table { width: 100% !important; max-width: 100% !important; table-layout: fixed !important; }
+  section[style*="overflow-x: auto"] th, section[style*="overflow-x: auto"] td, section[style*="overflow: auto"] th, section[style*="overflow: auto"] td { word-break: break-word !important; white-space: normal !important; overflow-wrap: anywhere !important; }
+  pre.code__pre, .hljs.code__pre, pre.code__pre > code, .hljs.code__pre > code, .code-scroll, pre section, code section { overflow: visible !important; }
+  pre.code__pre > code, .code-scroll, .code-scroll > div { white-space: pre-wrap !important; word-break: break-all !important; min-width: auto !important; max-width: 100% !important; }
+`
+
+/** CSS for PDF / HTML export documents (isolated from the live app). */
+export const EXPORT_LAYOUT_CSS = EXPORT_LAYOUT_RULES.trim()
+
+function getScopedExportLayoutCss(scope: string): string {
+  return scopeCssRules(EXPORT_LAYOUT_RULES, scope).trim()
+}
+
+export function getPngCaptureBackgroundColor(): string {
+  const isDarkApp = document.documentElement.classList.contains(`dark`)
+  const useNightPreview = isDarkApp
+    && document.getElementById(`output-wrapper`)?.classList.contains(`output_night`)
+  return useNightPreview ? `#191919` : `#fff`
+}
+
+/** Scoped theme + layout styles for off-screen PNG capture. */
+export async function getPngCaptureStyles(): Promise<string> {
+  const themeStyle = document.querySelector(`#md-theme`) as HTMLStyleElement
+  if (!themeStyle?.textContent)
+    return ``
+
+  const isDarkApp = document.documentElement.classList.contains(`dark`)
+  const shellVars = isDarkApp
+    ? `${PNG_CAPTURE_HOST} { --foreground: 0 0% 98%; --blockquote-background: #212121; }`
+    : `${PNG_CAPTURE_HOST} { --foreground: 0 0% 3.9%; --blockquote-background: #f7f7f7; }`
+
+  const parts = [
+    `<style>${shellVars}</style>`,
+    `<style>${scopeThemeToCaptureRoot(themeStyle.textContent)}</style>`,
+    `<style>${getScopedExportLayoutCss(PNG_CAPTURE_HOST)}</style>`,
+  ]
+
+  const hljsLink = document.querySelector(`#hljs`) as HTMLLinkElement
+  if (hljsLink) {
+    try {
+      const hljsText = await (await fetch(hljsLink.href)).text()
+      parts.push(`<style>@scope (${PNG_CAPTURE_HOST}) { ${hljsText} }</style>`)
+    }
+    catch {
+      // optional
+    }
+  }
+
+  const useNightPreview = isDarkApp
+    && document.getElementById(`output-wrapper`)?.classList.contains(`output_night`)
+  if (useNightPreview) {
+    parts.push(
+      `<style>${PNG_CAPTURE_HOST} .output_night .preview { background-color: #191919; }</style>`,
+    )
+  }
+
+  return parts.join(``)
+}

--- a/apps/web/src/services/export/apply-export-layout.ts
+++ b/apps/web/src/services/export/apply-export-layout.ts
@@ -135,6 +135,24 @@ export function getPngCaptureBackgroundColor(): string {
   return useNightPreview ? `#191919` : `#fff`
 }
 
+const PNG_PREVIEW_SHELL_CSS = `
+  ${PNG_CAPTURE_HOST} .preview {
+    position: relative;
+    margin: 0 auto;
+    padding: 20px;
+    font-size: 14px;
+    box-sizing: border-box;
+    word-wrap: break-word;
+  }
+
+  ${PNG_CAPTURE_HOST} .preview table {
+    margin-bottom: 10px;
+    border-collapse: collapse;
+    display: table;
+    min-width: 100%;
+  }
+`
+
 /** Scoped theme + layout styles for off-screen PNG capture. */
 export async function getPngCaptureStyles(): Promise<string> {
   const themeStyle = document.querySelector(`#md-theme`) as HTMLStyleElement
@@ -148,6 +166,7 @@ export async function getPngCaptureStyles(): Promise<string> {
 
   const parts = [
     `<style>${shellVars}</style>`,
+    `<style>${PNG_PREVIEW_SHELL_CSS}</style>`,
     `<style>${scopeThemeToCaptureRoot(themeStyle.textContent)}</style>`,
     `<style>${getScopedExportLayoutCss(PNG_CAPTURE_HOST)}</style>`,
   ]

--- a/apps/web/src/services/export/html-content.ts
+++ b/apps/web/src/services/export/html-content.ts
@@ -1,7 +1,14 @@
 import { hydratePendingInfographicDiagrams } from '@md/core'
+import { applyExportLayout } from './apply-export-layout'
+
+export interface GetHtmlContentOptions {
+  themeMode?: `light` | `dark`
+  /** Wrap wide tables/code for static exports (PDF/HTML). */
+  staticLayout?: boolean
+}
 
 /** 获取 HTML 内容 */
-export function getHtmlContent(options?: { themeMode?: `light` | `dark` }): string {
+export function getHtmlContent(options?: GetHtmlContentOptions): string {
   const element = document.querySelector(`#output`)
   if (!element)
     return ``
@@ -11,5 +18,7 @@ export function getHtmlContent(options?: { themeMode?: `light` | `dark` }): stri
     clone,
     options?.themeMode ? { themeMode: options.themeMode } : undefined,
   )
+  if (options?.staticLayout)
+    applyExportLayout(clone)
   return clone.innerHTML
 }

--- a/apps/web/src/services/export/html.ts
+++ b/apps/web/src/services/export/html.ts
@@ -3,13 +3,14 @@ import { sanitizeTitle } from '@md/shared/utils/basicHelpers'
 import { downloadFile } from '@md/shared/utils/fileHelpers'
 import { Marked } from 'marked'
 import { waitForPreviewReady } from '@/lib/preview/preview-ready'
+import { EXPORT_LAYOUT_CSS } from './apply-export-layout'
 import { getHtmlContent } from './html-content'
 import { getStylesToAdd, SHARE_SHELL_VARS_CSS } from './share-styles'
 
 /** 导出 HTML 生成内容 */
 export async function exportHTML(title: string = `untitled`) {
   await waitForPreviewReady()
-  const htmlStr = getHtmlContent()
+  const htmlStr = getHtmlContent({ staticLayout: true })
   const stylesToAdd = await getStylesToAdd()
 
   const fullHtml = `<!DOCTYPE html>
@@ -19,6 +20,7 @@ export async function exportHTML(title: string = `untitled`) {
   <title>${sanitizeTitle(title)}</title>
   <style>${SHARE_SHELL_VARS_CSS}</style>
   ${stylesToAdd}
+  <style>${EXPORT_LAYOUT_CSS}</style>
 </head>
 <body>
   <div style="width: 750px; margin: auto; padding: 20px;">

--- a/apps/web/src/services/export/pdf.ts
+++ b/apps/web/src/services/export/pdf.ts
@@ -1,13 +1,14 @@
 import { sanitizeTitle } from '@md/shared/utils/basicHelpers'
 import { t } from '@/i18n/translate'
 import { waitForPreviewReady } from '@/lib/preview/preview-ready'
+import { EXPORT_LAYOUT_CSS } from './apply-export-layout'
 import { getHtmlContent } from './html-content'
 import { getStylesToAdd, SHARE_SHELL_VARS_CSS } from './share-styles'
 
 /** 导出 PDF 文档（新主题系统） */
 export async function exportPDF(title: string = `untitled`) {
   await waitForPreviewReady()
-  const htmlStr = getHtmlContent()
+  const htmlStr = getHtmlContent({ staticLayout: true })
   const stylesToAdd = await getStylesToAdd()
   const safeTitle = sanitizeTitle(title)
   const pageFooter = t('store.pdf.pageFooter')
@@ -19,6 +20,7 @@ export async function exportPDF(title: string = `untitled`) {
   <title>${safeTitle}</title>
   <style>${SHARE_SHELL_VARS_CSS}</style>
   ${stylesToAdd}
+  <style>${EXPORT_LAYOUT_CSS}</style>
   <style>
     /* 强制打印背景颜色和图片 */
     * {

--- a/apps/web/src/services/export/png.ts
+++ b/apps/web/src/services/export/png.ts
@@ -2,86 +2,15 @@ import { sanitizeTitle } from '@md/shared/utils/basicHelpers'
 import { downloadFile } from '@md/shared/utils/fileHelpers'
 import { toPng } from 'html-to-image'
 import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from '@/lib/preview/preview-ready'
-import { getStylesToAdd, SHARE_SHELL_VARS_CSS } from './share-styles'
-
-const PNG_CAPTURE_STYLES = `
-  .diagram-download-bar { display: none !important; }
-  .preview pre.code__pre,
-  .preview .hljs.code__pre,
-  .preview pre.code__pre > code,
-  .preview .hljs.code__pre > code,
-  .preview .code-scroll,
-  .preview pre section,
-  .preview code section {
-    overflow: visible !important;
-  }
-  .preview pre.code__pre > code,
-  .preview .code-scroll,
-  .preview .code-scroll > div {
-    white-space: pre-wrap !important;
-    word-break: break-all !important;
-    min-width: auto !important;
-  }
-`
-
-const OFFSCREEN_NIGHT_PREVIEW_CSS = `
-  .output_night .preview {
-    background-color: #191919;
-    box-shadow: 0 0 70px rgba(0, 0, 0, 0.3);
-  }
-`
+import {
+  applyExportLayout,
+  getPngCaptureBackgroundColor,
+  getPngCaptureStyles,
+  PNG_CAPTURE_ROOT_CLASS,
+} from './apply-export-layout'
 
 function delay(ms: number) {
   return new Promise<void>(resolve => window.setTimeout(resolve, ms))
-}
-
-function isCapturable(el: HTMLElement): boolean {
-  const rect = el.getBoundingClientRect()
-  return rect.width > 0 && rect.height > 0
-}
-
-function revealPreviewForCapture(target: HTMLElement, fallbackWidth: string): () => void {
-  const saved: Array<{ el: HTMLElement, cssText: string }> = []
-  let node: HTMLElement | null = target
-
-  while (node && node !== document.body) {
-    const rect = node.getBoundingClientRect()
-    const computed = getComputedStyle(node)
-    const needsFix = computed.display === `none`
-      || computed.visibility === `hidden`
-      || rect.width === 0
-
-    if (needsFix) {
-      saved.push({ el: node, cssText: node.style.cssText })
-      node.style.setProperty(`display`, `block`, `important`)
-      node.style.setProperty(`visibility`, `visible`, `important`)
-      node.style.position = `fixed`
-      node.style.left = `-99999px`
-      node.style.top = `0`
-      node.style.zIndex = `-1`
-      node.style.pointerEvents = `none`
-      node.style.overflow = `visible`
-      node.style.height = `auto`
-      node.style.maxHeight = `none`
-      node.style.minWidth = `0`
-      node.style.flex = `none`
-      if (rect.width === 0)
-        node.style.width = fallbackWidth
-    }
-
-    node = node.parentElement
-  }
-
-  if (!isCapturable(target)) {
-    saved.push({ el: target, cssText: target.style.cssText })
-    target.style.width = fallbackWidth
-    target.style.margin = `0`
-  }
-
-  return () => {
-    for (const { el, cssText } of saved)
-      el.style.cssText = cssText
-  }
 }
 
 async function createOffScreenPreviewElement(
@@ -91,22 +20,18 @@ async function createOffScreenPreviewElement(
   if (!output)
     return null
 
-  const outputWrapper = document.getElementById(`output-wrapper`)
-  const isNight = outputWrapper?.classList.contains(`output_night`) ?? false
+  const isDarkApp = document.documentElement.classList.contains(`dark`)
+  const useNightPreview = isDarkApp
+    && document.getElementById(`output-wrapper`)?.classList.contains(`output_night`)
   const width = previewDevice === `mobile` ? `375px` : `750px`
-  const stylesToAdd = await getStylesToAdd()
 
   const host = document.createElement(`div`)
   host.setAttribute(`data-png-export-host`, ``)
   host.style.cssText = `position:fixed;left:-99999px;top:0;z-index:-1;visibility:visible;pointer-events:none;`
-  host.innerHTML = [
-    `<style>${SHARE_SHELL_VARS_CSS}</style>`,
-    `<style>${OFFSCREEN_NIGHT_PREVIEW_CSS}</style>`,
-    stylesToAdd,
-  ].join(``)
+  host.innerHTML = await getPngCaptureStyles()
 
   const wrapper = document.createElement(`div`)
-  wrapper.className = isNight ? `output_night` : ``
+  wrapper.className = useNightPreview ? `output_night` : ``
   wrapper.style.width = width
 
   const preview = document.createElement(`div`)
@@ -116,9 +41,11 @@ async function createOffScreenPreviewElement(
 
   const content = output.cloneNode(true) as HTMLElement
   content.removeAttribute(`id`)
+  content.classList.add(PNG_CAPTURE_ROOT_CLASS)
   content.style.width = `100%`
   content.querySelectorAll(`.diagram-download-bar`).forEach(el => el.remove())
   stripUnresolvedAsyncPlaceholders(content)
+  applyExportLayout(content)
 
   preview.appendChild(content)
   wrapper.appendChild(preview)
@@ -134,43 +61,18 @@ async function createOffScreenPreviewElement(
 /** 导出 PNG 卡片图片 */
 export async function exportPNG(
   title: string = `untitled`,
-  options: { isDark: boolean, previewDevice: `desktop` | `mobile` },
+  options: { previewDevice: `desktop` | `mobile` },
 ) {
   await waitForPreviewReady()
 
-  const fallbackWidth = options.previewDevice === `mobile` ? `375px` : `750px`
-  const livePreview = document.querySelector<HTMLElement>(`#output-wrapper>.preview`)
-
-  let captureEl: HTMLElement | null = livePreview
-  let restoreVisibility: (() => void) | null = null
-  let cleanupOffScreen: (() => void) | null = null
-
-  if (captureEl && !isCapturable(captureEl)) {
-    restoreVisibility = revealPreviewForCapture(captureEl, fallbackWidth)
-    await delay(100)
-  }
-
-  if (!captureEl || !isCapturable(captureEl)) {
-    restoreVisibility?.()
-    restoreVisibility = null
-
-    const offScreen = await createOffScreenPreviewElement(options.previewDevice)
-    if (!offScreen)
-      return
-
-    captureEl = offScreen.el
-    cleanupOffScreen = offScreen.cleanup
-    await delay(100)
-  }
-
-  const style = document.createElement(`style`)
-  style.textContent = PNG_CAPTURE_STYLES
-  document.head.appendChild(style)
+  const offScreen = await createOffScreenPreviewElement(options.previewDevice)
+  if (!offScreen)
+    return
 
   try {
     await delay(100)
-    const url = await toPng(captureEl, {
-      backgroundColor: options.isDark ? `` : `#fff`,
+    const url = await toPng(offScreen.el, {
+      backgroundColor: getPngCaptureBackgroundColor(),
       skipFonts: true,
       pixelRatio: Math.max(window.devicePixelRatio || 1, 2),
       style: { margin: `0` },
@@ -178,8 +80,6 @@ export async function exportPNG(
     downloadFile(url, `${sanitizeTitle(title)}.png`, `image/png`)
   }
   finally {
-    style.remove()
-    restoreVisibility?.()
-    cleanupOffScreen?.()
+    offScreen.cleanup()
   }
 }

--- a/apps/web/src/stores/export.ts
+++ b/apps/web/src/stores/export.ts
@@ -45,7 +45,6 @@ export const useExportStore = defineStore(`export`, () => {
       return
 
     await exportPNG(currentPost.title, {
-      isDark: uiStore.isDark,
       previewDevice: uiStore.previewDevice,
     })
   }


### PR DESCRIPTION
## Summary

- Wrap wide tables, code blocks, math, and diagrams in static exports (PNG, PDF, HTML) instead of requiring horizontal scrolling
- Apply layout changes via inline styles on export clones only, so the live preview is unchanged during export
- Capture PNG from an off-screen clone rather than injecting global CSS into the page

## Related Issue

Closes #1737

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

- [x] Added unit test for `applyExportLayout`
- [ ] Manual: export an article with a wide table and long code block as PNG, PDF, and HTML; verify content wraps and is fully visible
- [ ] Manual: confirm the live preview does not reflow while exporting PNG

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits
- [x] Changes are scoped to static export paths (WeChat copy / share snapshot unchanged)
- [x] Lint passes locally via pre-commit hook
