### PR TITLE
fix(web): prevent horizontal scrollbar in style menu on Firefox

### DIFF
--- a/apps/web/src/components/editor/editor-header/StyleOptionMenu.vue
+++ b/apps/web/src/components/editor/editor-header/StyleOptionMenu.vue
@@ -30,7 +30,7 @@ function setStyle(styleKey: typeof props.styleKey, value: string) {
       <span v-else class="mr-2 h-4 w-4" />
       <span>{{ props.title }}</span>
     </MenubarSubTrigger>
-    <MenubarSubContent class="min-w-44 max-h-56 overflow-auto">
+    <MenubarSubContent class="min-w-44 max-h-56 overflow-y-auto">
       <MenubarRadioGroup :model-value="current" @update:model-value="change">
         <MenubarRadioItem
           v-for="{ label, value, desc } in options"


### PR DESCRIPTION
优化：Firefox 会在触发 `overflow-auto` 时，同时出现横向滚动条，需改为指定轴向