### PR TITLE
fix(core): prevent extra line break before inline math formulas

### DIFF
--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -102,7 +102,7 @@ function blockKatex(_options: MarkedKatexOptions | undefined, renderer: KatexRen
     name: `blockKatex`,
     level: `block` as const,
     start(src: string) {
-      const index = src.search(/^\s{0,3}\${1,2}/m)
+      const index = src.search(/^\s{0,3}\$\$/m)
       return index === -1 ? undefined : index
     },
     tokenizer(src: string) {

--- a/packages/core/src/renderer/inline-katex.test.ts
+++ b/packages/core/src/renderer/inline-katex.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { renderMarkdown } from '../utils/markdownHelpers'
+import { initRenderer } from './renderer-impl'
+
+describe('inline katex rendering', () => {
+  it('renders inline formula in Chinese text without block wrapper or line break', () => {
+    const renderer = initRenderer({})
+    const md = `取$y_1 = y_2 = \\cdots = y_n = -y$，就退化为二元的情形`
+    const { html } = renderMarkdown(md, renderer)
+
+    expect(html).toContain(`katex-inline`)
+    expect(html).not.toContain(`katex-block`)
+    expect(html).not.toMatch(/<p[^>]*>[\s\S]*?<section class="katex-block"/)
+    // Inline formula should stay in the same paragraph as surrounding text
+    expect(html).toMatch(/取[\s\S]*katex-inline[\s\S]*就退化为二元的情形/)
+  })
+
+  it('does not treat inline formula on its own as block when mixed with text on same line', () => {
+    const renderer = initRenderer({})
+    const md = `before $x+y$ after`
+    const { html } = renderMarkdown(md, renderer)
+
+    expect(html).toContain(`katex-inline`)
+    expect(html).not.toContain(`katex-block`)
+  })
+
+  it('keeps inline formula inline after soft line break in paragraph (#1743)', () => {
+    const renderer = initRenderer({})
+    const md = `取
+$y_1 = y_2 = \\cdots = y_n = -y$，就退化为二元的情形`
+    const { html } = renderMarkdown(md, renderer)
+
+    expect(html).toContain(`katex-inline`)
+    expect(html).not.toContain(`katex-block`)
+    expect(html).not.toContain(`<br>`)
+    expect(html).toMatch(/取[\s\S]*katex-inline[\s\S]*就退化为二元的情形/)
+  })
+
+  it('does not render line-start single-dollar formula as block katex', () => {
+    const renderer = initRenderer({})
+    const md = `$y_1 = y_2 = \\cdots = y_n = -y$`
+    const { html } = renderMarkdown(md, renderer)
+
+    expect(html).toContain(`katex-inline`)
+    expect(html).not.toContain(`katex-block`)
+  })
+
+  it('keeps inline formula in list item without block wrapper', () => {
+    const renderer = initRenderer({})
+    const md = `- 取$y_1 = y_2 = \\cdots = y_n = -y$，就退化为二元的情形`
+    const { html } = renderMarkdown(md, renderer)
+
+    expect(html).toContain(`katex-inline`)
+    expect(html).not.toContain(`katex-block`)
+  })
+})

--- a/packages/core/src/utils/markdownHelpers.ts
+++ b/packages/core/src/utils/markdownHelpers.ts
@@ -1,6 +1,7 @@
 import type { RendererAPI } from '@md/shared/types'
 import type { ReadTimeResults } from '@md/shared/utils/readingTime'
 import DOMPurify from 'isomorphic-dompurify'
+import { stripBreakBeforeInlineKatex } from './mathDetection'
 
 const INFOGRAPHIC_PLACEHOLDER_REGEX = /<!--infographic-start-->[\s\S]*?<!--infographic-end-->/g
 const MERMAID_PLACEHOLDER_REGEX = /<!--mermaid-start-->[\s\S]*?<!--mermaid-end-->/g
@@ -59,6 +60,7 @@ export function renderMarkdown(raw: string, renderer: RendererAPI) {
 
   // marked -> html
   let html = renderer.renderMarkdownToHtml(markdownContent)
+  html = stripBreakBeforeInlineKatex(html)
   html = sanitizeHtml(html)
   return { html, readingTime }
 }
@@ -109,6 +111,7 @@ export function modifyHtmlContent(content: string, renderer: RendererAPI): strin
   } = renderer.parseFrontMatterAndContent(content)
 
   let html = renderer.renderMarkdownToHtml(markdownContent)
+  html = stripBreakBeforeInlineKatex(html)
   html = sanitizeHtml(html)
   return postProcessHtml(html, readingTimeResult, renderer)
 }

