### PR TITLE
fix: clarify component name placeholder to reduce ambiguity

### DIFF
--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -442,7 +442,7 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
             <Input
               id="comp-name"
               v-model="formData.name"
-              placeholder="QRCodeBlock"
+              :placeholder="t('component.namePlaceholder')"
               :class="{ 'border-red-500': formErrors.name }"
             />
             <p v-if="formErrors.name" class="text-sm text-red-500">

--- a/apps/web/src/i18n/messages/en-US/editor.ts
+++ b/apps/web/src/i18n/messages/en-US/editor.ts
@@ -236,6 +236,7 @@ export default {
     edit: `Edit component`,
     nameLabel: `Component name`,
     nameHint: `(PascalCase, e.g. QRCodeBlock)`,
+    namePlaceholder: `e.g. QRCodeBlock`,
     descLabel: `Description`,
     descPlaceholder: `Brief description of this component`,
     propsLabel: `Props definition`,

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -236,6 +236,7 @@ export default {
     edit: `编辑组件`,
     nameLabel: `组件名称`,
     nameHint: `（PascalCase，如 QRCodeBlock）`,
+    namePlaceholder: `例：QRCodeBlock`,
     descLabel: `组件描述`,
     descPlaceholder: `简短描述该组件的用途`,
     propsLabel: `Props 定义`,


### PR DESCRIPTION
组件名称 placeholder 优化，减少歧义