### PR TITLE
fix(web): refresh heading style select label on locale change

### DIFF
--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -61,6 +61,13 @@ const selectedHeadingStyle = computed({
   },
 })
 
+// reka-ui SelectValue 默认缓存选项 textContent，语言切换时需显式渲染本地化标签
+const selectedHeadingStyleLabel = computed(() =>
+  localizedStyleOptions.value.headingStyleOptions
+    .find(option => option.value === selectedHeadingStyle.value)
+    ?.label,
+)
+
 const { isMobile, isOpenRightSlider, isDark } = storeToRefs(uiStore)
 
 // Theme change handlers
@@ -343,7 +350,9 @@ const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth
           </Select>
           <Select v-model="selectedHeadingStyle">
             <SelectTrigger class="flex-1">
-              <SelectValue :placeholder="t('rightSlider.selectStyle')" />
+              <SelectValue :placeholder="t('rightSlider.selectStyle')">
+                {{ selectedHeadingStyleLabel }}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectItem v-for="{ label, value } in localizedStyleOptions.headingStyleOptions" :key="value" :value="value">


### PR DESCRIPTION
﻿## Summary
- Fix the style panel heading-style Select so its trigger label updates immediately when switching locale (e.g. `默认` → `Default`).
- reka-ui `SelectValue` caches selected item textContent; render the localized label explicitly instead.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure
1. Open the style panel (right slider) and set heading style to the default option.
2. Switch UI language between zh-CN and en-US in preferences.
3. Confirm the heading style Select trigger updates to `默认` / `Default` without reopening the dropdown.
4. Confirm changing heading style still works as before.

## Pre-flight Checklist
- [x] Change is focused on a single concern
- [x] Self-tested locally
- [x] No secrets committed
- [ ] Docs updated (N/A — no public API/docs change)