--- a/packages/core/src/utils/mathDetection.test.ts
+++ b/packages/core/src/utils/mathDetection.test.ts
@@ -34,4 +34,15 @@ describe('mathDetection block rules', () => {
     expect(singleLineFormula.match(inlineRuleNonStandard)?.[2]?.trim())
       .toBe(`ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}`)
   })
+
+  it('does not match single-dollar formula at line start (#1743)', () => {
+    expect(matchBlockKatex(`$y_1 = y_2$`)).toBeNull()
+    expect(matchBlockKatex(`  $y_1 = y_2$`)).toBeNull()
+  })
+
+  it('does not match single-dollar formula after newline in block scan', () => {
+    const src = `取\n$y_1 = y_2 = \\cdots = y_n = -y$，就退化为二元的情形`
+    const lineStart = src.indexOf(`$`)
+    expect(matchBlockKatex(src.slice(lineStart))).toBeNull()
+  })
 })

--- a/packages/core/src/utils/mathDetection.ts
+++ b/packages/core/src/utils/mathDetection.ts
@@ -2,8 +2,8 @@ export const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1
 export const inlineRuleNonStandard = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1/
 /** 块级公式：换行写法 `$$\n...\n$$` */
 export const blockRuleMultiline = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
-/** 块级公式：单行写法 `$$...$$`（独占一行） */
-export const blockRuleSingleLine = /^\s{0,3}(\${1,2})([^\n$]+)\1[ \t]*(?:\n|$)/
+/** 块级公式：单行写法 `$$...$$`（独占一行，仅双美元符） */
+export const blockRuleSingleLine = /^\s{0,3}(\$\$)([^\n]+)\1[ \t]*(?:\n|$)/
 
 export function matchBlockKatex(src: string): RegExpMatchArray | null {
   return src.match(blockRuleMultiline) ?? src.match(blockRuleSingleLine)
@@ -78,4 +78,9 @@ export function contentHasMath(content: string, nonStandard = true): boolean {
 
   const ruleReg = nonStandard ? inlineRuleNonStandard : inlineRule
   return findInlineKatexStart(content, nonStandard, ruleReg) !== undefined
+}
+
+/** 移除 inline 公式前因 breaks 产生的多余换行 */
+export function stripBreakBeforeInlineKatex(html: string): string {
+  return html.replace(/<br\s*\/?>\s*(?=<span class="katex-inline)/gi, ``)
 }


### PR DESCRIPTION
## Summary

- Restrict single-line block katex detection to `$$...$$` only, so line-start `$...$` is parsed as inline math instead of a block `section` (regression from #1722).
- Strip `<br>` tags inserted immediately before inline formula spans when `breaks: true` causes a soft line break in the same paragraph.
- Add regression tests for issue #1743 scenarios.

## Related Issue

Closes #1743

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI / workflow

## Test Procedure

- [x] `pnpm exec vitest run` in `packages/core` (35 tests pass, including new `inline-katex.test.ts` cases)
- [ ] Manual: preview `取$y_1 = y_2 = \cdots = y_n = -y$，就退化为二元的情形` — formula stays on the same line as surrounding text
- [ ] Manual: confirm `$$E=mc^2$$` on its own line still renders as a centered block formula

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits (English)
- [x] Changes are scoped to `@md/core` math rendering
- [x] zh-CN / en-US i18n not required (no user-facing copy changes)
- [x] Regression tests added
