### PR TITLE
fix(web): load MathJax when formula editor mounts via v-if

### DIFF
--- a/apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue
+++ b/apps/web/src/components/editor/dialogs/FormulaEditorDialog.vue
@@ -240,6 +240,8 @@ watch(
     await nextTick()
     latexInputRef.value?.focus()
   },
+  // Dialog is mounted via v-if when already open; without immediate the first open never loads MathJax.
+  { immediate: true },
 )
 
 function onUpdate(open: boolean) {


### PR DESCRIPTION
﻿## Summary
- Fix formula editor snippets stuck on "Loading math engine…" when opened by clicking a formula.
- The dialog is mounted with `v-if` after `isShowFormulaEditorDialog` is already `true`, so the MathJax load watcher never ran without `immediate: true`.

## Type of Change
- [ ] 新特性
- [x] Bug 修复
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 样式 / UI 调整
- [ ] 文档更新
- [ ] 工作流 / CI

## Test Procedure
- [x] Open a document with LaTeX formulas and click a rendered formula in the preview
- [x] Confirm the formula editor opens and snippet library renders MathJax (not loading text)
- [x] Confirm the live preview also renders after MathJax loads
- [x] Close and reopen the dialog; confirm formulas still render

## Pre-flight Checklist
- [x] 已自测，确认无回归
- [x] 变更范围聚焦，未夹带无关改动
- [x] Commit message 遵循 Conventional Commits
