### PR TITLE
refactor(web): remove builtin badge from component dialog

### DIFF
--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -628,7 +628,6 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
                   <div class="flex-1 min-w-0">
                     <div class="flex flex-wrap items-center gap-1.5 mb-0.5">
                       <code class="text-sm font-semibold text-primary">{{ def.name }}</code>
-                      <span class="text-[10px] border px-1.5 py-px rounded-full bg-muted text-muted-foreground">{{ t('component.builtinBadge') }}</span>
                       <span class="text-[10px] border px-1.5 py-px rounded-full bg-muted text-muted-foreground">
                         {{ t('component.propCount', { count: def.props.length }) }}
                       </span>

--- a/apps/web/src/i18n/messages/en-US/editor.ts
+++ b/apps/web/src/i18n/messages/en-US/editor.ts
@@ -256,7 +256,6 @@ export default {
     previewLabel: `Preview (using default prop values)`,
     builtin: `Built-in`,
     custom: `Custom`,
-    builtinBadge: `Built-in`,
     propCount: `{count} props`,
     propDocs: `Props`,
     propNameCol: `Name`,

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -256,7 +256,6 @@ export default {
     previewLabel: `预览（使用默认 prop 值）`,
     builtin: `内置组件`,
     custom: `自定义组件`,
-    builtinBadge: `内置`,
     propCount: `{count} 个属性`,
     propDocs: `属性说明`,
     propNameCol: `属性名`,


### PR DESCRIPTION
移除内置组件的「内置」标签，通过 Tab 区分内置与自定义即可