### PR TITLE
fix: widen status column in component dialog to prevent wrapping

### DIFF
--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -684,7 +684,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                               <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
                                 {{ t('component.typeCol') }}
                               </th>
-                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-14">
+                              <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
                                 {{ t('component.statusCol') }}
                               </th>
                               <th class="text-left px-3 py-2 font-medium text-muted-foreground">
@@ -954,7 +954,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                                 <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
                                   {{ t('component.typeCol') }}
                                 </th>
-                                <th class="text-left px-3 py-2 font-medium text-muted-foreground w-14">
+                                <th class="text-left px-3 py-2 font-medium text-muted-foreground w-16">
                                   {{ t('component.statusCol') }}
                                 </th>
                                 <th class="text-left px-3 py-2 font-medium text-muted-foreground">


### PR DESCRIPTION
将组件弹窗里的两处状态列宽度从 w-14 改为 w-16，避免两个字也会换行。