### PR TITLE
fix(web): lazy-load Cloudflare plugin and tune Vite build config

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,7 +2,6 @@ import type { Plugin } from 'vite'
 import path from 'node:path'
 
 import process from 'node:process'
-import { cloudflare } from '@cloudflare/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { visualizer } from 'rollup-plugin-visualizer'
@@ -23,6 +22,10 @@ const base = isNetlify || isCfWorkers || isCfPages ? `/` : isUTools ? `./` : `/m
 
 const PKG_NAME_SPECIAL_CHARS = /[^\w-]/g
 
+const cloudflarePlugin = isCfWorkers
+  ? (await import(`@cloudflare/vite-plugin`)).cloudflare()
+  : undefined
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
 
@@ -37,7 +40,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       }),
-      isCfWorkers && cloudflare(),
+      isCfWorkers && cloudflarePlugin,
       tailwindcss(),
       mode === `development` && env.VITE_VUE_DEVTOOLS === `true` && vueDevTools({
         launchEditor: env.VITE_LAUNCH_EDITOR ?? `code`,
@@ -74,7 +77,7 @@ export default defineConfig(({ mode }) => {
           chunkFileNames: `static/js/md-[name]-[hash].js`,
           entryFileNames: `static/js/md-[name]-[hash].js`,
           assetFileNames: `static/[ext]/md-[name]-[hash].[ext]`,
-          manualChunks(id) {
+          manualChunks(id: string) {
             if (id.includes(`node_modules`)) {
               // @lezer/* are CodeMirror's parser primitives, keep together
               if (id.includes(`codemirror`) || id.includes(`@lezer`))
@@ -124,7 +127,8 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 2000,
+      // Mermaid is lazy-loaded (~2.15 MB minified); keep limit above that chunk
+      chunkSizeWarningLimit: 2500,
     },
   }
 })

--- a/packages/config/tsconfig.node.json
+++ b/packages/config/tsconfig.node.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": [],


### PR DESCRIPTION
## Summary

- Lazy-load `@cloudflare/vite-plugin` via top-level `await` only when `CF_WORKERS=1`, so normal `pnpm web build` no longer pulls in wrangler and triggers the Node `punycode` deprecation warning
- Raise `chunkSizeWarningLimit` to 2500 for the lazy-loaded Mermaid vendor chunk (~2.15 MB minified)
- Set `target: ES2022` in shared `tsconfig.node.json` to allow top-level `await` in `vite.config.ts`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] `pnpm web build` — passes type-check and Vite build without chunk size warning
- [x] `pnpm web wrangler:dev` — dev server starts; frontend (`GET /`) returns 200
- [x] Worker proxy verified: `GET /cgi-bin/token?...` forwards to WeChat API and returns expected response
- [x] `tsc -p apps/web/tsconfig.worker.json --noEmit` — worker entrypoint type-check passes

## Pre-flight Checklist

- [x] Commit follows Conventional Commits (English)
- [x] Change is scoped to Vite / TS config only
- [x] No secrets committed
- [ ] Remaining local changes (`apps/web/package.json`, `apps/vscode/package.json`, `pnpm-lock.yaml` dependency bumps) intentionally left out of this PR
