### PR TITLE
fix(core): wrap code block content to prevent line misalignment on some browsers

### DIFF
--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -149,7 +149,8 @@ function renderDiffCode(text: string, baseLang: string): string {
     .join(``)
 
   const span = `<span class="mac-sign" style="padding: 10px 14px 0;">${macCodeSvg}</span>`
-  return `<pre class="hljs code__pre">${span}<code class="language-diff-${baseLang}">${rendered}</code></pre>`
+  // 与普通代码块一致：用单个块级容器包裹，避免 code 上的 -webkit-box 把多行 span 横向摆放导致错位
+  return `<pre class="hljs code__pre">${span}<code class="language-diff-${baseLang}"><span class="code-block__inner" style="display:block">${rendered}</span></code></pre>`
 }
 
 interface ParseResult {

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -241,7 +241,11 @@ export function highlightAndFormatCode(text: string, language: string, hljs: HLJ
   }
   else {
     const rawHighlighted = hljs.highlight(text, { language }).value
-    highlighted = formatHighlightedCode(rawHighlighted, true)
+    const formatted = formatHighlightedCode(rawHighlighted, true)
+    // 用单个块级容器包裹高亮内容：code 上的 display:-webkit-box 是老式弹性盒，
+    // 若直接平铺多个 span/<br>，不同 Chromium 版本（如部分 Edge）会把子节点按横向盒重排导致代码行错位。
+    // 只保留一个 flex 子项即可让内部 <br> 正常换行，同时保留 -webkit-box 以维持微信端横向滚动。
+    highlighted = `<span class="code-block__inner" style="display:block">${formatted}</span>`
   }
 
   return highlighted


### PR DESCRIPTION
## Summary

Fenced code blocks (and `diff-*` blocks) could render with **overlapping / misaligned lines** in some Chromium builds (reported on Microsoft Edge, while Chrome rendered fine).

Root cause: the `<code>` element uses `display: -webkit-box` — an intentional legacy trick required for horizontal scrolling of code blocks on WeChat mobile. In the non-line-number path, the highlighted content is emitted as many `span` + `<br>` nodes placed **directly** inside that flex box. Blink has reimplemented `-webkit-box` over time, and on some versions the multiple children get laid out along the horizontal box axis, collapsing the code lines on top of each other (e.g. a 7-line block rendered at ~92px tall). Chrome still folded the inline content into a single anonymous box, so `<br>` line breaks kept working there.

The fix wraps the highlighted content (and each diff line group) in a **single block-level container** so the `-webkit-box` has exactly one flex child. This restores deterministic `<br>` line breaks across browsers while keeping `-webkit-box` intact for WeChat horizontal scroll. This mirrors what the line-number path already does (it wraps content in a single `<div>`, which is why line-numbered blocks were unaffected).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- `packages/core/src/utils/languages.ts` — wrap non-line-number highlighted output in a single `display:block` container.
- `packages/core/src/renderer/renderer-impl.ts` — apply the same wrapper to `diff-*` code blocks (which also emit one `display:block` span per line).

## Test Procedure

- `pnpm --filter @md/core exec vitest run` — 35 tests pass.
- `pnpm --filter @md/web exec vitest run apply-export-layout wechat-svg` — 15 tests pass (export/WeChat layout unaffected; the wrapper sets no `white-space`/`min-width`, so it inherits the export wrap rules).
- Manual: paste a multi-line code block (e.g. C++ with `#include`, or a markdown block of headings) in the preview and verify lines no longer overlap in Edge while remaining correct in Chrome.
