### PR TITLE
fix(core): avoid vue-i18n plural parsing in TipBlock

### DIFF
--- a/apps/web/src/i18n/messages/en-US/editor.ts
+++ b/apps/web/src/i18n/messages/en-US/editor.ts
@@ -321,7 +321,7 @@ export default {
       TipBlock: {
         description: `Callout block for tips and notices`,
         props: {
-          type: `Type: info | success | warning | danger`,
+          type: `Type: info, success, warning, danger`,
           title: `Title (optional)`,
           content: `Tip content`,
         },

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -321,7 +321,7 @@ export default {
       TipBlock: {
         description: `提示框组件，高亮展示小贴士或注意事项`,
         props: {
-          type: `类型：info | success | warning | danger`,
+          type: `类型：info、success、warning、danger`,
           title: `标题（可选）`,
           content: `提示内容`,
         },

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -73,7 +73,7 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
     description: `提示框组件，高亮展示小贴士或注意事项`,
     builtIn: true,
     props: [
-      { name: `type`, description: `类型：info | success | warning | danger`, default: `info` },
+      { name: `type`, description: `类型：info、success、warning、danger`, default: `info` },
       { name: `title`, description: `标题（可选）` },
       { name: `content`, description: `提示内容`, required: true },
     ],


### PR DESCRIPTION
修复：描述内容中包含 `|`，触发了某个规则，导致内容被切割