### PR TITLE
feat(i18n): add one-click locale switching

### DIFF
--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -15,6 +15,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useSyncFooterMeta } from '@/composables/useSyncStatusMeta'
+import { getLocaleOption, getNextLocale } from '@/i18n/constants'
 import { formatRelativeTime } from '@/lib/format/relative-time'
 import {
   clampGoToLineValue,
@@ -28,6 +29,7 @@ import { isShareUiEnabled } from '@/services/share/client'
 import { isSyncUiEnabled } from '@/services/sync/client'
 import { useAuthStore } from '@/stores/auth'
 import { useEditorStore } from '@/stores/editor'
+import { useLocaleStore } from '@/stores/locale'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
@@ -37,19 +39,30 @@ const editorStore = useEditorStore()
 const postStore = usePostStore()
 const uiStore = useUIStore()
 const authStore = useAuthStore()
+const localeStore = useLocaleStore()
 const { readingTime } = storeToRefs(renderStore)
 const { editor } = storeToRefs(editorStore)
 const { currentPost } = storeToRefs(postStore)
 const { isDark } = storeToRefs(uiStore)
 const { isMobile, viewMode, previewDevice, enableScrollSync } = storeToRefs(uiStore)
 const { isLoggedIn } = storeToRefs(authStore)
+const { locale } = storeToRefs(localeStore)
 const showAccountUi = isAccountUiEnabled()
 const showSyncUi = isSyncUiEnabled()
 const showShareUi = isShareUiEnabled()
 const { syncFooterIcon, syncFooterIconClass, syncTooltip } = useSyncFooterMeta()
 
 const isMoreOpen = ref(false)
-const { t, locale } = useI18n()
+const { t, locale: i18nLocale } = useI18n()
+
+const currentLocaleOption = computed(() => getLocaleOption(locale.value))
+
+const nextLocaleOption = computed(() => getLocaleOption(getNextLocale(locale.value)))
+
+const languageTooltip = computed(() => {
+  void i18nLocale.value
+  return t(`footer.switchToLanguage`, { language: t(nextLocaleOption.value.labelKey) })
+})
 
 const accountTooltip = computed(() => {
   if (!isLoggedIn.value)
@@ -75,6 +88,11 @@ function openShareDialog() {
 function toggleTheme() {
   isMoreOpen.value = false
   uiStore.toggleDark()
+}
+
+function toggleLanguage() {
+  isMoreOpen.value = false
+  localeStore.cycleLocale()
 }
 
 // 快速文档切换器
@@ -719,6 +737,23 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
           <Tooltip>
             <TooltipTrigger as-child>
               <button
+                :aria-label="t('footer.toggleLanguage')"
+                class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
+                @click="toggleLanguage"
+              >
+                <span class="min-w-3 text-center text-[10px] font-semibold leading-none tracking-wide">
+                  {{ currentLocaleOption.shortLabel }}
+                </span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" :side-offset="6" class="text-xs text-muted-foreground">
+              <p>{{ languageTooltip }}</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <button
                 :aria-label="t('footer.toggleDarkMode')"
                 class="flex cursor-pointer items-center rounded-md p-1.5 transition-colors hover:bg-accent hover:text-foreground"
                 :class="isDark ? 'text-foreground' : ''"
@@ -779,6 +814,15 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
             >
               <Share2 class="size-3 shrink-0" />
               <span>{{ t('menu.sharePreview') }}</span>
+            </button>
+            <button
+              class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent"
+              @click="toggleLanguage"
+            >
+              <span class="inline-flex size-3 shrink-0 items-center justify-center text-[10px] font-semibold leading-none">
+                {{ currentLocaleOption.shortLabel }}
+              </span>
+              <span>{{ languageTooltip }}</span>
             </button>
             <button
               class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent"

--- a/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { AppLocale } from '@/i18n/types'
 import { Settings } from '@lucide/vue'
 import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
 import PanelSegmented from '@/components/shared/panel-dialog/PanelSegmented.vue'
@@ -7,7 +8,7 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useEditorRefresh } from '@/composables/useEditorRefresh'
-import { LOCALE_OPTIONS } from '@/i18n/constants'
+import { LOCALE_OPTIONS, SUPPORTED_LOCALES } from '@/i18n/constants'
 import { useLocaleStore } from '@/stores/locale'
 import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
@@ -71,6 +72,11 @@ function setCountStatus(value: boolean) {
   isCountStatus.value = value
   editorRefresh()
 }
+
+function onLocaleChange(value: string) {
+  if ((SUPPORTED_LOCALES as readonly string[]).includes(value))
+    localeStore.setLocale(value as AppLocale)
+}
 </script>
 
 <template>
@@ -105,7 +111,7 @@ function setCountStatus(value: boolean) {
           <PanelSegmented
             :model-value="localeStore.locale"
             :options="localeOptions"
-            @update:model-value="localeStore.setLocale($event as typeof localeStore.locale)"
+            @update:model-value="onLocaleChange"
           />
         </div>
 

--- a/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Settings } from '@lucide/vue'
 import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
+import PanelSegmented from '@/components/shared/panel-dialog/PanelSegmented.vue'
 import PanelSelect from '@/components/shared/panel-dialog/PanelSelect.vue'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -101,7 +102,7 @@ function setCountStatus(value: boolean) {
               {{ t('preferences.language.hint') }}
             </p>
           </div>
-          <PanelSelect
+          <PanelSegmented
             :model-value="localeStore.locale"
             :options="localeOptions"
             @update:model-value="localeStore.setLocale($event as typeof localeStore.locale)"

--- a/apps/web/src/components/shared/panel-dialog/PanelSegmented.vue
+++ b/apps/web/src/components/shared/panel-dialog/PanelSegmented.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  modelValue: string
+  options: readonly { value: string, label: string }[]
+  class?: HTMLAttributes[`class`]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+function select(value: string) {
+  if (value === props.modelValue)
+    return
+  emit(`update:modelValue`, value)
+}
+</script>
+
+<template>
+  <div
+    role="radiogroup"
+    :class="cn(
+      'inline-flex h-10 shrink-0 items-center rounded-md bg-muted p-1 text-muted-foreground',
+      props.class,
+    )"
+  >
+    <button
+      v-for="option in options"
+      :key="option.value"
+      type="button"
+      role="radio"
+      :aria-checked="modelValue === option.value"
+      class="inline-flex h-full items-center justify-center whitespace-nowrap rounded-sm px-3 text-sm font-medium transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+      :class="modelValue === option.value
+        ? 'bg-background text-foreground shadow-xs'
+        : 'hover:text-foreground'"
+      @click="select(option.value)"
+    >
+      {{ option.label }}
+    </button>
+  </div>
+</template>

--- a/apps/web/src/components/shared/panel-dialog/PanelSegmented.vue
+++ b/apps/web/src/components/shared/panel-dialog/PanelSegmented.vue
@@ -12,27 +12,84 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
 }>()
 
+const rootRef = ref<HTMLElement | null>(null)
+
+const activeValue = computed(() =>
+  props.options.some(option => option.value === props.modelValue)
+    ? props.modelValue
+    : props.options[0]?.value,
+)
+
 function select(value: string) {
   if (value === props.modelValue)
     return
   emit(`update:modelValue`, value)
 }
+
+function focusOption(value: string) {
+  const button = rootRef.value?.querySelector<HTMLButtonElement>(
+    `button[data-value="${CSS.escape(value)}"]`,
+  )
+  button?.focus()
+}
+
+function onKeydown(event: KeyboardEvent) {
+  const { key } = event
+  if (
+    key !== `ArrowLeft`
+    && key !== `ArrowRight`
+    && key !== `ArrowUp`
+    && key !== `ArrowDown`
+    && key !== `Home`
+    && key !== `End`
+  ) {
+    return
+  }
+
+  const { options } = props
+  if (!options.length)
+    return
+
+  const currentIndex = Math.max(0, options.findIndex(option => option.value === props.modelValue))
+  let nextIndex = currentIndex
+
+  if (key === `Home`)
+    nextIndex = 0
+  else if (key === `End`)
+    nextIndex = options.length - 1
+  else if (key === `ArrowRight` || key === `ArrowDown`)
+    nextIndex = (currentIndex + 1) % options.length
+  else
+    nextIndex = (currentIndex - 1 + options.length) % options.length
+
+  const next = options[nextIndex]
+  if (!next)
+    return
+
+  event.preventDefault()
+  select(next.value)
+  nextTick(() => focusOption(next.value))
+}
 </script>
 
 <template>
   <div
+    ref="rootRef"
     role="radiogroup"
     :class="cn(
       'inline-flex h-10 shrink-0 items-center rounded-md bg-muted p-1 text-muted-foreground',
       props.class,
     )"
+    @keydown="onKeydown"
   >
     <button
       v-for="option in options"
       :key="option.value"
       type="button"
       role="radio"
+      :data-value="option.value"
       :aria-checked="modelValue === option.value"
+      :tabindex="activeValue === option.value ? 0 : -1"
       class="inline-flex h-full items-center justify-center whitespace-nowrap rounded-sm px-3 text-sm font-medium transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
       :class="modelValue === option.value
         ? 'bg-background text-foreground shadow-xs'

--- a/apps/web/src/composables/useCommandPalette.ts
+++ b/apps/web/src/composables/useCommandPalette.ts
@@ -6,6 +6,7 @@ import { isAccountUiEnabled } from '@/services/account/config'
 import { isShareUiEnabled } from '@/services/share/client'
 import { isSyncUiEnabled } from '@/services/sync/client'
 import { useEditorStore } from '@/stores/editor'
+import { useLocaleStore } from '@/stores/locale'
 import { useUIStore } from '@/stores/ui'
 
 export interface PaletteCommand {
@@ -20,6 +21,7 @@ export interface PaletteCommand {
 export function useCommandPalette() {
   const uiStore = useUIStore()
   const editorStore = useEditorStore()
+  const localeStore = useLocaleStore()
   const { formatContent } = useEditorDocumentActions()
 
   function withEditor(run: (view: EditorView) => void | Promise<void>) {
@@ -86,6 +88,13 @@ export function useCommandPalette() {
         group: t(`commandPalette.group.view`),
         keywords: [`深色`, `浅色`, `主题`, `dark`, `light`, `theme`],
         action: () => { uiStore.toggleDark() },
+      },
+      {
+        id: `toggle-language`,
+        label: t(`commandPalette.toggleLanguage`),
+        group: t(`commandPalette.group.settings`),
+        keywords: [`语言`, `中文`, `英文`, `language`, `locale`, `english`, `chinese`],
+        action: () => { localeStore.cycleLocale() },
       },
       {
         id: `toggle-style-panel`,

--- a/apps/web/src/i18n/constants.ts
+++ b/apps/web/src/i18n/constants.ts
@@ -7,6 +7,16 @@ export const DEFAULT_LOCALE: AppLocale = `zh-CN`
 export const SUPPORTED_LOCALES: AppLocale[] = [`zh-CN`, `en-US`]
 
 export const LOCALE_OPTIONS: LocaleOption[] = [
-  { value: `zh-CN`, labelKey: `locale.zhCN` },
-  { value: `en-US`, labelKey: `locale.enUS` },
+  { value: `zh-CN`, labelKey: `locale.zhCN`, shortLabel: `中` },
+  { value: `en-US`, labelKey: `locale.enUS`, shortLabel: `EN` },
 ]
+
+export function getNextLocale(current: AppLocale): AppLocale {
+  const index = SUPPORTED_LOCALES.indexOf(current)
+  const nextIndex = index < 0 ? 0 : (index + 1) % SUPPORTED_LOCALES.length
+  return SUPPORTED_LOCALES[nextIndex]!
+}
+
+export function getLocaleOption(locale: AppLocale): LocaleOption {
+  return LOCALE_OPTIONS.find(option => option.value === locale) ?? LOCALE_OPTIONS[0]!
+}

--- a/apps/web/src/i18n/messages/en-US/chrome.ts
+++ b/apps/web/src/i18n/messages/en-US/chrome.ts
@@ -26,6 +26,8 @@ export default {
     enableScrollSync: `Enable scroll sync`,
     lastModified: `Last modified`,
     toggleDarkMode: `Toggle dark mode`,
+    toggleLanguage: `Toggle language`,
+    switchToLanguage: `Switch to {language}`,
   },
   rightSlider: {
     title: `Styles`,
@@ -78,6 +80,7 @@ export default {
       settings: `Settings`,
     },
     openPreferences: `Open preferences`,
+    toggleLanguage: `Toggle language`,
     viewEdit: `View: Edit`,
     viewSplit: `View: Split`,
     viewPreview: `View: Preview`,

--- a/apps/web/src/i18n/messages/zh-CN/chrome.ts
+++ b/apps/web/src/i18n/messages/zh-CN/chrome.ts
@@ -26,6 +26,8 @@ export default {
     enableScrollSync: `开启同步滚动`,
     lastModified: `上次修改时间`,
     toggleDarkMode: `切换深色模式`,
+    toggleLanguage: `切换语言`,
+    switchToLanguage: `切换为 {language}`,
   },
   rightSlider: {
     title: `样式`,
@@ -78,6 +80,7 @@ export default {
       settings: `设置`,
     },
     openPreferences: `打开偏好设置`,
+    toggleLanguage: `切换语言`,
     viewEdit: `视图：编辑`,
     viewSplit: `视图：双屏`,
     viewPreview: `视图：预览`,

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -3,4 +3,5 @@ export type AppLocale = `zh-CN` | `en-US`
 export interface LocaleOption {
   value: AppLocale
   labelKey: `locale.zhCN` | `locale.enUS`
+  shortLabel: string
 }

--- a/apps/web/src/stores/locale.ts
+++ b/apps/web/src/stores/locale.ts
@@ -1,5 +1,5 @@
 import type { AppLocale } from '@/i18n/types'
-import { LOCALE_STORAGE_KEY } from '@/i18n/constants'
+import { getNextLocale, LOCALE_STORAGE_KEY } from '@/i18n/constants'
 import { detectInitialLocale } from '@/i18n/detect'
 import { getAppI18n } from '@/i18n/index'
 import enUS from '@/i18n/messages/en-US'
@@ -57,8 +57,14 @@ export const useLocaleStore = defineStore(`locale`, () => {
     locale.value = value
   }
 
+  /** 按 SUPPORTED_LOCALES 顺序循环切换到下一语言 */
+  function cycleLocale() {
+    locale.value = getNextLocale(locale.value)
+  }
+
   return {
     locale,
     setLocale,
+    cycleLocale,
   }
 })


### PR DESCRIPTION
﻿## Summary
- Replace the preferences language dropdown with a one-click segmented control
- Add footer and command-palette shortcuts to cycle locales via `SUPPORTED_LOCALES`
- Keep panel styling consistent with existing Tabs / panel-dialog controls

## Type of Change
- [x] 新功能（New feature）
- [ ] Bug 修复（Bug fix）
- [ ] 破坏性变更（Breaking change）
- [ ] 代码重构（Refactor）
- [ ] 样式调整（Cosmetic）
- [ ] 文档更新（Documentation）
- [ ] 工作流（Workflow / CI）

## Test Procedure
- [x] Open Preferences → General and switch language with the segmented control
- [x] Click the footer `中` / `EN` button and confirm locale cycles and UI updates
- [x] Use command palette (`切换语言` / `language`) to cycle locale
- [x] Confirm dark-mode footer control and preferences layout still look consistent

## Pre-flight Checklist
- [x] Self-reviewed the diff
- [x] No secrets committed
- [x] Follows Conventional Commits
- [ ] Docs updated (N/A — no public API/docs change)
