### PR TITLE
fix(web): ensure formula editor initializes on mount

### DIFF
--- a/apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue
+++ b/apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue
@@ -240,6 +240,7 @@ watch(
     await nextTick()
     latexInputRef.value?.focus()
   },
+  { immediate: true },
 )
 
 function onUpdate(open: boolean) {


### PR DESCRIPTION
修复：公式编辑器对话框因 watch 缺少 `{ immediate: true }`，导致组件首次挂载时初始化逻辑被跳过的问题——MathJax 未加载、公式文本未回填