### PR TITLE
chore: unify code comments to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Web 主应用与部分浏览器扩展 UI 支持 **zh-CN**、**zh-TW**、**en-US*
 - **Prettier:** 固定版本 `2.8.8`（通过 `pnpm-workspace.yaml` 的 `overrides` 强制）
 - **Pre-commit 钩子:** `lint-staged` 对所有文件执行 `eslint --fix`
 - 规则：不使用分号，关闭 `no-unused-vars`、`no-console`、`no-debugger`
+- **代码注释：** 统一英文。保留非显而易见的 why / 约束 / 兼容性说明；删除复述下一行代码的噪音注释。勿改动 `i18n/messages` 等用户可见文案。
 
 ## 依赖管理
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ pnpm web dev
 - 遵循项目自带的 **ESLint**、**Prettier** 与 **Stylelint** 配置。
 - 所有提交必须通过 `pnpm run lint` 检查，无警告、无错误。
 - 推荐在 IDE 中启用 **ESLint** 与 **Prettier** 自动修复。
+- **代码注释统一使用英文。** 只写非显而易见的 why / 约束 / 坑；删除复述代码的噪音注释。用户可见文案（i18n）不受此限制。
 
 ## 提交规范
 

--- a/apps/api/src/afdian.ts
+++ b/apps/api/src/afdian.ts
@@ -72,11 +72,11 @@ export function isAfdianConfigured(env: Env): boolean {
   return Boolean(env.AFDIAN_USER_ID && env.AFDIAN_API_TOKEN)
 }
 
-/** 是否为可开通 Pro 的赞助方案订单（product_type=0 为常规方案） */
+/** Whether the order is eligible for Pro (product_type=0 is a regular plan). */
 export function isProEligibleOrder(env: Env, order: AfdianOrder): boolean {
   if (order.status !== 2)
     return false
-  // 售卖商品（一次性）也允许开通，按 month 字段折算天数
+  // One-time product purchases are also allowed; duration is derived from the month field
   if (order.product_type !== 0 && order.product_type !== 1)
     return false
 

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -9,7 +9,7 @@ import { getEffectivePlan } from './plan'
 
 const STATE_COOKIE = `md_oauth_state`
 const REDIRECT_COOKIE = `md_oauth_redirect`
-const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30 // 30 天
+const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30 // 30 days
 
 function callbackUrl(c: Context): string {
   const url = new URL(c.req.url)
@@ -21,7 +21,7 @@ export async function issueToken(env: Env, payload: { sub: string, login: string
   return sign({ ...payload, exp }, env.JWT_SECRET, `HS256`)
 }
 
-/** 鉴权中间件：校验 Bearer JWT，并把用户 id 写入 context */
+/** Auth middleware: validate Bearer JWT and set user id on context. */
 export const authMiddleware: MiddlewareHandler<{ Bindings: Env, Variables: { userId: string } }> = async (c, next) => {
   const header = c.req.header(`Authorization`) ?? ``
   const token = header.startsWith(`Bearer `) ? header.slice(7) : ``
@@ -42,7 +42,7 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env, Variables: { use
 
 export const authRoutes = new Hono<{ Bindings: Env }>()
 
-// 第一步：跳转到 GitHub 授权页
+// Step 1: redirect to GitHub authorization
 authRoutes.get(`/github`, (c) => {
   const state = crypto.randomUUID()
   const isHttps = new URL(c.req.url).protocol === `https:`
@@ -56,7 +56,7 @@ authRoutes.get(`/github`, (c) => {
 
   setCookie(c, STATE_COOKIE, state, cookieOpts)
 
-  // 记录发起登录的前端来源（校验后），授权完成后跳回它
+  // Remember the validated frontend origin; redirect back after authorization
   const redirect = resolveRedirect(c.env, c.req.query(`redirect`))
   setCookie(c, REDIRECT_COOKIE, redirect, cookieOpts)
 
@@ -68,7 +68,7 @@ authRoutes.get(`/github`, (c) => {
   return c.redirect(authorize.toString())
 })
 
-// 第二步：GitHub 回调，换取 token 并签发自有 JWT，回跳前端
+// Step 2: GitHub callback — exchange code, issue JWT, redirect to frontend
 authRoutes.get(`/github/callback`, async (c) => {
   const code = c.req.query(`code`)
   const state = c.req.query(`state`)
@@ -80,7 +80,6 @@ authRoutes.get(`/github/callback`, async (c) => {
   if (!code || !state || state !== savedState)
     return c.json({ error: `invalid_oauth_state` }, 400)
 
-  // 用 code 换 access_token
   const tokenRes = await fetch(`https://github.com/login/oauth/access_token`, {
     method: `POST`,
     headers: { 'Accept': `application/json`, 'Content-Type': `application/json` },
@@ -96,7 +95,7 @@ authRoutes.get(`/github/callback`, async (c) => {
   if (!accessToken)
     return c.json({ error: `oauth_exchange_failed` }, 400)
 
-  // 拉取用户信息（GitHub 要求 User-Agent）
+  // GitHub API requires a User-Agent header
   const userRes = await fetch(`https://api.github.com/user`, {
     headers: {
       'Authorization': `Bearer ${accessToken}`,
@@ -109,7 +108,6 @@ authRoutes.get(`/github/callback`, async (c) => {
 
   const gh = await userRes.json<{ id: number, login: string, name: string | null, avatar_url: string | null }>()
 
-  // upsert 用户
   const existing = await c.env.DB
     .prepare(`SELECT id FROM users WHERE github_id = ?`)
     .bind(gh.id)
@@ -126,14 +124,13 @@ authRoutes.get(`/github/callback`, async (c) => {
 
   const token = await issueToken(c.env, { sub: userId, login: gh.login })
 
-  // 回跳到发起登录的前端来源（再次校验），token 放在 fragment，避免进入服务端日志
+  // Redirect to the validated frontend origin; token in URL fragment avoids server logs
   const target = resolveRedirect(c.env, savedRedirect)
   const redirect = new URL(target || defaultOrigin(c.env))
   redirect.hash = `account_token=${token}`
   return c.redirect(redirect.toString())
 })
 
-// 当前用户信息
 export async function meHandler(c: Context<{ Bindings: Env, Variables: { userId: string } }>) {
   const user = await getUserById(c.env.DB, c.get(`userId`))
   if (!user)

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -40,8 +40,8 @@ function rowToDocument(row: DocumentRow): SyncDocument {
 }
 
 function rowToSetting(row: SettingRow): SyncSetting {
-  // 与前端契约一致：value 仅可能是 string | null。
-  // DB 存的是 JSON.stringify 后的字符串，非字符串结果（异常数据）一律回退。
+  // Frontend contract: value is string | null only.
+  // DB stores JSON.stringify output; non-string parse results fall back to null.
   let value: string | null = null
   try {
     const parsed = JSON.parse(row.value)
@@ -77,7 +77,7 @@ export async function getUserById(db: D1Database, id: string): Promise<UserRow |
   return db.prepare(`SELECT * FROM users WHERE id = ?`).bind(id).first<UserRow>()
 }
 
-/** 拉取 cursor 之后变更的文档与设置 */
+/** Fetch documents and settings changed after cursor. */
 export async function pullChanges(
   env: Env,
   userId: string,
@@ -116,8 +116,8 @@ export async function pullChanges(
 }
 
 /**
- * 推入客户端变更，按 update_datetime 做 last-write-wins。
- * 返回服务端最终更新过（即客户端较新）的记录，以及新游标。
+ * Push client changes with last-write-wins on update_datetime.
+ * Returns records accepted by the server and the new cursor.
  */
 export async function pushChanges(
   env: Env,
@@ -133,7 +133,7 @@ export async function pushChanges(
       .bind(userId, doc.id)
       .first<{ update_datetime: number }>()
 
-    // LWW：仅当客户端版本更新（或不存在）时写入
+    // LWW: write only when the client version is newer (or the row does not exist)
     if (existing && existing.update_datetime >= doc.updateDatetime)
       continue
 
@@ -188,8 +188,8 @@ export async function pushChanges(
       .run()
   }
 
-  // 返回本次写入（被接受）的记录，并以服务端时钟作为新游标。
-  // 客户端约定先 pull 再 push，因此服务端较新的记录已在 pull 阶段下发。
+  // Return accepted records with server clock as the new cursor.
+  // Clients pull before push, so server-newer records were already sent during pull.
   const accepted = await pullChanges(env, userId, now - 1)
   return { documents: accepted.documents, settings: accepted.settings, maxCursor: now }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,7 +12,7 @@ import { afdianWebhookHandler } from './webhook'
 
 const app = new Hono<{ Bindings: Env, Variables: { userId: string } }>()
 
-// CORS：允许 APP_URL 中配置的来源（支持通配符，逗号分隔）携带凭据访问
+// CORS: allow credentialed requests from origins listed in APP_URL (comma-separated, wildcards supported)
 app.use(`*`, async (c, next) => {
   const handler = cors({
     origin: origin => (isAllowedOrigin(c.env, origin) || isBrowserExtensionOrigin(origin) ? origin : null),
@@ -26,18 +26,18 @@ app.use(`*`, async (c, next) => {
 
 app.get(`/`, c => c.json({ name: `md-api`, ok: true }))
 
-// 默认图床上传（公开，由 UPLOAD_ENABLED 控制）
+// Default image upload (public; gated by UPLOAD_ENABLED)
 app.post(`/upload`, uploadHandler)
 
 app.get(SHARE_FAVICON_PATH, c => c.env.ASSETS.fetch(c.req.raw))
 
 app.route(`/auth`, authRoutes)
-// 爱发电 Webhook：无密钥与带路径密钥两种形式共用同一处理器。
-// 设置 AFDIAN_WEBHOOK_TOKEN 后，仅 `/webhooks/afdian/<token>` 可通过校验。
+// Afdian webhook: unauthenticated and path-token routes share one handler.
+// When AFDIAN_WEBHOOK_TOKEN is set, only /webhooks/afdian/<token> passes validation.
 app.post(`/webhooks/afdian`, afdianWebhookHandler)
 app.post(`/webhooks/afdian/:token`, afdianWebhookHandler)
 
-// 公开分享：只读 HTML 预览页 + 密码解锁
+// Public shares: read-only HTML preview + password unlock
 app.get(`/s/:shareId`, viewShareHandler)
 app.post(`/s/:shareId/unlock`, unlockShareHandler)
 

--- a/apps/api/src/origin.ts
+++ b/apps/api/src/origin.ts
@@ -4,7 +4,7 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
 }
 
-/** 浏览器扩展页面发起的 fetch 会携带 chrome-extension:// / moz-extension:// 来源 */
+/** Browser extension pages send fetch requests with chrome-extension:// / moz-extension:// origins */
 const EXTENSION_ORIGIN_RE = /^(?:chrome-extension|moz-extension|safari-web-extension):\/\/[^/]+$/i
 
 export function isBrowserExtensionOrigin(origin: string | undefined | null): boolean {
@@ -14,10 +14,10 @@ export function isBrowserExtensionOrigin(origin: string | undefined | null): boo
 }
 
 /**
- * 判断 origin 是否匹配某个模式。
- * - 精确匹配：完全相等
- * - 通配符 `*`：匹配单个主机标签（不含 `.` 与 `/`），可安全用于
- *   预览子域名（如 `https://*--doocs-md.netlify.app`、`http://localhost:*`）
+ * Whether an origin matches a pattern.
+ * - Exact match: strings are equal
+ * - Wildcard `*`: matches a single host label (no `.` or `/`), safe for
+ *   preview subdomains (e.g. `https://*--doocs-md.netlify.app`, `http://localhost:*`)
  */
 export function matchPattern(origin: string, pattern: string): boolean {
   if (!pattern)
@@ -30,28 +30,28 @@ export function matchPattern(origin: string, pattern: string): boolean {
   return re.test(origin)
 }
 
-/** 解析 APP_URL（逗号分隔）为模式列表 */
+/** Parse APP_URL (comma-separated) into pattern list */
 export function allowedPatterns(env: Env): string[] {
   return env.APP_URL.split(`,`).map(s => s.trim()).filter(Boolean)
 }
 
-/** origin 是否在白名单内 */
+/** Whether origin is on the allowlist */
 export function isAllowedOrigin(env: Env, origin: string | undefined | null): boolean {
   if (!origin)
     return false
   return allowedPatterns(env).some(p => matchPattern(origin, p))
 }
 
-/** 默认回跳地址：取第一个不含通配符的模式，否则取第一个 */
+/** Default redirect origin: first pattern without wildcards, else the first pattern */
 export function defaultOrigin(env: Env): string {
   const patterns = allowedPatterns(env)
   return patterns.find(p => !p.includes(`*`)) ?? patterns[0] ?? ``
 }
 
 /**
- * 校验请求的回跳地址：解析其 origin 是否在白名单内，
- * 合法则返回完整 URL（含 path），否则回退到默认地址。
- * 兼容仅传 origin 的旧形式。
+ * Validate a requested redirect URL: if its origin is allowlisted,
+ * return the full URL (including path); otherwise fall back to the default origin.
+ * Also accepts legacy values that pass only an origin.
  */
 export function resolveRedirect(env: Env, requested: string | undefined | null): string {
   if (requested) {
@@ -60,7 +60,7 @@ export function resolveRedirect(env: Env, requested: string | undefined | null):
       if (isAllowedOrigin(env, url.origin))
         return url.toString()
     }
-    catch { /* 非法 URL，回退默认 */ }
+    catch { /* invalid URL — fall back to default */ }
   }
   return defaultOrigin(env)
 }

--- a/apps/api/src/plan.ts
+++ b/apps/api/src/plan.ts
@@ -11,7 +11,7 @@ export const SYNC_RATE_LIMIT = {
   pro: 300,
 } as const
 
-/** 每天分享（新建或更新）次数上限；`pro: null` 表示不限 */
+/** Daily share create/update limit; `pro: null` means unlimited */
 export const SHARE_CREATE_LIMIT: Record<UserPlan, number | null> = {
   free: 2,
   pro: null,
@@ -26,12 +26,12 @@ export function parseGithubLoginFromRemark(remark: string): string | null {
   if (!trimmed)
     return null
 
-  // 支持纯用户名，或「github:用户名」形式
+  // Plain username or `github:username`
   const match = trimmed.match(/^(?:github\s*[:：]\s*)?([a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?)$/i)
   if (match)
     return normalizeGithubLogin(match[1])
 
-  // 备注中第一个像 GitHub 用户名的 token
+  // First token in the remark that looks like a GitHub username
   const token = trimmed.split(/[\s,，;；]+/).find(part => /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(part))
   return token ? normalizeGithubLogin(token) : null
 }

--- a/apps/api/src/share-head.ts
+++ b/apps/api/src/share-head.ts
@@ -1,4 +1,4 @@
-/** 分享页 favicon（静态文件见 public/images/） */
+/** Share page favicon (static file in public/images/) */
 export const SHARE_FAVICON_PATH = `/images/favicon-32x32.png`
 
 export function sharePageFaviconLink(): string {

--- a/apps/api/src/share-page.ts
+++ b/apps/api/src/share-page.ts
@@ -132,7 +132,7 @@ function ensureShareFooterStyles(html: string): string {
   return html.replace(`</style>`, `${SHARE_FOOTER_STYLES}\n  </style>`)
 }
 
-/** 将快照 HTML 中的 footer 占位符替换为分享者与阅读数（兼容旧版 footer） */
+/** Replace footer placeholders in snapshot HTML with author and view count (legacy footers supported) */
 export function injectShareFooter(
   html: string,
   author: ShareFooterAuthor,

--- a/apps/api/src/share-types.ts
+++ b/apps/api/src/share-types.ts
@@ -17,19 +17,19 @@ export interface ShareHtmlSnapshot {
 
 export type SharePasswordMode = `none` | `custom` | `auto`
 
-/** Pro 可选：1 天 / 7 天 / 30 天 / 永不过期；免费用户固定 1 天 */
+/** Pro: 1d / 7d / 30d / never; free users are fixed to 1 day */
 export type ShareExpiresMode = `1d` | `7d` | `30d` | `never`
 
 export interface CreateShareRequest {
-  /** 前端文章 id，同一用户同一篇文章重复分享时链接不变 */
+  /** Frontend post id; re-sharing the same post keeps the same link */
   postId: string
   title?: string
   htmlSnapshot: ShareHtmlSnapshot
-  /** 无密码 / 自定义密码 / 系统随机生成 */
+  /** No password / custom password / system-generated password */
   passwordMode?: SharePasswordMode
-  /** passwordMode=custom 时必填 */
+  /** Required when passwordMode=custom */
   password?: string
-  /** 链接有效期，Pro 用户可选；免费用户忽略并固定 1 天 */
+  /** Link expiry; Pro users may choose; free users are always capped at 1 day */
   expiresMode?: ShareExpiresMode
 }
 
@@ -37,11 +37,11 @@ export interface CreateShareResponse {
   id: string
   url: string
   expiresAt: number | null
-  /** true 表示更新了已有分享，false 表示首次创建 */
+  /** true if an existing share was updated; false if newly created */
   updated: boolean
-  /** 是否启用了访问密码 */
+  /** Whether access password protection is enabled */
   protected: boolean
-  /** 仅 passwordMode=auto 时返回系统生成的明文密码 */
+  /** Plaintext password returned only when passwordMode=auto */
   password?: string
 }
 

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -4,44 +4,44 @@ export interface Env {
   GITHUB_CLIENT_ID: string
   GITHUB_CLIENT_SECRET: string
   JWT_SECRET: string
-  /** 前端地址，用于 OAuth 回跳与 CORS 白名单，多个用英文逗号分隔 */
+  /** Frontend origin(s) for OAuth redirect and CORS allowlist; comma-separated */
   APP_URL: string
-  /** 爱发电创作者 user_id（开发者后台） */
+  /** Afdian creator user_id (developer dashboard) */
   AFDIAN_USER_ID?: string
-  /** 爱发电 API Token，通过 wrangler secret 注入 */
+  /** Afdian API token, injected via wrangler secret */
   AFDIAN_API_TOKEN?: string
-  /** 爱发电 API 基址，默认 https://afdian.com/api/open */
+  /** Afdian API base URL; default https://afdian.com/api/open */
   AFDIAN_API_BASE?: string
-  /** 可开通 Pro 的方案 plan_id，逗号分隔；留空则接受所有已付款方案 */
+  /** plan_id values eligible for Pro, comma-separated; empty accepts all paid plans */
   AFDIAN_PRO_PLAN_IDS?: string
   /**
-   * 爱发电 Webhook 路径密钥，通过 wrangler secret 注入。
-   * 配置后回调地址须为 `/webhooks/afdian/<token>`，缺失或不匹配则拒绝。
-   * 用于防止公开端点被任意调用 / 刷量（验单仍以爱发电 API 为准）。
+   * Afdian webhook path token, injected via wrangler secret.
+   * When set, callback URL must be `/webhooks/afdian/<token>`; missing or mismatched requests are rejected.
+   * Prevents arbitrary calls / abuse on the public endpoint (order verification still uses the Afdian API).
    */
   AFDIAN_WEBHOOK_TOKEN?: string
-  /** 是否开启图床上传 API（`true` / `1`） */
+  /** Enable image upload API (`true` / `1`) */
   UPLOAD_ENABLED?: string
-  /** 上传后端：`github`（默认）或 `r2` */
+  /** Upload backend: `github` (default) or `r2` */
   UPLOAD_BACKEND?: string
-  /** GitHub 图床用户名 */
+  /** GitHub image host username */
   UPLOAD_GITHUB_USERNAME?: string
-  /** GitHub 仓库列表，逗号分隔，如 `img0,img1`；留空则使用 img0–img19 */
+  /** GitHub repo list, comma-separated (e.g. `img0,img1`); empty uses img0–img19 */
   UPLOAD_GITHUB_REPO_LIST?: string
-  /** GitHub 分支，默认 `main` */
+  /** GitHub branch; default `main` */
   UPLOAD_GITHUB_BRANCH?: string
-  /** 是否将 GitHub 链接替换为 jsDelivr CDN，默认 true */
+  /** Replace GitHub URLs with jsDelivr CDN; default true */
   UPLOAD_GITHUB_USE_CDN?: string
-  /** GitHub PAT 列表，逗号分隔（wrangler secret） */
+  /** GitHub PAT list, comma-separated (wrangler secret) */
   UPLOAD_GITHUB_TOKENS_BUCKETIO?: string
-  /** R2 公开访问 URL 前缀，如 `https://images.example.com` */
+  /** R2 public URL prefix, e.g. `https://images.example.com` */
   UPLOAD_R2_PUBLIC_URL?: string
-  /** R2 图床 bucket 绑定（UPLOAD_BACKEND=r2 时需要） */
+  /** R2 image bucket binding (required when UPLOAD_BACKEND=r2) */
   UPLOAD_IMAGES?: R2Bucket
 }
 
 export interface JwtPayload {
-  sub: string // 内部 user id
+  sub: string // internal user id
   login: string
   exp: number
 }
@@ -57,7 +57,7 @@ export interface UserRow {
   plan_expires_at: number | null
 }
 
-/** 同步用文档（前后端共享契约），时间字段统一为 epoch ms */
+/** Sync document (shared frontend/backend contract); timestamps are epoch ms */
 export interface SyncDocument {
   id: string
   title: string
@@ -69,7 +69,7 @@ export interface SyncDocument {
   deleted: boolean
 }
 
-/** 同步用设置项（前后端共享契约，value 为 localStorage 原始字符串） */
+/** Sync setting (shared frontend/backend contract); value is the raw localStorage string */
 export interface SyncSetting {
   key: string
   value: string | null
@@ -88,7 +88,7 @@ export interface PushRequest {
 }
 
 export interface PushResponse {
-  /** 服务端合并后较新的文档（客户端需用其覆盖本地） */
+  /** Documents newer on the server after merge (client should overwrite local copies) */
   documents: SyncDocument[]
   settings: SyncSetting[]
   cursor: number

--- a/apps/api/src/webhook.ts
+++ b/apps/api/src/webhook.ts
@@ -15,15 +15,15 @@ interface WebhookBody {
 type WebhookContext = Context<{ Bindings: Env }>
 
 /**
- * 爱发电订单 Webhook。
+ * Afdian order webhook.
  *
- * 安全要点（本服务代码公开托管，回调地址与逻辑均可被获知）：
- * 1. 可选路径密钥 `AFDIAN_WEBHOOK_TOKEN`，防止公开端点被任意调用 / 刷量。
- * 2. **绝不信任回调 body 中的订单内容**：仅取 `out_trade_no`，再用爱发电
- *    Open API 反查真实订单，以服务端返回为准。这样伪造回调无法开通 Pro。
+ * Security (this service is publicly hosted; callback URL and logic are discoverable):
+ * 1. Optional path token `AFDIAN_WEBHOOK_TOKEN` to block arbitrary calls / abuse.
+ * 2. **Never trust order fields in the callback body**: read only `out_trade_no`, then
+ *    re-fetch the order via the Afdian Open API and treat that response as authoritative.
+ *    Forged callbacks cannot grant Pro.
  */
 export async function afdianWebhookHandler(c: WebhookContext) {
-  // 1. 可选共享密钥校验（通过 URL 路径段传入，配置在爱发电后台的回调地址中）
   const expectedToken = c.env.AFDIAN_WEBHOOK_TOKEN
   if (expectedToken) {
     const token = c.req.param(`token`)
@@ -31,7 +31,7 @@ export async function afdianWebhookHandler(c: WebhookContext) {
       return c.json({ ec: 403, em: `forbidden` }, 403)
   }
 
-  // 未配置爱发电 API 则无法验单，直接忽略（返回 200 避免平台重试）
+  // Cannot verify orders without Afdian API config; return 200 to avoid platform retries
   if (!isAfdianConfigured(c.env))
     return c.json({ ec: 200, em: `` })
 
@@ -50,14 +50,13 @@ export async function afdianWebhookHandler(c: WebhookContext) {
   if (!outTradeNo)
     return c.json({ ec: 200, em: `` })
 
-  // 2. 关键：以爱发电服务端查询结果为准，杜绝伪造回调
   const order = await queryOrder(c.env, outTradeNo)
   if (!order || order.status !== 2)
     return c.json({ ec: 200, em: `` })
 
   const githubLogin = parseGithubLoginFromRemark(order.remark ?? ``)
   if (!githubLogin) {
-    // 无备注无法自动绑定，仍返回 200 避免平台重试
+    // No GitHub login in remark; return 200 to avoid platform retries
     return c.json({ ec: 200, em: `` })
   }
 

--- a/apps/utools/preload.js
+++ b/apps/utools/preload.js
@@ -2,13 +2,12 @@
   if (typeof window === `undefined`)
     return
 
-  // 标识当前环境为 uTools
   window.__MD_UTOOLS__ = true
 
   /**
-   * 安全调用 uTools API 方法
-   * @param {string} method - 方法名
-   * @param {...any} args - 方法参数
+   * Safely invoke a uTools API method.
+   * @param {string} method - Method name
+   * @param {...any} args - Method arguments
    */
   const safeCall = (method, ...args) => {
     try {
@@ -22,31 +21,28 @@
   }
 
   /**
-   * 插件进入回调
-   * @param {object} action - 插件动作参数
+   * Plugin enter callback.
+   * @param {object} action - Plugin action payload
    */
   const enter = (action) => {
-    // 配置 uTools 窗口行为
+    // Configure uTools window behavior
     safeCall(`hideMainWindowWhenBlur`, false)
     safeCall(`showMainWindow`)
     safeCall(`setExpendHeight`, 680)
 
-    // 通知前端应用
     window.postMessage({ type: `utools:enter`, payload: action }, `*`)
   }
 
   /**
-   * 插件退出回调
+   * Plugin leave callback.
    */
   const leave = () => {
     window.postMessage({ type: `utools:leave` }, `*`)
   }
 
-  // 注册生命周期回调
   safeCall(`onPluginEnter`, enter)
   safeCall(`onPluginOut`, leave)
 
-  // 导出插件配置
   window.exports = {
     'wechat-md': {
       mode: `none`,

--- a/apps/web/plugins/vite-plugin-utools-local-assets.ts
+++ b/apps/web/plugins/vite-plugin-utools-local-assets.ts
@@ -18,7 +18,7 @@ async function downloadMathJaxTexSvg(targetDir: string) {
 }
 
 /**
- * Vite 插件：在 uTools 构建时将 MathJax 从 doocs CDN 下载为本地资源
+ * Vite plugin: download MathJax from doocs CDN as a local asset for uTools builds.
  */
 export function utoolsLocalAssetsPlugin(): Plugin {
   const isUTools = process.env.SERVER_ENV === `UTOOLS`

--- a/apps/web/src/assets/less/codemirror-global.less
+++ b/apps/web/src/assets/less/codemirror-global.less
@@ -1,4 +1,3 @@
-/* CSS-hints */
 .CodeMirror-hints {
   position: absolute;
   z-index: 10;
@@ -33,9 +32,9 @@
 }
 
 .search-match {
-  background-color: #ffeb3b; /* 所有匹配项颜色 */
+  background-color: #ffeb3b; /* All match highlights*/
 }
 
 .current-match {
-  background-color: #ff5722; /* 当前匹配项更鲜艳的颜色 */
+  background-color: #ff5722; /* Current match highlight*/
 }

--- a/apps/web/src/assets/less/global.less
+++ b/apps/web/src/assets/less/global.less
@@ -12,7 +12,7 @@ body {
   overflow: hidden;
 }
 
-// 抵消下拉菜单开启时带来的样式
+// Undo pointer-events override from open dropdown menus
 body {
   pointer-events: initial !important;
 }
@@ -37,18 +37,16 @@ body {
   background-color: #424242;
 }
 
-// Utools 模式下隐藏所有滚动条
+// Hide scrollbars in uTools mode
 .is-utools {
   ::-webkit-scrollbar {
     display: none;
   }
 
-  // Firefox
   * {
     scrollbar-width: none;
   }
 
-  // IE and Edge
   * {
     -ms-overflow-style: none;
   }

--- a/apps/web/src/assets/less/theme.less
+++ b/apps/web/src/assets/less/theme.less
@@ -8,7 +8,7 @@
 
 .dark {
   .container {
-    // CodeMirror v6 兼容
+    // CodeMirror v6 compatibility
     .cm-editor,
     .CodeMirror-wrap {
       background-color: @nightCodeMirrorColor;
@@ -36,7 +36,7 @@
   }
 }
 
-// CodeMirror v5 兼容样式
+// CodeMirror v5 compatibility styles
 .CodeMirror {
   padding-bottom: 0;
   height: 100% !important;
@@ -59,7 +59,7 @@
   box-sizing: border-box;
 }
 
-// CodeMirror v6 样式
+// CodeMirror v6 styles
 .cm-editor {
   height: 100% !important;
   font-size: 16px;
@@ -69,9 +69,9 @@
     overflow-x: auto !important;
     overflow-y: auto !important;
 
-    // 只隐藏 x 方向的滚动条
+    // Hide horizontal scrollbar only
     &::-webkit-scrollbar:horizontal {
-      display: none; /* Chrome/Safari/Webkit - 横向滚动条 */
+      display: none;
     }
   }
 
@@ -108,7 +108,7 @@
   font-style: normal !important;
 }
 
-// CodeMirror v6 折叠装订线样式
+// CodeMirror v6 fold gutter styles
 .cm-foldGutter {
   .cm-gutterElement {
     cursor: pointer;

--- a/apps/web/src/components/ai/SidebarAIToolbar.vue
+++ b/apps/web/src/components/ai/SidebarAIToolbar.vue
@@ -24,18 +24,15 @@ const { editor } = storeToRefs(editorStore)
 const { hasShownAIToolboxHint } = storeToRefs(uiStore)
 const { t } = useI18n()
 
-// 工具栏状态：false=默认(只显示贴边栏), true=展开(显示AI图标)
-const isExpanded = ref(false) // 默认收起状态
+// Toolbar: false = docked strip only, true = expanded with AI icons
+const isExpanded = ref(false)
 
-// AI 工具箱相关状态
 const toolBoxVisible = ref(false)
 
-// 是否显示选中文本提示动画
 const showSelectionHint = ref(false)
 let selectionHintTimer: NodeJS.Timeout | null = null
 let lastSelectedText = ``
 
-// 检查选中文本的函数
 function getSelectedText() {
   try {
     if (!editor.value)
@@ -48,33 +45,26 @@ function getSelectedText() {
   }
 }
 
-// 检查并更新选中文本提示
 function checkSelectionAndUpdateHint() {
-  // 如果已经显示过提示，就不再显示
   if (hasShownAIToolboxHint.value) {
     return
   }
 
   const selected = getSelectedText()
 
-  // 如果选中状态发生变化
   if (selected !== lastSelectedText) {
     lastSelectedText = selected
 
-    // 清除之前的定时器
     if (selectionHintTimer) {
       clearTimeout(selectionHintTimer)
       selectionHintTimer = null
     }
 
-    // 如果有选中文本且工具栏未展开
     if (selected && !isExpanded.value) {
       showSelectionHint.value = true
 
-      // 标记已经显示过提示
       hasShownAIToolboxHint.value = true
 
-      // 3秒后自动隐藏提示
       selectionHintTimer = setTimeout(() => {
         showSelectionHint.value = false
       }, SELECTION_HINT_TIMEOUT_MS)
@@ -85,23 +75,19 @@ function checkSelectionAndUpdateHint() {
   }
 }
 
-// 动态计算是否有选中文本
 const hasSelectedText = computed(() => {
   if (!editor.value || !isExpanded.value)
     return false
   return getSelectedText().length > 0
 })
 
-// 当打开工具箱时，获取当前选中的文本
 const currentSelectedText = computed(() => {
   return toolBoxVisible.value ? getSelectedText() : ``
 })
 
-// 切换展开/收起状态
 function toggleExpanded() {
   isExpanded.value = !isExpanded.value
 
-  // 展开后隐藏提示
   if (isExpanded.value) {
     showSelectionHint.value = false
     if (selectionHintTimer) {
@@ -111,31 +97,26 @@ function toggleExpanded() {
   }
 }
 
-// 打开AI助手
 function openAIChat() {
   toggleAIDialog(true)
 }
 
-// 打开AI文生图
 function openAIImageGenerator() {
   toggleAIImageDialog(true)
 }
 
-// 打开AI工具箱
 function openAIToolBox() {
   toolBoxVisible.value = true
 }
 
-// 监听编辑区点击，自动收起工具栏
 onMounted(() => {
-  // 使用 selectionchange 事件替代轮询，检测选中文本变化
+  // Use selectionchange instead of polling to detect selection changes
   const handleSelectionChange = () => {
     checkSelectionAndUpdateHint()
   }
   document.addEventListener(`selectionchange`, handleSelectionChange)
 
   const handleInteraction = (e: Event) => {
-    // 只有在展开状态才需要处理
     if (!isExpanded.value)
       return
 
@@ -145,11 +126,10 @@ onMounted(() => {
 
     const toolbar = document.querySelector(`.editor-ai-toolbar`)
 
-    // 如果点击的是工具栏及其子元素，不处理
     if (toolbar && toolbar.contains(target))
       return
 
-    // 排除不应该收起的区域
+    // Regions that should not collapse the toolbar
     const excludeSelectors = [
       `dialog`,
       `.popover`,
@@ -171,7 +151,6 @@ onMounted(() => {
     }
   }
 
-  // 同时监听点击和触摸事件，覆盖桌面端和移动端
   document.addEventListener(`click`, handleInteraction, true)
   document.addEventListener(`touchstart`, handleInteraction, true)
 
@@ -180,7 +159,6 @@ onMounted(() => {
     document.removeEventListener(`touchstart`, handleInteraction, true)
     document.removeEventListener(`selectionchange`, handleSelectionChange)
 
-    // 清理定时器
     if (selectionHintTimer) {
       clearTimeout(selectionHintTimer)
       selectionHintTimer = null
@@ -190,14 +168,12 @@ onMounted(() => {
 </script>
 
 <template>
-  <!-- 编辑区内侧AI工具栏 -->
-  <!-- @mousedown.prevent 防止点击工具栏时编辑器失去焦点，从而保持选区高亮 -->
+  <!-- @mousedown.prevent keeps editor focus and selection highlight -->
   <div
     v-if="(!isMobile || (isMobile && showEditor))"
     class="editor-ai-toolbar absolute top-1/2 -translate-y-1/2 right-0 z-30 transition-all duration-300 ease-out"
     @mousedown.prevent
   >
-    <!-- 默认状态：贴边栏 -->
     <div
       v-if="!isExpanded"
       class="w-5 h-16 bg-gradient-to-b from-blue-500/90 to-purple-500/90 hover:from-blue-600/95 hover:to-purple-600/95 dark:from-blue-400/90 dark:to-purple-400/90 dark:hover:from-blue-500/95 dark:hover:to-purple-500/95 backdrop-blur-lg border-l border-y border-blue-300/50 dark:border-blue-600/50 cursor-pointer transition-all duration-200 flex items-center justify-center rounded-l-lg shadow-lg group utools-sidebar-edge"
@@ -207,7 +183,6 @@ onMounted(() => {
     >
       <Settings2 class="h-4 w-4 text-white drop-shadow-sm group-hover:scale-110 transition-transform duration-200" />
 
-      <!-- 选中文本提示气泡 -->
       <Transition name="hint-fade">
         <div
           v-if="showSelectionHint"
@@ -217,22 +192,18 @@ onMounted(() => {
           <div class="relative flex items-center gap-2">
             <Wand2 class="h-4 w-4" />
             <span>{{ t('ai.toolbar.openToolboxHint') }}</span>
-            <!-- 箭头 -->
             <div class="hint-arrow absolute top-1/2 -right-2 -translate-y-1/2 w-0 h-0 border-t-[6px] border-b-[6px] border-l-[6px] border-transparent border-l-purple-500" />
           </div>
         </div>
       </Transition>
     </div>
 
-    <!-- 展开状态：显示AI图标 -->
     <div
       v-else
       class="bg-white/95 dark:bg-gray-900/95 backdrop-blur-lg border-l border-gray-200/50 dark:border-gray-700/50 shadow-lg overflow-hidden transition-all duration-300 w-12 rounded-l-md"
       :style="{ height: 'auto' }"
     >
-      <!-- 展开状态的AI按钮 -->
       <div class="flex flex-col py-2 gap-2">
-        <!-- AI助手按钮 -->
         <div class="flex flex-col items-center gap-1 px-1">
           <button
             class="group relative w-7 h-7 rounded-lg bg-gradient-to-br from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 transition-all duration-200 flex items-center justify-center utools-ai-button"
@@ -242,18 +213,15 @@ onMounted(() => {
             <Bot class="h-4 w-4" />
           </button>
 
-          <!-- 标签 -->
           <span class="text-[9px] text-gray-500 dark:text-gray-400 font-medium text-center leading-tight">
             {{ t('ai.toolbar.assistantLabel') }}
           </span>
         </div>
 
-        <!-- 分割线 -->
         <div class="mx-1.5">
           <div class="h-px bg-gray-200/50 dark:bg-gray-700/50" />
         </div>
 
-        <!-- AI文生图按钮 -->
         <div class="flex flex-col items-center gap-1 px-1">
           <button
             class="group relative w-7 h-7 rounded-lg bg-gradient-to-br from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 transition-all duration-200 flex items-center justify-center utools-ai-button"
@@ -263,18 +231,15 @@ onMounted(() => {
             <ImageIcon class="h-4 w-4" />
           </button>
 
-          <!-- 标签 -->
           <span class="text-[9px] text-gray-500 dark:text-gray-400 font-medium text-center leading-tight">
             {{ t('ai.toolbar.imageGenLabel') }}
           </span>
         </div>
 
-        <!-- 分割线 -->
         <div v-if="hasSelectedText && isExpanded" class="mx-1.5">
           <div class="h-px bg-gray-200/50 dark:bg-gray-700/50" />
         </div>
 
-        <!-- AI工具箱按钮 (只有选中文本且展开时才显示) -->
         <div v-if="hasSelectedText && isExpanded" class="flex flex-col items-center gap-1 px-1">
           <button
             class="group relative w-7 h-7 rounded-lg bg-gradient-to-br from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 transition-all duration-200 flex items-center justify-center utools-ai-button"
@@ -284,7 +249,6 @@ onMounted(() => {
             <Wand2 class="h-4 w-4" />
           </button>
 
-          <!-- 标签 -->
           <span class="text-[9px] text-gray-500 dark:text-gray-400 font-medium text-center leading-tight">
             {{ t('ai.toolbar.toolboxLabel') }}
           </span>
@@ -292,11 +256,9 @@ onMounted(() => {
       </div>
     </div>
 
-    <!-- AI面板组件 -->
     <AIAssistantPanel v-if="aiDialogVisible" v-model:open="aiDialogVisible" />
     <AIImageGeneratorPanel v-if="aiImageDialogVisible" v-model:open="aiImageDialogVisible" />
 
-    <!-- AI工具箱弹窗 -->
     <AIPolishPopover
       v-model:open="toolBoxVisible"
       :selected-text="currentSelectedText"
@@ -306,7 +268,6 @@ onMounted(() => {
 </template>
 
 <style scoped>
-/* 确保工具栏与编辑器完美集成 */
 .editor-ai-toolbar {
   z-index: 30;
   contain: layout style;
@@ -314,18 +275,15 @@ onMounted(() => {
   max-width: calc(100% - 0.5rem);
 }
 
-/* 工具栏自适应高度 */
 .editor-ai-toolbar > div {
   height: auto;
   min-height: fit-content;
 }
 
-/* 确保按钮悬浮提示正确显示 */
 .editor-ai-toolbar .absolute {
   overflow: visible;
 }
 
-/* 选中文本时的脉冲动画 */
 @keyframes pulse-hint {
   0%,
   100% {
@@ -340,7 +298,6 @@ onMounted(() => {
   animation: pulse-hint 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-/* 提示气泡的轻微弹跳动画 */
 @keyframes bounce-gentle {
   0%,
   100% {
@@ -355,7 +312,6 @@ onMounted(() => {
   animation: bounce-gentle 1s ease-in-out infinite;
 }
 
-/* 提示气泡淡入淡出过渡 */
 .hint-fade-enter-active,
 .hint-fade-leave-active {
   transition: opacity 0.3s ease, transform 0.3s ease;
@@ -377,21 +333,18 @@ onMounted(() => {
   transform: translateX(0);
 }
 
-/* 响应式调整 */
 @media (max-width: 768px) {
   .editor-ai-toolbar {
     transform: translateY(-50%);
     transform-origin: right center;
   }
 
-  /* 移动端图标稍微再大一点 */
   .editor-ai-toolbar .lucide {
     width: 1.125rem !important; /* h-4.5 w-4.5 */
     height: 1.125rem !important;
   }
 }
 
-/* 提高可访问性 */
 @media (prefers-reduced-motion: reduce) {
   .transition-all,
   .transform {
@@ -408,7 +361,6 @@ onMounted(() => {
   }
 }
 
-/* 确保在小屏幕上不会遮挡内容 */
 @media (max-height: 500px) {
   .min-h-\[120px\] {
     min-height: 80px;
@@ -419,7 +371,6 @@ onMounted(() => {
   }
 }
 
-/* 毛玻璃效果优化 */
 @supports (backdrop-filter: blur(16px)) {
   .backdrop-blur-lg {
     backdrop-filter: blur(16px);
@@ -427,12 +378,10 @@ onMounted(() => {
   }
 }
 
-/* 确保渐变按钮在深色模式下显示正确 */
 .bg-gradient-to-br {
   background-attachment: fixed;
 }
 
-/* 悬浮提示样式优化 */
 .group:hover > div {
   animation: fadeIn 0.2s ease-out;
 }
@@ -448,7 +397,6 @@ onMounted(() => {
   }
 }
 
-/* uTools 插件模式下使用黑白风格 */
 .is-utools .utools-sidebar-edge {
   background: rgb(0 0 0 / 0.9) !important;
   border-color: rgb(0 0 0 / 0.5) !important;
@@ -471,7 +419,6 @@ onMounted(() => {
   color: rgb(0 0 0) !important;
 }
 
-/* uTools 模式下提示气泡使用黑白风格 */
 .is-utools .hint-bubble {
   background: rgb(0 0 0 / 0.9) !important;
   background-image: none !important;
@@ -492,7 +439,6 @@ onMounted(() => {
   border-left-color: rgb(255 255 255 / 0.9) !important;
 }
 
-/* uTools 模式下脉冲动画使用黑白风格 */
 @keyframes pulse-hint-utools {
   0%,
   100% {
@@ -521,7 +467,6 @@ onMounted(() => {
   animation: pulse-hint-utools-dark 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-/* uTools 模式下 AI 按钮使用黑白风格 */
 .is-utools .utools-ai-button {
   background: rgb(0 0 0 / 0.85) !important;
   background-image: none !important;

--- a/apps/web/src/components/ai/chat-box/AIAssistantPanel.vue
+++ b/apps/web/src/components/ai/chat-box/AIAssistantPanel.vue
@@ -429,7 +429,6 @@ async function sendMessage() {
     <DialogContent
       class="bg-card text-card-foreground h-dvh max-h-dvh w-full flex flex-col rounded-none shadow-xl sm:max-h-[80vh] sm:max-w-2xl sm:rounded-xl"
     >
-      <!-- ============ 头部 ============ -->
       <DialogHeader class="space-y-1 flex flex-col items-start">
         <div class="space-x-1 flex items-center">
           <DialogTitle>{{ t('ai.chat.title') }}</DialogTitle>
@@ -520,7 +519,6 @@ async function sendMessage() {
         </DialogDescription>
       </DialogHeader>
 
-      <!-- ============ 快捷指令 ============ -->
       <div
         v-if="!configVisible"
         class="mb-3 flex flex-wrap gap-2 overflow-x-auto pb-1"
@@ -553,18 +551,15 @@ async function sendMessage() {
           <Plus class="h-4 w-4" />
         </Button>
 
-        <!-- 指令管理弹窗 -->
         <QuickCommandManager v-model:open="cmdMgrOpen" />
       </div>
 
-      <!-- ============ 参数配置面板 ============ -->
       <AIConfig
         v-if="configVisible"
         class="mb-4 w-full border rounded-md p-4"
         @saved="handleConfigSaved"
       />
 
-      <!-- ============ 聊天内容 ============ -->
       <div
         v-if="!configVisible"
         class="custom-scroll space-y-3 chat-container mb-4 flex-1 overflow-y-auto pr-2"
@@ -581,12 +576,10 @@ async function sendMessage() {
               ? 'bg-black text-white dark:bg-primary dark:text-primary-foreground'
               : 'bg-gray-100 text-gray-800 dark:bg-muted/60 dark:text-muted-foreground'"
           >
-            <!-- reasoning -->
             <div v-if="msg.reasoning" class="text-muted-foreground mb-1 italic">
               {{ msg.reasoning }}
             </div>
 
-            <!-- 消息内容 -->
             <div
               class="whitespace-pre-wrap"
               :class="msg.content ? '' : 'animate-pulse text-muted-foreground'"
@@ -597,7 +590,6 @@ async function sendMessage() {
               }}
             </div>
 
-            <!-- 工具按钮 -->
             <div
               class="mt-1 flex"
               :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
@@ -645,7 +637,6 @@ async function sendMessage() {
         </div>
       </div>
 
-      <!-- ============ 输入框 ============ -->
       <div v-if="!configVisible" class="relative mt-2">
         <div
           class="bg-background border-border flex flex-col items-baseline gap-2 border rounded-xl px-3 py-2 pr-12 shadow-inner"
@@ -659,7 +650,6 @@ async function sendMessage() {
             @keydown="handleKeydown"
           />
 
-          <!-- 引用全文按钮 -->
           <Button
             size="sm"
             variant="outline"
@@ -676,7 +666,6 @@ async function sendMessage() {
             <span class="text-xs">{{ t('ai.chat.quoteFullText') }}</span>
           </Button>
 
-          <!-- 发送 / 暂停按钮 -->
           <Button
             :disabled="!input.trim() && !loading"
             size="icon"
@@ -705,23 +694,19 @@ async function sendMessage() {
   --safe-bottom: env(safe-area-inset-bottom);
 }
 
-/* 聊天容器底部内边距，适配安全区 */
 .chat-container {
   padding-bottom: calc(1rem + var(--safe-bottom));
 }
 
-/* 让代码块可横向滚动 */
 .chat-container pre {
   overflow-x: auto;
 }
 
-/* highlight.js 暗黑主题适配 */
 .dark .hljs {
   background: #0d1117 !important;
   color: #c9d1d9 !important;
 }
 
-/* 自定义滚动条 */
 @media (pointer: coarse) {
   .custom-scroll::-webkit-scrollbar {
     width: 3px;

--- a/apps/web/src/components/ai/chat-box/AIConfig.vue
+++ b/apps/web/src/components/ai/chat-box/AIConfig.vue
@@ -6,38 +6,28 @@ import { buildAIHeaders, resolveEndpointUrl, useAIFetch } from '@/composables/us
 import { useLocalizedAIServiceOptions } from '@/composables/useLocalizedAIServices'
 import useAIConfigStore from '@/stores/aiConfig'
 
-/* -------------------------- 基础数据 -------------------------- */
-
 const emit = defineEmits([`saved`])
 
 const AIConfigStore = useAIConfigStore()
 const { type, endpoint, model, apiKey, temperature, maxToken } = storeToRefs(AIConfigStore)
 const { t } = useI18n()
 
-/** UI 状态 */
 const { loading, fetchJSON } = useAIFetch()
 const testResult = ref(``)
 const localizedAIServices = useLocalizedAIServiceOptions()
 
-/** 当前服务信息 */
 const currentService = computed(
   () => localizedAIServices.value.serviceOptions.find(s => s.value === type.value)
     || localizedAIServices.value.serviceOptions[0],
 )
 
-/* -------------------------- 监听 -------------------------- */
-
-// 监听服务类型变化，清空测试结果
 watch(type, () => {
   testResult.value = ``
 })
 
-// 监听模型变化，清空测试结果
 watch(model, () => {
   testResult.value = ``
 })
-
-/* -------------------------- 操作 -------------------------- */
 
 function saveConfig(emitEvent = true) {
   if (emitEvent) {
@@ -106,7 +96,6 @@ async function testConnection() {
       {{ t('ai.config.title') }}
     </div>
 
-    <!-- 服务类型 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.config.serviceType') }}</Label>
       <Select v-model="type">
@@ -127,7 +116,6 @@ async function testConnection() {
       </Select>
     </div>
 
-    <!-- API 端点 -->
     <div v-if="type !== DEFAULT_SERVICE_TYPE">
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.config.apiEndpoint') }}</Label>
       <Input
@@ -137,7 +125,6 @@ async function testConnection() {
       />
     </div>
 
-    <!-- API 密钥，仅非 default 显示 -->
     <div v-if="type !== DEFAULT_SERVICE_TYPE">
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.config.apiKey') }}</Label>
       <PasswordInput
@@ -147,7 +134,6 @@ async function testConnection() {
       />
     </div>
 
-    <!-- 模型名称 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.config.modelName') }}</Label>
       <Select v-if="currentService.models.length > 0" v-model="model">
@@ -174,7 +160,6 @@ async function testConnection() {
       />
     </div>
 
-    <!-- 温度 temperature -->
     <div>
       <Label class="mb-1 flex items-center gap-1 text-sm font-medium">
         {{ t('ai.config.temperature') }}
@@ -200,7 +185,6 @@ async function testConnection() {
       />
     </div>
 
-    <!-- 最大 Token 数 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.config.maxTokens') }}</Label>
       <Input
@@ -213,7 +197,6 @@ async function testConnection() {
       />
     </div>
 
-    <!-- 操作按钮区域 -->
     <div class="mt-2 flex flex-col gap-2 sm:flex-row">
       <Button size="sm" @click="saveConfig">
         {{ t('common.save') }}
@@ -231,7 +214,6 @@ async function testConnection() {
       </Button>
     </div>
 
-    <!-- 测试结果显示 -->
     <div v-if="testResult" class="mt-1 text-xs text-gray-500">
       {{ testResult }}
     </div>
@@ -245,7 +227,6 @@ async function testConnection() {
   width: 6px;
 }
 @media (pointer: coarse) {
-  /* 触屏设备更细 */
   .custom-scroll::-webkit-scrollbar {
     width: 3px;
   }

--- a/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
+++ b/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
@@ -6,7 +6,6 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useQuickCommandsStore } from '@/stores/quickCommands'
 
-/* ---------- 弹窗开关 ---------- */
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits([`update:open`])
 
@@ -14,7 +13,6 @@ const dialogOpen = ref(props.open)
 watch(() => props.open, v => (dialogOpen.value = v))
 watch(dialogOpen, v => emit(`update:open`, v))
 
-/* ---------- store & 新增 ---------- */
 const store = useQuickCommandsStore()
 const { t } = useI18n()
 const label = ref(``)
@@ -28,7 +26,6 @@ function addCmd() {
   template.value = ``
 }
 
-/* ---------- 编辑 ---------- */
 const editingId = ref<string | null>(null)
 const editLabel = ref(``)
 const editTemplate = ref(``)
@@ -58,14 +55,12 @@ function saveEdit() {
         <DialogTitle>{{ t('ai.quickCommand.title') }}</DialogTitle>
       </DialogHeader>
 
-      <!-- 列表：独立滚动区域 -->
       <div class="space-y-4 flex-1 overflow-y-auto pr-1">
         <div
           v-for="cmd in store.commands"
           :key="cmd.id"
           class="flex flex-col gap-2 border rounded-md p-3"
         >
-          <!-- 编辑态 -->
           <template v-if="editingId === cmd.id">
             <Input v-model="editLabel" :placeholder="t('ai.quickCommand.namePlaceholder')" />
             <Textarea
@@ -83,7 +78,6 @@ function saveEdit() {
             </div>
           </template>
 
-          <!-- 查看态 -->
           <template v-else>
             <div class="flex items-center justify-between">
               <span class="break-all text-sm">{{ cmd.label }}</span>
@@ -100,7 +94,6 @@ function saveEdit() {
         </div>
       </div>
 
-      <!-- 新增表单：固定在滚动区下方 -->
       <div class="space-y-2 mt-4 border rounded-md p-3">
         <Input v-model="label" :placeholder="t('ai.quickCommand.nameExamplePlaceholder')" />
         <Textarea

--- a/apps/web/src/components/ai/image-generator/AIImageConfig.vue
+++ b/apps/web/src/components/ai/image-generator/AIImageConfig.vue
@@ -15,43 +15,32 @@ import { buildAIHeaders, resolveEndpointUrl, useAIFetch } from '@/composables/us
 import { useLocalizedAIServiceOptions } from '@/composables/useLocalizedAIServices'
 import useAIImageConfigStore from '@/stores/aiImageConfig'
 
-/* -------------------------- 基础数据 -------------------------- */
-
 const emit = defineEmits([`saved`])
 
 const AIImageConfigStore = useAIImageConfigStore()
 const { type, endpoint, model, apiKey, size, quality, style } = storeToRefs(AIImageConfigStore)
 const { t } = useI18n()
 
-/** UI 状态 */
 const { loading, fetchJSON } = useAIFetch()
 const testResult = ref(``)
 const localizedAIServices = useLocalizedAIServiceOptions()
 
-/** 当前服务信息 */
 const currentService = computed(
   () => localizedAIServices.value.imageServiceOptions.find(s => s.value === type.value)
     || localizedAIServices.value.imageServiceOptions[0],
 )
 
-/* -------------------------- 监听 -------------------------- */
-
-// 监听服务类型变化，清空测试结果
 watch(type, () => {
   testResult.value = ``
 })
 
-// 监听模型变化，清空测试结果
 watch(model, () => {
   testResult.value = ``
 })
 
-// 监听端点变化，清空测试结果
 watch(endpoint, () => {
   testResult.value = ``
 })
-
-/* -------------------------- 表单提交 -------------------------- */
 
 function saveConfig() {
   if (!endpoint.value.trim() || !model.value.trim()) {
@@ -117,8 +106,6 @@ async function testConnection() {
   }
 }
 
-/* -------------------------- 图像尺寸选项 -------------------------- */
-
 const sizeOptions = computed(() => [
   { label: t('ai.imageConfig.sizeSquare'), value: `1024x1024` },
   { label: t('ai.imageConfig.sizeLandscape'), value: `1792x1024` },
@@ -142,7 +129,6 @@ const styleOptions = computed(() => [
       {{ t('ai.imageConfig.title') }}
     </div>
 
-    <!-- 服务商选择 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.imageConfig.provider') }}</Label>
       <Select v-model="type">
@@ -163,7 +149,6 @@ const styleOptions = computed(() => [
       </Select>
     </div>
 
-    <!-- 端点配置 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.imageConfig.apiEndpoint') }}</Label>
       <input
@@ -175,7 +160,6 @@ const styleOptions = computed(() => [
       >
     </div>
 
-    <!-- API Key -->
     <div v-if="type !== 'default'">
       <Label class="mb-1 block text-sm font-medium">API Key</Label>
       <PasswordInput
@@ -185,7 +169,6 @@ const styleOptions = computed(() => [
       />
     </div>
 
-    <!-- 模型选择 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.imageConfig.model') }}</Label>
       <Select v-if="type !== 'custom' && currentService.models.length > 0" v-model="model">
@@ -213,7 +196,6 @@ const styleOptions = computed(() => [
       >
     </div>
 
-    <!-- 图像尺寸 -->
     <div>
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.imageConfig.imageSize') }}</Label>
       <Select v-model="size">
@@ -234,7 +216,6 @@ const styleOptions = computed(() => [
       </Select>
     </div>
 
-    <!-- 图像质量 -->
     <div v-if="model.includes('dall-e')">
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.imageConfig.imageQuality') }}</Label>
       <Select v-model="quality">
@@ -255,7 +236,6 @@ const styleOptions = computed(() => [
       </Select>
     </div>
 
-    <!-- 图像风格 -->
     <div v-if="model.includes('dall-e')">
       <Label class="mb-1 block text-sm font-medium">{{ t('ai.imageConfig.imageStyle') }}</Label>
       <Select v-model="style">
@@ -276,7 +256,6 @@ const styleOptions = computed(() => [
       </Select>
     </div>
 
-    <!-- 说明 -->
     <div v-if="type === 'default'" class="flex items-start gap-2 p-3 bg-blue-50 dark:bg-blue-950/30 rounded-md text-sm">
       <Info class="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
       <div class="text-blue-700 dark:text-blue-300">
@@ -287,7 +266,6 @@ const styleOptions = computed(() => [
       </div>
     </div>
 
-    <!-- 自定义服务说明 -->
     <div v-else-if="type === 'custom'" class="flex items-start gap-2 p-3 bg-orange-50 dark:bg-orange-950/30 rounded-md text-sm">
       <Info class="h-4 w-4 text-orange-500 mt-0.5 flex-shrink-0" />
       <div class="text-orange-700 dark:text-orange-300">
@@ -301,7 +279,6 @@ const styleOptions = computed(() => [
       </div>
     </div>
 
-    <!-- 操作按钮 -->
     <div class="flex flex-wrap gap-2">
       <Button
         type="button"
@@ -329,7 +306,6 @@ const styleOptions = computed(() => [
       </Button>
     </div>
 
-    <!-- 测试结果显示 -->
     <div v-if="testResult" class="mt-1 text-xs text-gray-500">
       {{ testResult }}
     </div>

--- a/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
+++ b/apps/web/src/components/ai/image-generator/AIImageGeneratorPanel.vue
@@ -29,50 +29,43 @@ import { useEditorStore } from '@/stores/editor'
 import { useUIStore } from '@/stores/ui'
 import AIImageConfig from './AIImageConfig.vue'
 
-/* ---------- 组件属性 ---------- */
 const props = defineProps<{ open: boolean }>()
 
 const emit = defineEmits([`update:open`])
 
 const { t } = useI18n()
 
-/** 图片链接有效期：1小时（毫秒） */
+/** Image URL expiry: 1 hour (ms) */
 const EXPIRY_TIME = 60 * 60 * 1000
 
-/* ---------- 编辑器引用 ---------- */
 const editorStore = useEditorStore()
 const { editor } = storeToRefs(editorStore)
 const uiStore = useUIStore()
 const { toggleAIDialog } = uiStore
 
-/* ---------- 弹窗开关 ---------- */
 const dialogVisible = ref(props.open)
 watch(() => props.open, (val) => {
   dialogVisible.value = val
-  // 每次打开面板时检查并清理过期图片
   if (val) {
     cleanExpiredImages()
   }
 })
 watch(dialogVisible, val => emit(`update:open`, val))
 
-/* ---------- 状态管理 ---------- */
 const configVisible = ref(false)
 const loading = ref(false)
 const prompt = ref<string>(``)
 const generatedImages = ref<string[]>([])
-const imagePrompts = ref<string[]>([]) // 存储每张图片对应的prompt
-const imageTimestamps = ref<number[]>([]) // 存储每张图片的生成时间戳
+const imagePrompts = ref<string[]>([])
+const imageTimestamps = ref<number[]>([])
 const abortController = ref<AbortController | null>(null)
 const currentImageIndex = ref(0)
-const currentTime = ref(Date.now()) // 用于实时显示图片剩余有效期
+const currentTime = ref(Date.now())
 let timerIntervalId: ReturnType<typeof setInterval> | null = null
 
-/* ---------- AI 配置 ---------- */
 const AIImageConfigStore = useAIImageConfigStore()
 const { apiKey, endpoint, model, type, size, quality, style } = storeToRefs(AIImageConfigStore)
 
-/* ---------- 过期检查函数 ---------- */
 function isImageExpired(timestamp: number): boolean {
   return Date.now() - timestamp > EXPIRY_TIME
 }
@@ -81,14 +74,13 @@ async function cleanExpiredImages() {
   const images = await store.getJSON<string[]>(`ai_generated_images`, [])
   const timestamps = await store.getJSON<number[]>(`ai_image_timestamps`, [])
 
-  // 没有数据则无需清理
   if (images.length === 0) {
     return
   }
 
   const prompts = await store.getJSON<string[]>(`ai_image_prompts`, [])
 
-  // 如果没有时间戳数据，说明是旧版本，默认清除所有数据
+  // Missing timestamps (legacy data); clear all
   if (timestamps.length === 0) {
     generatedImages.value = []
     imagePrompts.value = []
@@ -99,7 +91,6 @@ async function cleanExpiredImages() {
     return
   }
 
-  // 过滤掉过期的图片
   const validIndices: number[] = []
   timestamps.forEach((timestamp: number, index: number) => {
     if (!isImageExpired(timestamp)) {
@@ -111,12 +102,10 @@ async function cleanExpiredImages() {
   const validPrompts = validIndices.map(i => prompts[i] || ``).filter((_, index) => validImages[index])
   const validTimestamps = validIndices.map(i => timestamps[i]).filter(Boolean)
 
-  // 更新数据
   generatedImages.value = validImages
   imagePrompts.value = validPrompts
   imageTimestamps.value = validTimestamps
 
-  // 如果有数据被清除，更新存储
   if (validImages.length < images.length) {
     if (validImages.length > 0) {
       await store.setJSON(`ai_generated_images`, validImages)
@@ -131,12 +120,9 @@ async function cleanExpiredImages() {
   }
 }
 
-/* ---------- 初始数据 & 定时器 ---------- */
 onMounted(async () => {
-  // 先进行过期检查和清理
   await cleanExpiredImages()
 
-  // 确保数组长度一致
   const imagesLength = generatedImages.value.length
   const promptsLength = imagePrompts.value.length
   const timestampsLength = imageTimestamps.value.length
@@ -144,7 +130,7 @@ onMounted(async () => {
   const maxLength = Math.max(imagesLength, promptsLength, timestampsLength)
 
   if (imagesLength < maxLength) {
-    // 如果图片少于其他数组，说明数据不一致，清除所有数据
+    // Image count mismatch; clear inconsistent data
     generatedImages.value = []
     imagePrompts.value = []
     imageTimestamps.value = []
@@ -153,7 +139,6 @@ onMounted(async () => {
     await store.remove(`ai_image_timestamps`)
   }
   else {
-    // 补齐较短的数组
     if (promptsLength < imagesLength) {
       imagePrompts.value = [...imagePrompts.value, ...Array.from<string>({ length: imagesLength - promptsLength }).fill(``)]
     }
@@ -162,8 +147,7 @@ onMounted(async () => {
     }
   }
 
-  // 每秒更新当前时间（用于实时显示剩余有效期）
-  // 每30秒顺带清理一次已过期的图片
+  // Also purge expired images every 30s
   let tick = 0
   timerIntervalId = setInterval(() => {
     currentTime.value = Date.now()
@@ -181,15 +165,12 @@ onBeforeUnmount(() => {
   }
 })
 
-/* ---------- 事件处理 ---------- */
 function handleConfigSaved() {
   configVisible.value = false
 }
 
 function switchToChat() {
-  // 先关闭当前文生图对话框
   emit(`update:open`, false)
-  // 然后打开聊天对话框
   setTimeout(() => {
     toggleAIDialog(true)
   }, 100)
@@ -205,7 +186,6 @@ function handleKeydown(e: KeyboardEvent) {
   }
 }
 
-/* ---------- 生成图像（核心） ---------- */
 async function doGenerateImage(promptText: string, clearInput = false) {
   if (!promptText.trim() || loading.value)
     return
@@ -225,7 +205,7 @@ async function doGenerateImage(promptText: string, clearInput = false) {
       n: 1,
     }
 
-    // 只对 DALL-E 模型添加额外参数
+    // Add extra params only for DALL-E models
     if (model.value.includes(`dall-e`)) {
       payload.quality = quality.value
       payload.style = style.value
@@ -249,7 +229,6 @@ async function doGenerateImage(promptText: string, clearInput = false) {
       const imageUrl = data.data[0].url || data.data[0].b64_json
 
       if (imageUrl) {
-        // 如果是 base64 格式，转换为 data URL
         const finalUrl = imageUrl.startsWith(`data:`) || imageUrl.startsWith(`http`)
           ? imageUrl
           : `data:image/png;base64,${imageUrl}`
@@ -257,11 +236,11 @@ async function doGenerateImage(promptText: string, clearInput = false) {
         const currentTimestamp = Date.now()
 
         generatedImages.value.unshift(finalUrl)
-        imagePrompts.value.unshift(promptText.trim()) // 保存对应的prompt
-        imageTimestamps.value.unshift(currentTimestamp) // 保存生成时间戳
+        imagePrompts.value.unshift(promptText.trim())
+        imageTimestamps.value.unshift(currentTimestamp)
         currentImageIndex.value = 0
 
-        // 限制存储的图片数量，避免占用过多存储空间
+        // Cap stored images to limit storage use
         if (generatedImages.value.length > 20) {
           generatedImages.value = generatedImages.value.slice(0, 20)
           imagePrompts.value = imagePrompts.value.slice(0, 20)
@@ -272,7 +251,6 @@ async function doGenerateImage(promptText: string, clearInput = false) {
         await store.setJSON(`ai_image_prompts`, imagePrompts.value)
         await store.setJSON(`ai_image_timestamps`, imageTimestamps.value)
 
-        // 清空输入框
         if (clearInput)
           prompt.value = ``
       }
@@ -292,7 +270,6 @@ async function doGenerateImage(promptText: string, clearInput = false) {
   }
 }
 
-/* ---------- 生成图像 ---------- */
 async function generateImage() {
   if (!prompt.value.trim() || loading.value)
     return
@@ -300,7 +277,6 @@ async function generateImage() {
   await doGenerateImage(prompt.value, true)
 }
 
-/* ---------- 取消生成 ---------- */
 function cancelGeneration() {
   if (abortController.value) {
     abortController.value.abort()
@@ -309,7 +285,6 @@ function cancelGeneration() {
   loading.value = false
 }
 
-/* ---------- 清空图像 ---------- */
 async function clearImages() {
   generatedImages.value = []
   imagePrompts.value = []
@@ -320,7 +295,6 @@ async function clearImages() {
   await store.remove(`ai_image_timestamps`)
 }
 
-/* ---------- 下载图像 ---------- */
 async function downloadImage(imageUrl: string, index: number) {
   try {
     const response = await fetch(imageUrl)
@@ -332,7 +306,6 @@ async function downloadImage(imageUrl: string, index: number) {
     const a = document.createElement(`a`)
     a.href = url
 
-    // 生成包含prompt信息的文件名
     const relatedPrompt = imagePrompts.value[index] || ``
     const promptPart = relatedPrompt
       ? relatedPrompt.substring(0, 20).replace(/[^\w\s-]/g, ``).replace(/\s+/g, `-`)
@@ -350,7 +323,6 @@ async function downloadImage(imageUrl: string, index: number) {
   }
 }
 
-/* ---------- 复制图像URL ---------- */
 async function copyImageUrl(imageUrl: string) {
   try {
     await copyPlain(imageUrl)
@@ -361,25 +333,16 @@ async function copyImageUrl(imageUrl: string) {
   }
 }
 
-/* ---------- 重新生成 ---------- */
 function regenerateImage() {
-  // 使用当前图片对应的prompt
   const currentPrompt = imagePrompts.value[currentImageIndex.value]
-  if (currentPrompt) {
-    // 直接使用当前图片的prompt生成，不修改输入框内容
+  if (currentPrompt)
     regenerateWithPrompt(currentPrompt)
-  }
-  else {
-    // No prompt available, silently skip
-  }
 }
 
-/* ---------- 使用指定prompt重新生成 ---------- */
 async function regenerateWithPrompt(promptText: string) {
   await doGenerateImage(promptText)
 }
 
-/* ---------- 切换图像 ---------- */
 function previousImage() {
   if (currentImageIndex.value > 0) {
     currentImageIndex.value--
@@ -392,36 +355,29 @@ function nextImage() {
   }
 }
 
-/* ---------- 插入图像到光标位置 ---------- */
 function insertImageToCursor(imageUrl: string) {
   if (!editor.value)
     return
 
   try {
-    // 获取当前图片对应的prompt
     const imagePrompt = imagePrompts.value[currentImageIndex.value] || ``
 
-    // 生成简洁的alt文本
     const altText = imagePrompt.trim()
       ? imagePrompt.trim().substring(0, 30).replace(/\n/g, ` `)
       : t(`ai.image.aiGeneratedAlt`)
 
-    // 生成Markdown图片语法
     const markdownImage = `![${altText}](${imageUrl})`
 
-    // 获取当前光标位置并插入
     const pos = editor.value.state.selection.main.head
     editor.value.dispatch({
       changes: { from: pos, insert: markdownImage },
       selection: { anchor: pos + markdownImage.length },
     })
 
-    // 聚焦编辑器
     editor.value.focus()
 
     toast.success(t(`ai.image.insertedToEditor`))
 
-    // 关闭弹窗
     dialogVisible.value = false
   }
   catch {
@@ -429,7 +385,6 @@ function insertImageToCursor(imageUrl: string) {
   }
 }
 
-/* ---------- 查看大图 ---------- */
 const previewImageUrl = ref('')
 const previewOverlayRef = ref<HTMLDivElement | null>(null)
 
@@ -452,13 +407,11 @@ function closePreview() {
   previewImageUrl.value = ''
 }
 
-/* ---------- 时间相关函数 ---------- */
 function getTimeRemaining(index: number): string {
   if (!imageTimestamps.value[index]) {
     return t(`common.unknown`)
   }
 
-  // EXPIRY_TIME 来自模块顶层常量
   const timestamp = imageTimestamps.value[index]
   const elapsed = currentTime.value - timestamp
   const remaining = EXPIRY_TIME - elapsed
@@ -483,7 +436,6 @@ function getTimeRemainingClass(index: number): string {
     return `text-muted-foreground`
   }
 
-  // EXPIRY_TIME 来自模块顶层常量
   const timestamp = imageTimestamps.value[index]
   const elapsed = currentTime.value - timestamp
   const remaining = EXPIRY_TIME - elapsed
@@ -491,10 +443,10 @@ function getTimeRemainingClass(index: number): string {
   if (remaining <= 0) {
     return `text-red-500 font-medium`
   }
-  else if (remaining < 10 * 60 * 1000) { // 少于10分钟
+  else if (remaining < 10 * 60 * 1000) { // less than 10 minutes
     return `text-orange-500 font-medium`
   }
-  else if (remaining < 30 * 60 * 1000) { // 少于30分钟
+  else if (remaining < 30 * 60 * 1000) { // less than 30 minutes
     return `text-yellow-600`
   }
   else {
@@ -508,7 +460,6 @@ function getTimeRemainingClass(index: number): string {
     <DialogContent
       class="bg-card text-card-foreground flex flex-col w-[95vw] max-h-[90vh] sm:max-h-[85vh] sm:max-w-4xl overflow-y-auto"
     >
-      <!-- ============ 头部 ============ -->
       <DialogHeader class="space-y-1 flex flex-col items-start">
         <div class="space-x-1 flex items-center">
           <DialogTitle>{{ t('ai.image.title') }}</DialogTitle>
@@ -549,7 +500,6 @@ function getTimeRemainingClass(index: number): string {
         </DialogDescription>
       </DialogHeader>
 
-      <!-- ============ 参数配置面板 ============ -->
       <div
         v-if="configVisible"
         class="mb-4 w-full border rounded-md p-4 max-h-[60vh] overflow-y-auto flex-shrink-0"
@@ -557,12 +507,10 @@ function getTimeRemainingClass(index: number): string {
         <AIImageConfig @saved="handleConfigSaved" />
       </div>
 
-      <!-- ============ 图像展示区域 ============ -->
       <div
         v-if="!configVisible && (loading || generatedImages.length > 0)"
         class="flex flex-col space-y-4 flex-shrink-0"
       >
-        <!-- 图像显示 -->
         <div class="flex items-center justify-center bg-gray-50 dark:bg-gray-800 rounded-lg min-h-[250px] sm:min-h-[300px]">
           <div v-if="loading" class="flex flex-col items-center gap-4">
             <Loader2 class="h-8 w-8 animate-spin text-primary" />
@@ -579,7 +527,6 @@ function getTimeRemainingClass(index: number): string {
           </div>
 
           <div v-else-if="generatedImages.length > 0" class="w-full flex flex-col space-y-3">
-            <!-- 图像导航 -->
             <div v-if="generatedImages.length > 1" class="flex items-center justify-between p-2 bg-muted/20 rounded">
               <Button
                 variant="outline"
@@ -602,7 +549,6 @@ function getTimeRemainingClass(index: number): string {
               </Button>
             </div>
 
-            <!-- 图像显示 -->
             <div class="flex items-center justify-center p-2 sm:p-4">
               <div class="relative group cursor-pointer max-w-lg inline-flex justify-center" @click="viewFullImage(generatedImages[currentImageIndex])">
                 <img
@@ -610,7 +556,6 @@ function getTimeRemainingClass(index: number): string {
                   :alt="t('ai.image.generatedImageAlt', { n: currentImageIndex + 1 })"
                   class="max-w-full h-[300px] object-contain rounded-lg shadow-lg border border-border transition-transform hover:scale-105"
                 >
-                <!-- 点击查看大图提示 -->
                 <div class="absolute inset-0 bg-black/0 group-hover:bg-black/10 rounded-lg flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
                   <div class="bg-black/70 text-white px-3 py-1 rounded-md text-sm">
                     {{ t('ai.image.clickToViewLarge') }}
@@ -619,12 +564,10 @@ function getTimeRemainingClass(index: number): string {
               </div>
             </div>
 
-            <!-- 图像信息 -->
             <div class="px-2 sm:px-4 py-2 bg-muted/10 rounded space-y-1">
               <p class="text-xs text-muted-foreground text-center">
                 {{ t('ai.image.size') }}: {{ size }}
               </p>
-              <!-- 提示词 -->
               <div class="text-xs text-muted-foreground break-words text-center">
                 <span class="font-medium">{{ t('ai.image.prompt') }}:</span>
                 <span class="ml-1">{{ imagePrompts[currentImageIndex] || t('ai.image.noPrompt') }}</span>
@@ -638,7 +581,6 @@ function getTimeRemainingClass(index: number): string {
               </div>
             </div>
 
-            <!-- 图像操作按钮 -->
             <div class="flex flex-wrap justify-center gap-2 p-2 sm:p-4 bg-muted/20 border-t border-border rounded-b-lg">
               <Button
                 variant="outline"
@@ -681,7 +623,6 @@ function getTimeRemainingClass(index: number): string {
         </div>
       </div>
 
-      <!-- ============ 输入框 ============ -->
       <div v-if="!configVisible" class="relative flex-shrink-0 mt-auto">
         <div
           class="bg-background border-border flex flex-col items-baseline gap-2 border rounded-xl px-3 py-2 pr-12 shadow-inner"
@@ -694,7 +635,6 @@ function getTimeRemainingClass(index: number): string {
             @keydown="handleKeydown"
           />
 
-          <!-- 生成按钮 -->
           <Button
             :disabled="!prompt.trim() && !loading"
             size="icon"
@@ -715,7 +655,6 @@ function getTimeRemainingClass(index: number): string {
     </DialogContent>
   </Dialog>
 
-  <!-- ============ 图片预览遮罩 ============ -->
   <Teleport to="body">
     <div
       v-if="previewImageUrl"
@@ -755,7 +694,6 @@ function getTimeRemainingClass(index: number): string {
   width: 6px;
 }
 @media (pointer: coarse) {
-  /* 触屏设备更细 */
   .custom-scroll::-webkit-scrollbar {
     width: 3px;
   }

--- a/apps/web/src/components/ai/tool-box/ToolBoxPopover.vue
+++ b/apps/web/src/components/ai/tool-box/ToolBoxPopover.vue
@@ -19,7 +19,6 @@ import { buildAIHeaders, resolveEndpointUrl, useAIFetch } from '@/composables/us
 import useAIConfigStore from '@/stores/aiConfig'
 import { useEditorStore } from '@/stores/editor'
 
-/* -------------------- props / emits -------------------- */
 const props = defineProps<{
   open: boolean
   selectedText: string
@@ -27,7 +26,6 @@ const props = defineProps<{
 }>()
 const emit = defineEmits([`update:open`])
 
-/* -------------------- reactive state -------------------- */
 const configVisible = ref(false)
 const dialogVisible = ref(props.open)
 const message = ref(``)
@@ -40,11 +38,9 @@ const selectedAction = ref<
 const currentText = ref(``)
 const error = ref(``)
 
-/* -------------------- store & refs -------------------- */
 const editorStore = useEditorStore()
 const resultContainer = ref<HTMLElement | null>(null)
 
-/* -------------------- dialog state sync -------------------- */
 watch(() => props.open, (val) => {
   dialogVisible.value = val
   if (val && props.selectedText.trim()) {
@@ -54,13 +50,11 @@ watch(() => props.open, (val) => {
 })
 watch(dialogVisible, val => emit(`update:open`, val))
 
-/* -------------------- AI config -------------------- */
 const AIConfigStore = useAIConfigStore()
 const { apiKey, endpoint, model, temperature, maxToken, type }
   = storeToRefs(AIConfigStore)
 const { t } = useI18n()
 
-/* -------------------- action options -------------------- */
 interface ActionOption {
   value: string
   label: string
@@ -106,7 +100,6 @@ const actionOptions = computed<ActionOption[]>(() => [
   { value: `custom`, label: t('ai.toolbox.actions.custom.label'), defaultPrompt: `` },
 ])
 
-/* -------------------- watchers -------------------- */
 watch(message, async () => {
   await nextTick()
   resultContainer.value?.scrollTo({ top: resultContainer.value.scrollHeight })
@@ -117,7 +110,6 @@ watch(selectedAction, (val) => {
     customPrompts.value = []
 })
 
-// 当 dialogVisible 且 props.selectedText 变更时，更新原文并重置状态
 watch(
   () => props.selectedText,
   (val) => {
@@ -128,7 +120,6 @@ watch(
   },
 )
 
-/* -------------------- prompt handlers -------------------- */
 function addPrompt(e: KeyboardEvent) {
   const input = e.target as HTMLInputElement
   const prompt = input.value.trim()
@@ -151,7 +142,6 @@ function resetState() {
   abortAI()
 }
 
-/* -------------------- AI call -------------------- */
 async function runAIAction() {
   const text = currentText.value.trim()
   if (!text || loading.value)
@@ -204,20 +194,17 @@ async function runAIAction() {
   }
 }
 
-/* -------------------- abort handler -------------------- */
 function stopAI() {
   if (loading.value) {
     abortAI()
   }
 }
 
-/* -------------------- actions -------------------- */
 function replaceText() {
   const editorView = toRaw(editorStore.editor!)!
   const selection = editorView.state.selection.main
   editorView.dispatch(editorView.state.replaceSelection(message.value))
 
-  // 选中替换后的文本
   const newSelection = editorView.state.selection.main
   editorView.dispatch({
     selection: { anchor: selection.from, head: newSelection.head },
@@ -247,7 +234,6 @@ defineExpose({ dialogVisible, runAIAction, replaceText, show, close, stopAI })
     <DialogContent
       class="bg-card text-card-foreground flex flex-col w-[95vw] max-h-[90vh] sm:max-h-[85vh] sm:max-w-2xl overflow-hidden p-0"
     >
-      <!-- ============ 头部 ============ -->
       <DialogHeader class="space-y-1 flex flex-col items-start px-6 pt-6 pb-4">
         <div class="space-x-1 flex items-center">
           <DialogTitle>{{ t('ai.toolbox.title') }}</DialogTitle>
@@ -265,17 +251,13 @@ defineExpose({ dialogVisible, runAIAction, replaceText, show, close, stopAI })
         </div>
       </DialogHeader>
 
-      <!-- ============ 内容区域 ============ -->
-      <!-- config panel -->
       <AIConfig
         v-if="configVisible"
         class="border-border mx-6 mb-4 w-auto border rounded-md p-4"
         @saved="() => (configVisible = false)"
       />
 
-      <!-- main content -->
       <div v-else class="custom-scroll space-y-3 flex-1 overflow-y-auto px-6 pb-3">
-        <!-- action selector -->
         <div>
           <div class="mb-1.5 text-sm font-medium">
             {{ t('ai.toolbox.selectAction') }}
@@ -298,7 +280,6 @@ defineExpose({ dialogVisible, runAIAction, replaceText, show, close, stopAI })
           </Select>
         </div>
 
-        <!-- original text -->
         <div>
           <div class="mb-1.5 text-sm font-medium">
             {{ t('ai.toolbox.originalText') }}
@@ -310,7 +291,6 @@ defineExpose({ dialogVisible, runAIAction, replaceText, show, close, stopAI })
           </div>
         </div>
 
-        <!-- custom prompts -->
         <div v-if="selectedAction === 'custom'">
           <div class="mb-1.5 text-sm font-medium">
             {{ t('ai.toolbox.customPrompt') }}
@@ -339,12 +319,10 @@ defineExpose({ dialogVisible, runAIAction, replaceText, show, close, stopAI })
           </div>
         </div>
 
-        <!-- error -->
         <div v-if="error" class="min-h-[20px] flex items-center text-xs text-red-500">
           {{ error }}
         </div>
 
-        <!-- result -->
         <div v-if="message">
           <div class="mb-1.5 text-sm font-medium">
             {{ t('ai.toolbox.result') }}
@@ -358,7 +336,6 @@ defineExpose({ dialogVisible, runAIAction, replaceText, show, close, stopAI })
         </div>
       </div>
 
-      <!-- ============ 底部按钮 ============ -->
       <div v-if="!configVisible" class="flex justify-end gap-2 px-6 py-3.5 mt-auto">
         <Button v-if="loading" variant="secondary" @click="stopAI">
           <Pause class="mr-1 h-4 w-4" /> {{ t('ai.toolbox.stop') }}

--- a/apps/web/src/components/ai/tool-box/index.ts
+++ b/apps/web/src/components/ai/tool-box/index.ts
@@ -1,14 +1,12 @@
 import type { EditorView } from '@codemirror/view'
 import AIPolishPopover from './ToolBoxPopover.vue'
 
-/* ---------- 简化的组合式函数 ---------- */
 function useAIPolish() {
-  // 现在工具箱已移到侧边栏，不再需要复杂的位置计算和事件监听
-  // 保留最基本的功能以维持兼容性
+  // Toolbox moved to sidebar; no position logic needed
+  // Keep minimal API for compatibility
 
   const selectedText = ref(``)
 
-  // 获取当前编辑器选中文本的简单函数
   function getCurrentSelection(editor: EditorView | null): string {
     try {
       if (!editor)
@@ -21,7 +19,6 @@ function useAIPolish() {
     }
   }
 
-  /* =============== 简化的对外导出 =============== */
   return {
     selectedText,
     getCurrentSelection,

--- a/apps/web/src/components/editor/CodemirrorEditor.vue
+++ b/apps/web/src/components/editor/CodemirrorEditor.vue
@@ -41,21 +41,16 @@ const {
   isShowComponentDialog,
 } = storeToRefs(uiStore)
 
-// --- 子组件引用 ---
 const editorPanelCompRef = ref<InstanceType<typeof EditorPanel> | null>(null)
 const previewPanelCompRef = ref<InstanceType<typeof PreviewPanel> | null>(null)
 
-// 从子组件获取 codeMirrorView 和 previewRef (使用 getter 避免 DeepReadonly 类型问题)
 const getEditorView = () => editorPanelCompRef.value?.codeMirrorView ?? null
 const getPreviewContainer = () => previewPanelCompRef.value?.previewRef ?? null
 
-// --- 点击预览内容跳转到编辑器对应位置 ---
 const { handlePreviewContentClick } = useCursorSync(getEditorView)
 
-// --- 滚动同步 ---
 useScrollSync(getEditorView, getPreviewContainer, enableScrollSync)
 
-// --- 复制状态 ---
 const backLight = ref(false)
 const isCoping = ref(false)
 let copyEndTimer: ReturnType<typeof setTimeout> | null = null
@@ -83,12 +78,10 @@ onUnmounted(() => {
   }
 })
 
-// --- 上传图片透传 ---
 function handleUploadImage(file: File, cb?: any, applyUrl?: boolean) {
   editorPanelCompRef.value?.uploadImage(file, cb, applyUrl)
 }
 
-// --- 面板尺寸配置 ---
 const hasSidePanel = computed(() => !isMobile.value && (isOpenRightSlider.value || uiStore.isShowCssEditor))
 
 const editorPanelConfig = computed(() => {
@@ -182,7 +175,6 @@ onMounted(() => {
   })
 })
 
-// --- 进度条 ---
 const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading) ?? false)
 </script>
 
@@ -219,10 +211,8 @@ const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading
           </ResizablePanel>
           <ResizableHandle v-if="!isMobile && isOpenFolderPanel" class="hidden md:block" />
 
-          <!-- 主内容区域 (嵌套灵动布局) -->
           <ResizablePanel :min-size="30">
             <ResizablePanelGroup direction="horizontal">
-              <!-- Markdown 编辑器 -->
               <ResizablePanel
                 ref="editorResizablePanelRef"
                 :order="1"
@@ -236,7 +226,6 @@ const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading
               </ResizablePanel>
               <ResizableHandle v-show="viewMode === 'split'" />
 
-              <!-- 预览区 -->
               <ResizablePanel
                 ref="previewResizablePanelRef"
                 :order="2"
@@ -254,7 +243,6 @@ const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading
                 />
               </ResizablePanel>
 
-              <!-- CSS 编辑器面板 -->
               <ResizableHandle v-show="!isMobile && uiStore.isShowCssEditor" class="hidden md:block" />
               <ResizablePanel
                 ref="cssEditorPanelRef"
@@ -268,7 +256,6 @@ const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading
                 <CssEditor v-if="!isMobile && uiStore.isShowCssEditor" />
               </ResizablePanel>
 
-              <!-- 样式面板 -->
               <ResizableHandle v-show="!isMobile && isOpenRightSlider" class="hidden md:block right-slider-handle" />
               <ResizablePanel
                 ref="rightSliderPanelRef"
@@ -284,7 +271,6 @@ const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading
               </ResizablePanel>
             </ResizablePanelGroup>
 
-            <!-- 移动端：组件内部用 transform 控制显隐，需保持挂载以保留滑入动画 -->
             <CssEditor v-if="isMobile" />
             <RightSlider v-if="isMobile" />
           </ResizablePanel>

--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -23,18 +23,14 @@ const themeStore = useThemeStore()
 const { isMobile } = storeToRefs(uiStore)
 const { cssContentConfig, isSelectMode, selectedIds } = storeToRefs(cssEditorStore)
 
-// 控制是否启用动画
 const enableAnimation = ref(false)
 
-// 监听 CssEditor 开关状态变化
 watch(() => uiStore.isShowCssEditor, () => {
   if (isMobile.value) {
-    // 在移动端,用户操作时启用动画
     enableAnimation.value = true
   }
 })
 
-// 监听设备类型变化，重置动画状态
 watch(() => isMobile.value, () => {
   enableAnimation.value = false
 })
@@ -108,7 +104,6 @@ function editTabName() {
 const isOpenAddDialog = ref(false)
 
 const addInputVal = ref(``)
-// 新建方案时选择的基础主题
 const baseThemeForNew = ref<'blank' | 'default' | 'grace' | 'simple'>('blank')
 
 async function addTab() {
@@ -117,28 +112,23 @@ async function addTab() {
     return
   }
 
-  // 根据选择的基础主题来初始化内容
   let initialContent = ''
   if (baseThemeForNew.value === 'blank') {
-    initialContent = '' // 空白方案
+    initialContent = ''
   }
   else {
-    // 基于内置主题
     initialContent = themeMap[baseThemeForNew.value]
   }
 
   const newTabName = addInputVal.value
 
-  // addCssContentTab 会自动设置 active 并触发回调
   cssEditorStore.addCssContentTab(newTabName, initialContent)
 
   isOpenAddDialog.value = false
   toast.success(t('cssEditor.createSuccess'))
 
-  // 重置为空白
   baseThemeForNew.value = 'blank'
 
-  // 滚动到新创建的 tab
   scrollToActiveTab()
 }
 
@@ -175,7 +165,7 @@ function removeHandler(targetId: string) {
 
 function addHandler() {
   addInputVal.value = t('cssEditor.schemeDefaultName', { index: cssContentConfig.value.tabs.length + 1 })
-  baseThemeForNew.value = 'blank' // 重置选择
+  baseThemeForNew.value = 'blank'
   isOpenAddDialog.value = true
 }
 
@@ -268,17 +258,15 @@ function openViewThemeDialog() {
   isOpenViewThemeDialog.value = true
 }
 
-// 复制主题 CSS
 async function copyThemeCSS() {
   const css = themeMap[selectedViewTheme.value]
   await copyPlain(css)
   toast.success(t('common.copiedToClipboard'))
 }
 
-// 基于当前查看的主题新建方案
 function createFromViewTheme() {
   isOpenViewThemeDialog.value = false
-  // 设置基础主题并打开新建对话框
+
   baseThemeForNew.value = selectedViewTheme.value
   addInputVal.value = t('cssEditor.basedOnTheme', { theme: getThemeLabel(t, selectedViewTheme.value as ThemeName) })
   isOpenAddDialog.value = true
@@ -286,33 +274,25 @@ function createFromViewTheme() {
 
 function tabChanged(tabId: string | number) {
   cssEditorStore.tabChanged(tabId as string)
-  // 切换后滚动到活跃的 tab
+
   scrollToActiveTab()
 }
 
-// 初始化 CSS 编辑器
 onMounted(() => {
-  // CSS 内容更新回调
   const handleCssUpdate = () => {
-    // 1. 使用新主题系统应用 CSS
     themeStore.applyCurrentTheme()
 
-    // 2. 触发编辑器刷新，重新渲染内容
     themeStore.updateCodeTheme()
     const raw = editorStore.getContent()
     renderStore.render(raw)
   }
 
-  // 设置切换方案时的回调（与编辑时使用相同的逻辑）
   cssEditorStore.setOnTabChangedCallback(handleCssUpdate)
 
-  // 初始化 CSS 编辑器
   cssEditorStore.initCssEditor(handleCssUpdate)
 
-  // 初始化时滚动到活跃的 tab
   scrollToActiveTab()
 
-  // 点击外部关闭右键菜单
   document.addEventListener('click', closeContextMenu)
 })
 
@@ -320,7 +300,6 @@ onUnmounted(() => {
   document.removeEventListener('click', closeContextMenu)
 })
 
-// 导出合并后的主题
 function exportCurrentTheme() {
   const currentTab = cssContentConfig.value.tabs.find(tab => tab.id === cssContentConfig.value.active)
   if (!currentTab) {
@@ -330,7 +309,7 @@ function exportCurrentTheme() {
 
   const currentThemeName = currentTab.title || currentTab.name
 
-  // 使用新的导出函数（包含 default 基础）
+  // Export merged theme (includes default base)
   const baseTheme = themeStore.theme === `default`
     ? themeMap.default
     : `${themeMap.default}\n\n${themeMap[themeStore.theme]}`
@@ -349,7 +328,6 @@ function exportCurrentTheme() {
 </script>
 
 <template>
-  <!-- 移动端遮罩层 -->
   <div
     v-if="isMobile && uiStore.isShowCssEditor"
     class="fixed inset-0 bg-black/50 z-40"
@@ -365,7 +343,6 @@ function exportCurrentTheme() {
     }"
     :style="isMobile ? { transform: uiStore.isShowCssEditor ? 'translateX(0)' : 'translateX(100%)' } : undefined"
   >
-    <!-- Tab 栏 + 工具栏合并 -->
     <div class="flex items-center h-9 px-2 shrink-0 border-b border-border">
       <div class="flex-1 flex items-center gap-0 overflow-x-auto custom-scrollbar min-w-0 h-full">
         <div
@@ -436,9 +413,7 @@ function exportCurrentTheme() {
         </div>
       </div>
 
-      <!-- 工具按钮组 -->
       <div class="flex items-center shrink-0">
-        <!-- 新增 Tab -->
         <button
           class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
           @click="addHandler"
@@ -446,7 +421,6 @@ function exportCurrentTheme() {
           <Plus class="size-3.5" />
         </button>
 
-        <!-- 内置主题 -->
         <button
           class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
           @click="openViewThemeDialog"
@@ -454,7 +428,6 @@ function exportCurrentTheme() {
           <Eye class="size-3.5" />
         </button>
 
-        <!-- 导出主题 -->
         <button
           class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
           @click="exportCurrentTheme"
@@ -462,7 +435,6 @@ function exportCurrentTheme() {
           <Download class="size-3.5" />
         </button>
 
-        <!-- 关闭 -->
         <button
           class="inline-flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
           @click="uiStore.isShowCssEditor = false"
@@ -472,7 +444,6 @@ function exportCurrentTheme() {
       </div>
     </div>
 
-    <!-- CSS编辑器内容区域 -->
     <div class="flex-1 min-h-0">
       <textarea
         id="cssEditor"
@@ -481,7 +452,6 @@ function exportCurrentTheme() {
       />
     </div>
 
-    <!-- 选择模式底部操作栏 -->
     <Transition name="slide-up">
       <div
         v-if="isSelectMode"
@@ -528,7 +498,6 @@ function exportCurrentTheme() {
       </div>
     </Transition>
 
-    <!-- 右键菜单 -->
     <Teleport to="body">
       <div
         v-if="showContextMenu"
@@ -565,7 +534,6 @@ function exportCurrentTheme() {
       </div>
     </Teleport>
 
-    <!-- 新增弹窗 -->
     <Dialog v-model:open="isOpenAddDialog">
       <DialogContent class="sm:max-w-[425px]">
         <DialogHeader>
@@ -616,7 +584,6 @@ function exportCurrentTheme() {
       </DialogContent>
     </Dialog>
 
-    <!-- 重命名弹窗 -->
     <Dialog v-model:open="isOpenEditDialog">
       <DialogContent class="sm:max-w-[425px]">
         <DialogHeader>
@@ -638,7 +605,6 @@ function exportCurrentTheme() {
     </Dialog>
   </div>
 
-  <!-- 查看内置主题对话框 -->
   <Dialog v-model:open="isOpenViewThemeDialog">
     <DialogContent class="sm:max-w-4xl max-h-[90vh] flex flex-col">
       <DialogHeader>
@@ -649,7 +615,6 @@ function exportCurrentTheme() {
       </DialogHeader>
 
       <div class="space-y-4 flex-1 min-h-0 flex flex-col">
-        <!-- 主题选择器 -->
         <div class="space-y-2">
           <label class="text-sm font-medium">{{ t('cssEditor.selectTheme') }}</label>
           <Select v-model="selectedViewTheme">
@@ -670,7 +635,6 @@ function exportCurrentTheme() {
           </Select>
         </div>
 
-        <!-- CSS 代码查看器 -->
         <div class="flex-1 min-h-0 border rounded-lg overflow-auto">
           <pre class="h-full overflow-auto p-4 bg-muted text-sm"><code>{{ themeMap[selectedViewTheme] }}</code></pre>
         </div>
@@ -692,23 +656,18 @@ function exportCurrentTheme() {
 </template>
 
 <style lang="less" scoped>
-/* 隐藏滚动条但保持滚动功能 */
 .custom-scrollbar {
-  /* Firefox */
   scrollbar-width: none;
 
-  /* Chrome, Edge, Safari */
   &::-webkit-scrollbar {
     display: none;
   }
 }
 
-/* 移动端CSS编辑器动画 - 只有添加了 animate 类才启用 */
 .mobile-css-editor.animate {
   transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* 底部操作栏动画 */
 .slide-up-enter-active,
 .slide-up-leave-active {
   transition: transform 200ms ease, opacity 200ms ease;

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -355,7 +355,6 @@ function mdLocalToRemote() {
 // --- Image paste handler for CodeMirror ---
 function createPasteHandler() {
   return (event: ClipboardEvent, view: EditorView) => {
-    // 1. 处理剪贴板中的文件 (截图/复制文件)
     if (event.clipboardData?.items && [...event.clipboardData.items].some(item => item.kind === 'file')) {
       if (isImgLoading.value) {
         return true
@@ -378,7 +377,6 @@ function createPasteHandler() {
       return true
     }
 
-    // 2. 处理剪贴板中的文本 (检测 Markdown 图片链接)
     const text = event.clipboardData?.getData('text/plain')
     if (text) {
       const mdImgRegex = /!\[(.*?)\]\((https?:\/\/[^)]+)\)/g
@@ -609,7 +607,7 @@ watch(currentPostIndex, (newIndex, oldIndex) => {
   syncEditorToPostContent(post.content)
 })
 
-/** 云端同步等外部写入 posts 时，当前文章 index 不变也需刷新编辑器 */
+/** Refresh editor when posts change externally (e.g. cloud sync) even if index is unchanged */
 watch(
   () => currentPost.value?.content,
   (content) => {
@@ -619,7 +617,6 @@ watch(
   },
 )
 
-// 历史记录的定时器
 const historyTimer = ref<ReturnType<typeof setTimeout>>()
 onMounted(() => {
   historyTimer.value = setInterval(() => {

--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -95,13 +95,11 @@ function toggleLanguage() {
   localeStore.cycleLocale()
 }
 
-// 光标位置
 const cursorLine = ref(1)
 const cursorCol = ref(1)
 const selectionLength = ref(0)
 const totalLines = ref(1)
 
-// Go-to-Line
 const isGoToLineActive = ref(false)
 const goToLineInput = ref(``)
 const goToLineRef = ref<HTMLInputElement | null>(null)
@@ -127,10 +125,8 @@ function cancelGoToLine() {
   editor.value?.focus()
 }
 
-// 监听编辑器变化，更新光标位置
 const attachedViews = new WeakSet()
 
-// 大纲 & 面包屑
 const breadcrumbs = ref<MarkdownHeading[]>([])
 const allHeadings = ref<MarkdownHeading[]>([])
 
@@ -155,7 +151,6 @@ watch(editor, (view) => {
 
   attachedViews.add(view)
 
-  // 初始化一次
   updateCursorInfo(view as EditorView, { rebuildHeadings: true })
 
   const extension = EditorView.updateListener.of((update) => {
@@ -172,7 +167,6 @@ watch(editor, (view) => {
   })
 }, { immediate: true })
 
-// 切换文章时立即刷新光标及统计信息
 watch(currentPost, () => {
   nextTick(() => {
     if (editor.value) {
@@ -211,7 +205,6 @@ watch(() => uiStore.goToLineRequest, () => {
   openGoToLine()
 })
 
-// 上次保存时间
 const savedTimeAgo = computed(() => {
   void locale.value
   if (!currentPost.value?.updateDatetime)
@@ -219,7 +212,7 @@ const savedTimeAgo = computed(() => {
   return formatRelativeTime(currentPost.value.updateDatetime)
 })
 
-// 每 10 秒刷新一次相对时间（页面不可见时暂停）
+// Refresh relative time every 10s (paused when page hidden)
 const refreshKey = ref(0)
 const REFRESH_INTERVAL_MS = 10_000
 let refreshTimer: ReturnType<typeof setInterval> | null = null
@@ -238,7 +231,7 @@ onUnmounted(() => {
     clearInterval(refreshTimer)
 })
 
-// 强制 computed 依赖 refreshKey 与 locale
+// Force computed to depend on refreshKey and locale
 const displaySavedTime = computed(() => {
   // eslint-disable-next-line ts/no-unused-expressions
   refreshKey.value
@@ -246,7 +239,6 @@ const displaySavedTime = computed(() => {
   return savedTimeAgo.value
 })
 
-// 右侧统计项
 const stats = computed(() => [
   { icon: Pilcrow, value: readingTime.value.words, tooltip: t(`footer.wordCount`) },
   { icon: Type, value: readingTime.value.chars, tooltip: t(`footer.charCount`) },
@@ -263,7 +255,7 @@ const viewModes = computed(() =>
   isMobile.value ? allViewModes.value.filter(m => m.key !== `split`) : allViewModes.value,
 )
 
-// 是否显示设备切换（双屏/预览模式 + 非真实移动端）
+// Show device toggle in split/preview mode on non-mobile
 const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.value)
 </script>
 
@@ -272,9 +264,7 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
     class="flex select-none items-center overflow-hidden px-3 py-1 text-xs text-muted-foreground max-md:px-4 max-md:py-1.5 max-md:pb-[max(0.375rem,env(safe-area-inset-bottom,0px))]"
   >
     <TooltipProvider :delay-duration="300">
-      <!-- 左侧：光标位置 & 选区 -->
       <div class="flex shrink-0 items-center gap-2 sm:gap-3">
-        <!-- Go-to-Line 内联输入 -->
         <span v-if="isGoToLineActive" class="flex items-center gap-1">
           <Keyboard class="size-3 opacity-60" />
           <input
@@ -310,13 +300,11 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
         </span>
       </div>
 
-      <!-- 文档切换器 -->
       <FooterDocumentSwitcher
         :current-title="currentPost?.title"
         @select="switchToPost"
       />
 
-      <!-- 大纲视图 -->
       <FooterOutlinePopover
         :breadcrumbs="breadcrumbs"
         :headings="allHeadings"
@@ -325,12 +313,9 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
         @dismiss="onOutlineDismiss"
       />
 
-      <!-- 桌面端占位 flex-1 -->
       <div class="hidden min-w-0 flex-1 sm:block" />
 
-      <!-- 右侧：统计信息 -->
       <div class="ml-auto flex shrink-0 items-center gap-2.5 sm:gap-3.5">
-        <!-- 视图模式切换 -->
         <div class="flex items-center gap-0.5 rounded-md border border-border/60 p-0.5">
           <Tooltip v-for="mode in viewModes" :key="mode.key">
             <TooltipTrigger as-child>
@@ -351,7 +336,6 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
           </Tooltip>
         </div>
 
-        <!-- 设备切换（双屏/预览下可用，真实移动端隐藏） -->
         <Tooltip v-if="!isMobile">
           <TooltipTrigger as-child>
             <button
@@ -371,7 +355,6 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
           </TooltipContent>
         </Tooltip>
 
-        <!-- 同步滚动（双屏模式下可用，真实移动端隐藏） -->
         <Tooltip v-if="!isMobile && viewMode === 'split'">
           <TooltipTrigger as-child>
             <button
@@ -392,7 +375,6 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
         <span class="hidden text-border sm:block">·</span>
 
-        <!-- 保存状态（小屏隐藏） -->
         <Tooltip v-if="displaySavedTime">
           <TooltipTrigger as-child>
             <span class="hidden cursor-default items-center gap-1 opacity-70 transition-opacity hover:opacity-100 sm:flex">
@@ -407,7 +389,6 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
         <span class="hidden text-border sm:block">·</span>
 
-        <!-- 统计项（小屏隐藏） -->
         <Tooltip v-for="stat in stats" :key="stat.tooltip">
           <TooltipTrigger as-child>
             <span class="hidden cursor-default items-center gap-1 tabular-nums sm:flex">
@@ -422,7 +403,6 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
 
         <span class="hidden text-border sm:block">·</span>
 
-        <!-- 账户 & 同步 & 分享 & 主题（桌面端） -->
         <div class="hidden items-center gap-0.5 sm:flex">
           <template v-if="showAccountUi">
             <Tooltip>
@@ -522,7 +502,6 @@ const showDeviceToggle = computed(() => viewMode.value !== `edit` && !isMobile.v
           </Tooltip>
         </div>
 
-        <!-- 移动端：更多操作 -->
         <Popover v-model:open="isMoreOpen">
           <PopoverTriggerPrimitive as-child>
             <button

--- a/apps/web/src/components/editor/PreviewPanel.vue
+++ b/apps/web/src/components/editor/PreviewPanel.vue
@@ -244,7 +244,6 @@ defineExpose({
   opacity: 0.7;
 }
 
-/* Dark mode */
 .output_night .diagram-download-btn {
   background: rgba(30, 32, 38, 0.88);
   border-color: rgba(255, 255, 255, 0.1);

--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -39,29 +39,26 @@ const {
 
 const { scheduleEditorRefresh, editorRefresh } = useEditorRefresh()
 
-// 标题样式选择器状态
 const selectedHeadingLevel = ref<HeadingLevel>(`h2`)
 const selectedHeadingStyle = computed({
   get: () => themeStore.getHeadingStyle(selectedHeadingLevel.value),
   set: (val: HeadingStyleType) => {
     themeStore.setHeadingStyle(selectedHeadingLevel.value, val)
     if (val === `custom`) {
-      // 打开 CSS 编辑器并滚动到对应标题区域
       uiStore.isShowCssEditor = true
-      // 等待 CSS 编辑器打开后再滚动
       nextTick(() => {
         setTimeout(() => {
           cssEditorStore.scrollToHeading(selectedHeadingLevel.value)
         }, 100)
       })
     }
-    // 无论选择预设还是自定义，都立即应用主题，确保标题样式及时恢复/更新
+    // Apply theme immediately for preset or custom to restore heading styles
     themeStore.applyCurrentTheme()
     scheduleEditorRefresh()
   },
 })
 
-// reka-ui SelectValue 默认缓存选项 textContent，语言切换时需显式渲染本地化标签
+// reka-ui SelectValue caches textContent; re-render localized labels on locale change
 const selectedHeadingStyleLabel = computed(() =>
   localizedStyleOptions.value.headingStyleOptions
     .find(option => option.value === selectedHeadingStyle.value)
@@ -70,31 +67,30 @@ const selectedHeadingStyleLabel = computed(() =>
 
 const { isMobile, isOpenRightSlider, isDark } = storeToRefs(uiStore)
 
-// Theme change handlers
 function themeChanged(newTheme: keyof typeof themeMap) {
   themeStore.theme = newTheme
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
 }
 
 function fontChanged(fonts: string) {
   themeStore.fontFamily = fonts
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
 }
 
 function sizeChanged(size: string) {
   themeStore.fontSize = size
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
 }
 
 function colorChanged(newColor: string) {
   themeStore.primaryColor = newColor
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
 }
@@ -128,14 +124,14 @@ function citeStatusChanged() {
 
 function useIndentChanged() {
   themeStore.isUseIndent = !themeStore.isUseIndent
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
 }
 
 function useJustifyChanged() {
   themeStore.isUseJustify = !themeStore.isUseJustify
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
 }
@@ -189,18 +185,14 @@ function resetStyleConfirm() {
   })
 }
 
-// 控制是否启用动画
 const enableAnimation = ref(false)
 
-// 监听 RightSlider 开关状态变化
 watch(isOpenRightSlider, () => {
   if (isMobile.value) {
-    // 在移动端，用户操作时启用动画
     enableAnimation.value = true
   }
 })
 
-// 监听设备类型变化，重置动画状态
 watch(isMobile, () => {
   enableAnimation.value = false
 })
@@ -209,14 +201,13 @@ const pickColorsContainer = useTemplateRef<HTMLElement | undefined>(`pickColorsC
 const format = ref<Format>(`rgb`)
 const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
 
-// 右侧栏收窄时，主题色只显示色块
+// Show color swatch only when right sidebar is narrow
 const colorGridRef = useTemplateRef<HTMLElement | undefined>(`colorGridRef`)
 const { width: colorGridWidth } = useElementSize(colorGridRef)
 const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth.value < 280)
 </script>
 
 <template>
-  <!-- 移动端遮罩层 -->
   <div
     v-if="isMobile && isOpenRightSlider"
     class="fixed inset-0 bg-black/50 z-40"
@@ -235,7 +226,6 @@ const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth
       class="h-full space-y-4 overflow-auto p-4"
       :class="{ 'pt-0': isMobile }"
     >
-      <!-- 移动端标题栏 -->
       <div v-if="isMobile" class="sticky top-0 z-10 -mx-4 mb-4 border-b bg-background px-4 pb-3 pt-[max(0.5rem,env(safe-area-inset-top,0px))]">
         <div aria-hidden="true" class="mx-auto mb-2 h-1 w-10 rounded-full bg-muted-foreground/25" />
         <div class="flex items-center justify-between">
@@ -428,7 +418,6 @@ const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth
 </template>
 
 <style scoped>
-/* 移动端右侧栏动画 - 只有添加了 animate 类才启用 */
 .mobile-right-drawer.animate {
   transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
 }

--- a/apps/web/src/components/editor/SlashCommandMenu.vue
+++ b/apps/web/src/components/editor/SlashCommandMenu.vue
@@ -239,7 +239,6 @@ onUnmounted(() => {
       @contextmenu.capture.prevent.stop
     >
       <div class="slash-scroll-wrap">
-        <!-- 搜索模式：统一列表 -->
         <div
           v-if="isFiltering"
           ref="scrollRef"
@@ -282,7 +281,6 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- 默认模式：分区紧凑布局 -->
         <div
           v-else
           ref="scrollRef"

--- a/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentDialog.vue
@@ -22,9 +22,6 @@ const uiStore = useUIStore()
 
 const { toggleShowComponentDialog } = uiStore
 
-// ──────────────────────────────────────────────
-// 表单状态
-// ──────────────────────────────────────────────
 const isShowForm = ref(false)
 const formMode = ref<'create' | 'edit'>('create')
 const editingId = ref('')
@@ -58,9 +55,6 @@ function onFormCancel() {
   isShowForm.value = false
 }
 
-// ──────────────────────────────────────────────
-// 导入 / 导出
-// ──────────────────────────────────────────────
 function exportComponents() {
   const data = JSON.stringify(componentStore.userComponents, null, 2)
   const blob = new Blob([data], { type: 'application/json' })
@@ -117,16 +111,12 @@ function onImportFile(event: Event) {
     catch {
       toast.error(t('component.importFailed'))
     }
-    // reset input so the same file can be re-imported
     if (importFileRef.value)
       importFileRef.value.value = ''
   }
   reader.readAsText(file)
 }
 
-// ──────────────────────────────────────────────
-// 列表操作
-// ──────────────────────────────────────────────
 function insertSnippet(def: CustomComponentDef) {
   const snippet = def.example || componentStore.buildSnippet(def.builtIn ? findBuiltinDef(def.id) ?? def : def)
   editorStore.insertAtCursor(snippet)
@@ -149,9 +139,6 @@ function onUpdate(val: boolean) {
   }
 }
 
-// ──────────────────────────────────────────────
-// 展开/折叠详情
-// ──────────────────────────────────────────────
 const activeComponentTab = ref<'builtin' | 'custom'>('builtin')
 const expandedId = ref<string | null>(null)
 
@@ -163,9 +150,6 @@ function toggleExpand(id: string) {
   expandedId.value = expandedId.value === id ? null : id
 }
 
-// ──────────────────────────────────────────────
-// 复制代码片段
-// ──────────────────────────────────────────────
 const copiedId = ref<string | null>(null)
 
 function findBuiltinDef(id: string) {
@@ -184,7 +168,6 @@ async function copySnippet(def: CustomComponentDef) {
   }
 }
 
-// 类型颜色标签
 function propTypeBadge(prop: ComponentPropDef) {
   if (prop.required)
     return { label: t('component.required'), class: 'bg-red-50 text-red-600 border-red-200' }
@@ -193,9 +176,7 @@ function propTypeBadge(prop: ComponentPropDef) {
   return { label: t('component.optional'), class: 'bg-muted text-muted-foreground border-border' }
 }
 
-// ──────────────────────────────────────────────
-// MpProfile 公众号名片集成
-// ──────────────────────────────────────────────
+// MpProfile WeChat card integration
 const isShowMpAccountConfig = ref(false)
 const editingMpAccountId = ref<string | null>(null)
 
@@ -245,7 +226,6 @@ function deleteMpAccount(account: MpAccount) {
   })
 }
 
-// 当对话框打开且携带 target 时，自动展开对应的内置组件
 watch(() => uiStore.isShowComponentDialog, (val) => {
   if (val && uiStore.componentDialogTarget) {
     const target = uiStore.componentDialogTarget
@@ -277,7 +257,6 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
       </DialogHeader>
 
       <div class="flex-1 overflow-y-auto px-4 sm:px-6 py-4 space-y-6">
-        <!-- ─── 新建/编辑表单 ─── -->
         <CustomComponentForm
           v-if="isShowForm"
           :mode="formMode"
@@ -286,7 +265,6 @@ watch(() => uiStore.isShowComponentDialog, (val) => {
           @cancel="onFormCancel"
         />
 
-        <!-- ─── 组件列表 ─── -->
         <div v-if="!isShowForm">
           <Tabs v-model="activeComponentTab" class="w-full">
             <TabsList class="grid w-full grid-cols-2">

--- a/apps/web/src/components/editor/dialogs/CustomComponentForm.vue
+++ b/apps/web/src/components/editor/dialogs/CustomComponentForm.vue
@@ -187,7 +187,6 @@ function getPropDefaultPlaceholder(type: string): string {
       {{ mode === 'create' ? t('component.create') : t('component.edit') }}
     </h3>
 
-    <!-- 组件名称 -->
     <div class="space-y-1.5">
       <Label for="comp-name">
         {{ t('component.nameLabel') }}
@@ -205,7 +204,6 @@ function getPropDefaultPlaceholder(type: string): string {
       </p>
     </div>
 
-    <!-- 组件描述 -->
     <div class="space-y-1.5">
       <Label for="comp-desc">{{ t('component.descLabel') }}</Label>
       <Input
@@ -215,7 +213,6 @@ function getPropDefaultPlaceholder(type: string): string {
       />
     </div>
 
-    <!-- Props 定义 -->
     <div class="space-y-2">
       <div class="flex items-center justify-between">
         <Label>{{ t('component.propsLabel') }}</Label>
@@ -225,7 +222,6 @@ function getPropDefaultPlaceholder(type: string): string {
         </Button>
       </div>
       <template v-if="propRows.length > 0">
-        <!-- 桌面端：网格表头 -->
         <div class="hidden sm:grid grid-cols-13 gap-2 px-1">
           <span class="col-span-3 text-xs text-muted-foreground">{{ t('component.propName') }}</span>
           <span class="col-span-2 text-xs text-muted-foreground">{{ t('component.propType') }}</span>
@@ -299,7 +295,6 @@ function getPropDefaultPlaceholder(type: string): string {
       </p>
     </div>
 
-    <!-- HTML 模板 -->
     <div class="space-y-1.5">
       <Label for="comp-template">
         {{ t('component.htmlTemplate') }}
@@ -323,7 +318,6 @@ function getPropDefaultPlaceholder(type: string): string {
       </div>
     </div>
 
-    <!-- 实时预览 -->
     <div v-if="formData.template.trim()" class="space-y-1.5">
       <div class="flex items-center justify-between">
         <Label class="text-muted-foreground">{{ t('component.previewLabel') }}</Label>

--- a/apps/web/src/components/editor/dialogs/EditorStateDialog.vue
+++ b/apps/web/src/components/editor/dialogs/EditorStateDialog.vue
@@ -49,7 +49,6 @@ const tabs = computed(() => [
   { value: `export`, label: t('editorState.exportTab') },
 ] as const)
 
-// 使用响应式对象存储状态和选中状态
 const storeStates = ref<{
   data: Record<string, any>
   selected: Record<string, boolean>
@@ -58,16 +57,13 @@ const storeStates = ref<{
   selected: {},
 })
 
-// 获取状态并初始化选中状态
 function getAllStoreStates() {
   return {
-    // UI store 的状态
     isDark: uiStore.isDark,
     isOpenRightSlider: uiStore.isOpenRightSlider,
     isOpenPostSlider: uiStore.isOpenPostSlider,
     showAIToolbox: uiStore.showAIToolbox,
 
-    // Theme store 的状态
     theme: themeStore.theme,
     fontFamily: themeStore.fontFamily,
     fontSize: themeStore.fontSize,
@@ -81,19 +77,15 @@ function getAllStoreStates() {
     isUseIndent: themeStore.isUseIndent,
     isUseJustify: themeStore.isUseJustify,
 
-    // Post store 的状态
     currentPostId: postStore.currentPostId,
     currentPostIndex: postStore.currentPostIndex,
     posts: postStore.posts,
 
-    // CSS Editor store 的状态
     cssContentConfig: cssEditorStore.cssContentConfig,
 
-    // Render store 的状态
     titleList: renderStore.titleList,
     readingTime: renderStore.readingTime,
 
-    // Display store 的状态
     isShowCssEditor: uiStore.isShowCssEditor,
     isShowInsertFormDialog: uiStore.isShowInsertFormDialog,
     isShowUploadImgDialog: uiStore.isShowUploadImgDialog,
@@ -108,7 +100,7 @@ async function fetchStoreStates() {
     storeStates.value = {
       data: states,
       selected: Object.keys(states).reduce((acc, key) => {
-        acc[key] = true // 默认全部选中
+        acc[key] = true
         return acc
       }, {} as Record<string, boolean>),
     }
@@ -117,7 +109,6 @@ async function fetchStoreStates() {
   }
 }
 
-// 计算属性：根据选中状态过滤后的JSON
 const filteredExportJSON = computed(() => {
   if (!storeStates.value.data)
     return {}
@@ -130,7 +121,6 @@ const filteredExportJSON = computed(() => {
   }, {} as Record<string, any>)
 })
 
-// 导入的配置数据
 const importStates = ref<{
   data: Record<string, any>
   selected: Record<string, boolean>
@@ -167,7 +157,6 @@ function exportSelectedConfig() {
   dialogOpen.value = false
 }
 
-// 处理最大化弹窗预览代码
 const isMaximized = ref(false)
 const currentMaximizedJSON = computed(() => {
   if (activeName.value === `export`) {
@@ -194,7 +183,6 @@ async function copyToClipboard(text: string) {
   }
 }
 
-// 处理文件导入
 const fileInputRef = ref<HTMLInputElement | null>(null)
 
 function triggerFileInput() {
@@ -213,13 +201,12 @@ function handleFileImport(event: Event) {
     try {
       const content = e.target?.result as string
       const importedData = JSON.parse(content) as Record<string, any>
-      // 检查导入的数据是否符合预期
+
       if (typeof importedData !== `object` || Array.isArray(importedData)) {
         toast.error(t('editorState.importFormatError'))
         return
       }
 
-      // 过滤导入的数据项，只接受允许的项，与getLable函数对应
       const allowedKeys = Object.keys(storeStates.value.data).concat(Object.keys(importStates.value.data))
       const filteredData = Object.keys(importedData).reduce((acc, key) => {
         if (allowedKeys.includes(key)) {
@@ -227,17 +214,17 @@ function handleFileImport(event: Event) {
         }
         return acc
       }, {} as Record<string, any>)
-      // 检查导入的数据是否符合预期
+
       if (Object.keys(filteredData).length === 0) {
         toast.error(t('editorState.importNoApplicable'))
         return
       }
 
-      originalImportData.value = importedData // 保存原始导入数据
+      originalImportData.value = importedData
       importStates.value = {
         data: importedData,
         selected: Object.keys(importedData).reduce((acc, key) => {
-          acc[key] = true // 默认全部选中
+          acc[key] = true
           return acc
         }, {} as Record<string, boolean>),
       }
@@ -249,10 +236,9 @@ function handleFileImport(event: Event) {
   }
 
   reader.readAsText(file)
-  input.value = `` // 重置input，允许重复选择同一文件
+  input.value = ``
 }
 
-// 应用导入的配置
 function applyImportedConfig() {
   if (!filteredImportJSON.value)
     return
@@ -261,7 +247,6 @@ function applyImportedConfig() {
     if (importStates.value.selected[key] && importStates.value.data?.[key] !== undefined) {
       const value = importStates.value.data[key]
 
-      // UI store 的状态
       if (key === `isDark`)
         uiStore.isDark = value
       else if (key === `isOpenRightSlider`)
@@ -271,7 +256,6 @@ function applyImportedConfig() {
       else if (key === `showAIToolbox`)
         uiStore.showAIToolbox = value
 
-      // Theme store 的状态
       else if (key === `theme`)
         themeStore.theme = value
       else if (key === `fontFamily`)
@@ -297,7 +281,6 @@ function applyImportedConfig() {
       else if (key === `isUseJustify`)
         themeStore.isUseJustify = value
 
-      // Post store 的状态
       else if (key === `currentPostId`)
         postStore.currentPostId = value
       else if (key === `currentPostIndex`)
@@ -305,17 +288,14 @@ function applyImportedConfig() {
       else if (key === `posts`)
         postStore.replacePosts(value)
 
-      // CSS Editor store 的状态
       else if (key === `cssContentConfig`)
         cssEditorStore.cssContentConfig = value
 
-      // Render store 的状态
       else if (key === `titleList`)
         renderStore.titleList = value
       else if (key === `readingTime`)
         renderStore.readingTime = value
 
-      // Display store 的状态
       else if (key === `isShowCssEditor`)
         uiStore.isShowCssEditor = value
       else if (key === `isShowInsertFormDialog`)

--- a/apps/web/src/components/editor/dialogs/ImportMarkdownDialog.vue
+++ b/apps/web/src/components/editor/dialogs/ImportMarkdownDialog.vue
@@ -9,13 +9,11 @@ const uiStore = useUIStore()
 
 const { isShowImportMdDialog } = storeToRefs(uiStore)
 
-// 当前选中的 tab
 const activeTab = ref<'url' | 'file'>(`file`)
 
-// ==================== 检测本地图片路径 ====================
 /**
- * 从 Markdown 内容中检测本地图片路径
- * 排除 http/https URL、data URI 和空路径
+ * Detect local image paths in Markdown content
+ * Exclude http/https URLs, data URIs, and empty paths
  */
 function detectLocalImagePaths(content: string): string[] {
   const regex = /!\[[^\]]*\]\((?!https?:\/\/|data:)([^)]+)\)/g
@@ -32,26 +30,23 @@ function detectLocalImagePaths(content: string): string[] {
 }
 
 /**
- * 导入内容，如果包含本地图片则弹出上传对话框
+ * Import content; open upload dialog when local images are present
  */
 async function importContent(title: string, content: string) {
   const localPaths = detectLocalImagePaths(content)
   if (localPaths.length === 0) {
-    // 没有本地图片，直接导入
     postStore.addPost(title)
     postStore.updatePostContent(postStore.currentPostId, content)
     closeDialog()
     return
   }
 
-  // 有本地图片，弹出上传对话框
   uiStore.localImageUploadData = {
     markdownContent: content,
     detectedPaths: localPaths,
   }
   uiStore.isShowLocalImageUpload = true
 
-  // 等待上传对话框处理完成
   await new Promise<void>((resolve) => {
     const unwatch = watch(
       () => uiStore.localImageUploadData,
@@ -59,12 +54,10 @@ async function importContent(title: string, content: string) {
         if (data && data.processed) {
           unwatch()
           if (data.skipUpload) {
-            // 用户选择跳过，按原样导入
             postStore.addPost(title)
             postStore.updatePostContent(postStore.currentPostId, content)
           }
           else {
-            // 用户已上传并应用，使用替换后的内容
             postStore.addPost(title)
             postStore.updatePostContent(postStore.currentPostId, data!.markdownContent)
           }
@@ -75,11 +68,9 @@ async function importContent(title: string, content: string) {
     )
   })
 
-  // 清理
   uiStore.localImageUploadData = null
 }
 
-// ==================== 网络链接导入 ====================
 const url = ref(``)
 const isUrlLoading = ref(false)
 const urlError = ref(``)
@@ -87,7 +78,7 @@ let abortController: AbortController | null = null
 
 const ANYTHING_MD_API = `https://anything-md.doocs.org/`
 
-/** 判断链接是否直接指向 Markdown 文件 */
+/** Whether the URL points directly to a Markdown file */
 function isMarkdownUrl(rawUrl: string): boolean {
   try {
     const { pathname } = new URL(rawUrl)
@@ -98,7 +89,7 @@ function isMarkdownUrl(rawUrl: string): boolean {
   }
 }
 
-/** 直接获取 Markdown 文件内容 */
+/** Fetch Markdown file content directly */
 async function fetchMarkdownFile(rawUrl: string, signal: AbortSignal): Promise<string> {
   const response = await fetch(rawUrl, { signal })
   if (!response.ok) {
@@ -111,7 +102,7 @@ async function fetchMarkdownFile(rawUrl: string, signal: AbortSignal): Promise<s
   return content
 }
 
-/** 通过 Anything-MD 将网页转换为 Markdown */
+/** Convert web page to Markdown via Anything-MD */
 async function fetchViaAnythingMd(rawUrl: string, signal: AbortSignal): Promise<string> {
   const response = await fetch(ANYTHING_MD_API, {
     method: `POST`,
@@ -162,7 +153,6 @@ async function importFromUrl() {
       ? await fetchMarkdownFile(rawUrl, signal)
       : await fetchViaAnythingMd(rawUrl, signal)
 
-    // 从 URL 中提取标题
     const urlTitle = (() => {
       try {
         const { pathname } = new URL(rawUrl)
@@ -185,7 +175,6 @@ async function importFromUrl() {
   }
 }
 
-// ==================== 本地文件导入 ====================
 const isDragover = ref(false)
 const { open: openFileDialog, reset: resetFileDialog, onChange: onFileChange } = useFileDialog({
   accept: `.md,.markdown,.txt`,
@@ -248,7 +237,6 @@ async function readAndImportFiles(files: File[]) {
   }
 }
 
-// ==================== 对话框控制 ====================
 function closeDialog() {
   abortController?.abort()
   abortController = null
@@ -266,7 +254,6 @@ function onOpenChange(val: boolean) {
   }
 }
 
-// URL 参数 open 传入的链接：打开对话框时自动填入并执行导入
 watch(isShowImportMdDialog, (visible) => {
   if (!visible || !uiStore.importMdOpenUrl)
     return
@@ -305,7 +292,6 @@ watch(isShowImportMdDialog, (visible) => {
           </TabsTrigger>
         </TabsList>
 
-        <!-- 本地文件导入 -->
         <TabsContent value="file" class="mt-4">
           <div
             class="relative flex h-40 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed transition-colors"
@@ -328,7 +314,6 @@ watch(isShowImportMdDialog, (visible) => {
           </div>
         </TabsContent>
 
-        <!-- 网络链接导入 -->
         <TabsContent value="url" class="mt-4">
           <div class="space-y-4">
             <div class="space-y-2">

--- a/apps/web/src/components/editor/dialogs/InsertFormDialog.vue
+++ b/apps/web/src/components/editor/dialogs/InsertFormDialog.vue
@@ -20,7 +20,6 @@ function resetVal() {
   tableData.value = {}
 }
 
-// 插入表格
 function insertTable() {
   const table = createTable({
     rows: rowNum.value,

--- a/apps/web/src/components/editor/dialogs/LocalImageUploadDialog.vue
+++ b/apps/web/src/components/editor/dialogs/LocalImageUploadDialog.vue
@@ -16,7 +16,7 @@ const { t } = useI18n()
 const uiStore = useUIStore()
 const { upload } = useImageUploader()
 
-// 批次上传状态（覆盖整个上传循环）
+// Batch upload state (covers the entire upload loop)
 const isUploading = ref(false)
 
 const isDialogOpen = computed({
@@ -26,18 +26,14 @@ const isDialogOpen = computed({
   },
 })
 
-// 用户勾选要上传的路径
 const selectedPaths = ref<Set<string>>(new Set())
 
-// 上传进度
 const progressValue = ref(0)
 const uploadResults = ref<Record<string, string>>({})
 const uploadErrors = ref<Record<string, string>>({})
 
-// 用户选择的文件夹中的文件列表
 const folderFiles = ref<File[]>([])
 
-// 匹配状态
 const matchedCount = computed(() => {
   let count = 0
   for (const path of selectedPaths.value) {
@@ -47,12 +43,10 @@ const matchedCount = computed(() => {
   return count
 })
 
-// 是否已有上传结果（成功或失败）
 const hasUploadAttempt = computed(() =>
   Object.keys(uploadResults.value).length > 0 || Object.keys(uploadErrors.value).length > 0,
 )
 
-// 是否全部上传成功（选中的图片都有结果且无报错）
 const isAllUploaded = computed(() => {
   const paths = Array.from(selectedPaths.value)
   return paths.length > 0 && paths.every(p => uploadResults.value[p] && !uploadErrors.value[p])
@@ -68,7 +62,6 @@ watch(() => uiStore.localImageUploadData, (data) => {
   }
 }, { immediate: true })
 
-// 选择包含图片的文件夹
 function handleFolderSelect(event: Event) {
   const files = (event.target as HTMLInputElement).files
   if (!files || files.length === 0)
@@ -76,7 +69,6 @@ function handleFolderSelect(event: Event) {
 
   folderFiles.value = Array.from(files)
 
-  // 自动选中已匹配的路径
   for (const path of selectedPaths.value) {
     if (!findMatchedFile(path)) {
       selectedPaths.value.delete(path)
@@ -88,23 +80,22 @@ function handleFolderSelect(event: Event) {
     }
   }
 
-  // 重置 input
   ;(event.target as HTMLInputElement).value = ''
 }
 
 /**
- * 根据路径从文件夹文件中查找匹配的文件
+ * Find a matching file in the folder for a path
  */
 function findMatchedFile(path: string): File | undefined {
   const pathFileName = path.split(/[/\\]/).pop()!.toLowerCase()
   const fileArray = folderFiles.value
 
-  // 第一轮：精确匹配文件名
+  // Round 1: exact filename match
   for (const file of fileArray) {
     if (file.name.toLowerCase() === pathFileName)
       return file
   }
-  // 第二轮：去扩展名匹配
+  // Round 2: match without extension
   const pathBase = pathFileName.replace(/\.[^.]+$/, '')
   for (const file of fileArray) {
     const fileBase = file.name.toLowerCase().replace(/\.[^.]+$/, '')
@@ -114,7 +105,6 @@ function findMatchedFile(path: string): File | undefined {
   return undefined
 }
 
-// 开始上传
 async function handleUpload() {
   if (!uiStore.localImageUploadData)
     return
@@ -126,7 +116,6 @@ async function handleUpload() {
     return
   }
 
-  // 检查未匹配的
   const unmatched = pathsToUpload.filter(p => !findMatchedFile(p))
   if (unmatched.length > 0) {
     toast.error(t('localImage.notFoundInFolder', { paths: unmatched.join(', ') }))
@@ -138,7 +127,7 @@ async function handleUpload() {
   uploadErrors.value = {}
   isUploading.value = true
 
-  // 文件 → URL 缓存，避免同文件重复上传
+  // File-to-URL cache to avoid re-uploading the same file
   const fileUrlMap = new WeakMap<File, string>()
 
   for (let i = 0; i < pathsToUpload.length; i++) {
@@ -160,12 +149,11 @@ async function handleUpload() {
   isUploading.value = false
 }
 
-// 关闭并应用
 function handleApply() {
   if (!uiStore.localImageUploadData)
     return
 
-  // 仅替换图片语法 `![alt](path)` 中的路径为上传后的 URL
+  // Replace only image syntax `![alt](path)` paths with uploaded URLs
   let content = uiStore.localImageUploadData.markdownContent
   for (const [path, url] of Object.entries(uploadResults.value)) {
     const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -182,7 +170,6 @@ function handleApply() {
   isDialogOpen.value = false
 }
 
-// 关闭并跳过上传
 function handleSkip() {
   if (uiStore.localImageUploadData) {
     uiStore.localImageUploadData = {
@@ -213,7 +200,6 @@ function onOpenChange(val: boolean) {
       </DialogHeader>
 
       <div v-if="uiStore.localImageUploadData" class="space-y-4">
-        <!-- 图片路径列表 -->
         <div class="rounded-md border">
           <div class="flex items-center justify-between border-b px-4 py-2">
             <span class="text-sm font-medium">
@@ -252,10 +238,8 @@ function onOpenChange(val: boolean) {
           </div>
         </div>
 
-        <!-- 进度条 -->
         <Progress v-if="isUploading || progressValue > 0" :model-value="progressValue" class="h-1.5" />
 
-        <!-- 选择文件夹按钮 -->
         <label v-if="!isAllUploaded" class="block">
           <input
             type="file"
@@ -271,7 +255,6 @@ function onOpenChange(val: boolean) {
           </Button>
         </label>
 
-        <!-- 底部操作区 -->
         <div v-if="isAllUploaded" class="flex justify-end pt-2">
           <Button @click="handleApply">
             {{ t('common.done') }}

--- a/apps/web/src/components/editor/dialogs/MpAccountConfigDialog.vue
+++ b/apps/web/src/components/editor/dialogs/MpAccountConfigDialog.vue
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 
 const props = defineProps<{
   open: boolean
-  /** null = 新建，string = 编辑指定账号 */
+  /** null = create; string = edit account id */
   accountId: string | null
 }>()
 
@@ -27,7 +27,7 @@ const editingAccount = computed<MpAccount | null>(() => {
   return (mpAccountsStore.accounts as MpAccount[]).find(a => a.id === props.accountId) ?? null
 })
 
-/** key 变化时 vee-validate Form 重新初始化 */
+/** Re-init vee-validate Form when key changes */
 const formKey = computed(() => `${props.accountId ?? `new`}-${props.open}`)
 
 const initialValues = computed(() => {

--- a/apps/web/src/components/editor/dialogs/TemplateDialog.vue
+++ b/apps/web/src/components/editor/dialogs/TemplateDialog.vue
@@ -16,32 +16,26 @@ const uiStore = useUIStore()
 
 const { toggleShowTemplateDialog } = uiStore
 
-// 搜索关键词
 const searchKeyword = ref('')
 
-// 搜索结果
 const filteredTemplates = computed(() => {
   return templateStore.searchTemplates(searchKeyword.value)
 })
 
-// 是否显示新建/编辑模板表单
 const isShowForm = ref(false)
 const formMode = ref<'create' | 'edit'>('create')
 const editingTemplateId = ref<string>('')
 
-// 表单数据
 const formData = reactive({
   name: '',
   description: '',
   content: '',
 })
 
-// 表单验证错误
 const formErrors = reactive({
   name: '',
 })
 
-// 打开创建模板表单
 function openCreateForm() {
   formMode.value = 'create'
   formData.name = ''
@@ -51,7 +45,6 @@ function openCreateForm() {
   isShowForm.value = true
 }
 
-// 打开编辑模板表单
 function openEditForm(template: Template) {
   formMode.value = 'edit'
   editingTemplateId.value = template.id
@@ -62,7 +55,6 @@ function openEditForm(template: Template) {
   isShowForm.value = true
 }
 
-// 验证表单
 function validateForm(): boolean {
   formErrors.name = ''
 
@@ -79,7 +71,6 @@ function validateForm(): boolean {
   return true
 }
 
-// 保存模板
 function saveTemplate() {
   if (!validateForm())
     return
@@ -102,12 +93,10 @@ function saveTemplate() {
   isShowForm.value = false
 }
 
-// 取消表单
 function cancelForm() {
   isShowForm.value = false
 }
 
-// 应用模板到当前文章
 function applyTemplate(template: Template) {
   const currentPost = postStore.currentPost
   if (currentPost) {
@@ -122,7 +111,6 @@ function applyTemplate(template: Template) {
   toggleShowTemplateDialog(false)
 }
 
-// 在光标位置插入模板
 function insertTemplate(template: Template) {
   editorStore.insertAtCursor(template.content)
 
@@ -135,7 +123,6 @@ function insertTemplate(template: Template) {
   toggleShowTemplateDialog(false)
 }
 
-// 打开删除确认对话框
 function openDeleteConfirm(template: Template) {
   confirmStore.confirm({
     title: t('template.confirmDelete'),
@@ -144,7 +131,6 @@ function openDeleteConfirm(template: Template) {
   })
 }
 
-// 格式化日期
 function formatDate(timestamp: number): string {
   const date = new Date(timestamp)
   return date.toLocaleString(locale.value, {
@@ -156,7 +142,6 @@ function formatDate(timestamp: number): string {
   })
 }
 
-// 对话框关闭回调
 function onUpdate(val: boolean) {
   if (!val) {
     toggleShowTemplateDialog(false)
@@ -178,9 +163,7 @@ function onUpdate(val: boolean) {
         </DialogDescription>
       </DialogHeader>
 
-      <!-- 主体内容区域 -->
       <div class="flex-1 overflow-auto px-6 py-4">
-        <!-- 新建/编辑表单 -->
         <div v-if="isShowForm" class="space-y-4 mb-6 p-4 border rounded-lg bg-muted/30">
           <div class="flex items-center justify-between">
             <h3 class="text-lg font-semibold">
@@ -189,7 +172,6 @@ function onUpdate(val: boolean) {
           </div>
 
           <div class="space-y-4">
-            <!-- 模板名称 -->
             <div class="space-y-2">
               <Label for="template-name">{{ t('template.nameLabel') }}</Label>
               <Input
@@ -203,7 +185,6 @@ function onUpdate(val: boolean) {
               </p>
             </div>
 
-            <!-- 模板描述 -->
             <div class="space-y-2">
               <Label for="template-description">{{ t('template.descLabel') }}</Label>
               <Textarea
@@ -214,7 +195,6 @@ function onUpdate(val: boolean) {
               />
             </div>
 
-            <!-- 模板内容编辑 -->
             <div class="space-y-2">
               <Label for="template-content">{{ t('template.contentLabel') }}</Label>
               <Textarea
@@ -226,7 +206,6 @@ function onUpdate(val: boolean) {
             </div>
           </div>
 
-          <!-- 表单操作按钮 -->
           <div class="flex gap-2 justify-end">
             <Button variant="outline" @click="cancelForm">
               {{ t('common.cancel') }}
@@ -237,7 +216,6 @@ function onUpdate(val: boolean) {
           </div>
         </div>
 
-        <!-- 搜索栏和新建按钮 -->
         <div v-if="!isShowForm" class="flex gap-2 mb-4">
           <div class="relative flex-1">
             <Search class="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
@@ -253,9 +231,7 @@ function onUpdate(val: boolean) {
           </Button>
         </div>
 
-        <!-- 模板列表 -->
         <div v-if="!isShowForm" class="space-y-3">
-          <!-- 空状态 -->
           <div v-if="filteredTemplates.length === 0" class="text-center py-12">
             <Package class="mx-auto size-12 text-muted-foreground mb-4" />
             <p class="text-muted-foreground mb-2">
@@ -266,14 +242,12 @@ function onUpdate(val: boolean) {
             </p>
           </div>
 
-          <!-- 模板卡片列表 -->
           <div
             v-for="template in filteredTemplates"
             :key="template.id"
             class="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
           >
             <div class="flex items-start justify-between gap-4">
-              <!-- 模板信息 -->
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2 mb-2">
                   <FileText class="size-4 text-muted-foreground flex-shrink-0" />
@@ -298,7 +272,6 @@ function onUpdate(val: boolean) {
                 </div>
               </div>
 
-              <!-- 操作按钮 -->
               <div class="flex gap-1 flex-shrink-0">
                 <Button
                   variant="outline"

--- a/apps/web/src/components/editor/dialogs/UploadImgDialog.vue
+++ b/apps/web/src/components/editor/dialogs/UploadImgDialog.vue
@@ -32,7 +32,6 @@ async function githubSubmit(formValues: GenericObject) {
   toast.success(t(`common.saveSuccess`))
 }
 
-// 阿里云
 const aliOSSSchema = computed(() => toTypedSchema(yup.object({
   accessKeyId: yup.string().required(t(`upload.validation.accessKeyIdRequired`)),
   accessKeySecret: yup.string().required(t(`upload.validation.accessKeySecretRequired`)),
@@ -58,7 +57,6 @@ async function aliOSSSubmit(formValues: GenericObject) {
   toast.success(t(`common.saveSuccess`))
 }
 
-// 腾讯云
 const txCOSSchema = computed(() => toTypedSchema(yup.object({
   secretId: yup.string().required(t(`upload.validation.secretIdRequired`)),
   secretKey: yup.string().required(t(`upload.validation.secretKeyRequired`)),
@@ -82,7 +80,6 @@ async function txCOSSubmit(formValues: GenericObject) {
   toast.success(t(`common.saveSuccess`))
 }
 
-// 七牛云
 const qiniuSchema = computed(() => toTypedSchema(yup.object({
   accessKey: yup.string().required(t(`upload.validation.accessKeyRequired`)),
   secretKey: yup.string().required(t(`upload.validation.secretKeyRequired`)),
@@ -158,7 +155,6 @@ async function s3Submit(formValues: GenericObject) {
   toast.success(t(`common.saveSuccess`))
 }
 
-// Telegram 图床
 const telegramSchema = computed(() => toTypedSchema(
   yup.object({
     token: yup.string().required(t(`upload.validation.botTokenRequired`)),
@@ -173,17 +169,16 @@ async function telegramSubmit(values: GenericObject) {
   toast.success(t(`common.saveSuccess`))
 }
 
-// 公众号
-// 当前是否为网页（http/https 协议）
+// Whether running on http/https
 const isWebsite = window.location.protocol.startsWith(`http`)
 
-// Cloudflare Workers 环境
+// Cloudflare Workers environment
 const isCfWorkers = import.meta.env.CF_WORKERS === `1`
 
-// 插件模式运行（如 chrome-extension://）
+// Extension context (e.g. chrome-extension://)
 const isPluginMode = !isWebsite
 
-// 是否需要填写 proxyOrigin（只在 非插件 且 非CF页面 时需要）
+// Whether proxyOrigin is required (non-extension, non-CF page only)
 const isProxyRequired = computed(() => {
   return !isPluginMode && !isCfWorkers
 })
@@ -239,7 +234,6 @@ async function r2Submit(formValues: GenericObject) {
   toast.success(t(`common.saveSuccess`))
 }
 
-// 又拍云
 const upyunSchema = computed(() => toTypedSchema(
   yup.object({
     bucket: yup.string().required(t(`upload.validation.bucketRequired`)),
@@ -304,7 +298,6 @@ async function changeImgHost() {
 }
 
 async function changeCompression() {
-  // reactive 会自动保存，不需要手动操作
 }
 
 async function beforeImageUpload(file: File) {
@@ -975,7 +968,6 @@ function onTabScroll(e: WheelEvent) {
         <TabsContent value="mp" class="flex-1 flex flex-col overflow-hidden">
           <Form :validation-schema="mpSchema" :initial-values="mpConfig" class="flex flex-col flex-1 overflow-hidden" @submit="mpSubmit">
             <div class="flex-1 overflow-y-auto p-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-              <!-- 只有在需要代理时才显示 proxyOrigin 字段 -->
               <Field
                 v-if="isProxyRequired"
                 v-slot="{ field, errorMessage }"

--- a/apps/web/src/components/editor/editor-header/EditDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/EditDropdown.vue
@@ -95,7 +95,6 @@ function openReplace() {
 </script>
 
 <template>
-  <!-- 作为 MenubarSub 使用 -->
   <MenubarSub v-if="asSub">
     <MenubarSubTrigger>
       {{ t('menu.edit') }}
@@ -204,7 +203,6 @@ function openReplace() {
     </MenubarSubContent>
   </MenubarSub>
 
-  <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>
       {{ t('menu.edit') }}

--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -36,7 +36,6 @@ function openTemplateDialog() {
   toggleShowTemplateDialog(true)
 }
 
-// Export functions
 function exportEditorContent2HTML() {
   exportStore.exportEditorContent2HTML()
 }
@@ -59,13 +58,11 @@ function exportEditorContent2PDF() {
 </script>
 
 <template>
-  <!-- 作为 MenubarSub 使用 -->
   <MenubarSub v-if="asSub">
     <MenubarSubTrigger>
       {{ t('menu.file') }}
     </MenubarSubTrigger>
     <MenubarSubContent class="min-w-56">
-      <!-- 本地文件夹 -->
       <MenubarItem @click="isOpenFolderPanel = !isOpenFolderPanel">
         <FolderOpen class="mr-2 size-4" />
         {{ t('menu.localFolder') }}
@@ -73,7 +70,6 @@ function exportEditorContent2PDF() {
 
       <MenubarSeparator />
 
-      <!-- 导入子菜单 -->
       <MenubarSub>
         <MenubarSubTrigger>
           <Upload class="mr-2 size-4" />
@@ -87,7 +83,6 @@ function exportEditorContent2PDF() {
         </MenubarSubContent>
       </MenubarSub>
 
-      <!-- 导出子菜单 -->
       <MenubarSub>
         <MenubarSubTrigger>
           <Download class="mr-2 size-4" />
@@ -121,13 +116,11 @@ function exportEditorContent2PDF() {
 
       <MenubarSeparator />
 
-      <!-- 模板管理 -->
       <MenubarItem @click="openTemplateDialog()">
         <Package class="mr-2 size-4" />
         {{ t('menu.templateManage') }}
       </MenubarItem>
 
-      <!-- 内容管理 -->
       <MenubarItem @click="isOpenPostSlider = !isOpenPostSlider">
         <FolderKanban class="mr-2 size-4" />
         {{ t('menu.contentManage') }}
@@ -135,12 +128,10 @@ function exportEditorContent2PDF() {
 
       <template v-if="showSyncUi || showShareUi">
         <MenubarSeparator />
-        <!-- 云同步 -->
         <MenubarItem v-if="showSyncUi" @click="toggleShowSyncDialog(true)">
           <Cloud class="mr-2 size-4" />
           {{ t('menu.cloudSync') }}
         </MenubarItem>
-        <!-- 分享预览 -->
         <MenubarItem v-if="showShareUi" @click="openShareDialog()">
           <Share2 class="mr-2 size-4" />
           {{ t('menu.sharePreview') }}
@@ -149,13 +140,11 @@ function exportEditorContent2PDF() {
 
       <MenubarSeparator />
 
-      <!-- 偏好设置 -->
       <MenubarItem @click="openPreferencesDialog()">
         <Settings class="mr-2 size-4" />
         {{ t('menu.preferences') }}
       </MenubarItem>
 
-      <!-- 导入/导出配置 -->
       <MenubarItem @click="openEditorStateDialog()">
         <FileCog class="mr-2 size-4" />
         {{ t('menu.importExportConfig') }}
@@ -163,13 +152,11 @@ function exportEditorContent2PDF() {
     </MenubarSubContent>
   </MenubarSub>
 
-  <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>
       {{ t('menu.file') }}
     </MenubarTrigger>
     <MenubarContent class="min-w-56" align="start">
-      <!-- 本地文件夹 -->
       <MenubarItem @click="isOpenFolderPanel = !isOpenFolderPanel">
         <FolderOpen class="mr-2 size-4" />
         {{ t('menu.localFolder') }}
@@ -177,7 +164,6 @@ function exportEditorContent2PDF() {
 
       <MenubarSeparator />
 
-      <!-- 导入子菜单 -->
       <MenubarSub>
         <MenubarSubTrigger>
           <Upload class="mr-2 size-4" />
@@ -191,7 +177,6 @@ function exportEditorContent2PDF() {
         </MenubarSubContent>
       </MenubarSub>
 
-      <!-- 导出子菜单 -->
       <MenubarSub>
         <MenubarSubTrigger>
           <Download class="mr-2 size-4" />
@@ -225,13 +210,11 @@ function exportEditorContent2PDF() {
 
       <MenubarSeparator />
 
-      <!-- 模板管理 -->
       <MenubarItem @click="openTemplateDialog()">
         <Package class="mr-2 size-4" />
         {{ t('menu.templateManage') }}
       </MenubarItem>
 
-      <!-- 内容管理 -->
       <MenubarItem @click="isOpenPostSlider = !isOpenPostSlider">
         <FolderKanban class="mr-2 size-4" />
         {{ t('menu.contentManage') }}
@@ -239,12 +222,10 @@ function exportEditorContent2PDF() {
 
       <template v-if="showSyncUi || showShareUi">
         <MenubarSeparator />
-        <!-- 云同步 -->
         <MenubarItem v-if="showSyncUi" @click="toggleShowSyncDialog(true)">
           <Cloud class="mr-2 size-4" />
           {{ t('menu.cloudSync') }}
         </MenubarItem>
-        <!-- 分享预览 -->
         <MenubarItem v-if="showShareUi" @click="openShareDialog()">
           <Share2 class="mr-2 size-4" />
           {{ t('menu.sharePreview') }}
@@ -253,13 +234,11 @@ function exportEditorContent2PDF() {
 
       <MenubarSeparator />
 
-      <!-- 偏好设置 -->
       <MenubarItem @click="openPreferencesDialog()">
         <Settings class="mr-2 size-4" />
         {{ t('menu.preferences') }}
       </MenubarItem>
 
-      <!-- 导入/导出配置 -->
       <MenubarItem @click="openEditorStateDialog()">
         <FileCog class="mr-2 size-4" />
         {{ t('menu.importExportConfig') }}

--- a/apps/web/src/components/editor/editor-header/FormatDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FormatDropdown.vue
@@ -81,13 +81,11 @@ function textColorChanged(color: string) {
 </script>
 
 <template>
-  <!-- 作为 MenubarSub 使用 -->
   <MenubarSub v-if="asSub">
     <MenubarSubTrigger>
       {{ t('menu.format') }}
     </MenubarSubTrigger>
     <MenubarSubContent class="min-w-64">
-      <!-- 文本格式化 -->
       <MenubarItem @click="addFormat(`${ctrlKey}-B`)">
         <Bold class="mr-2 h-4 w-4" />
         {{ t('menu.bold') }}
@@ -152,7 +150,6 @@ function textColorChanged(color: string) {
 
       <MenubarSeparator />
 
-      <!-- 标题和列表 -->
       <MenubarSub>
         <MenubarSubTrigger>
           <Heading1 class="mr-2 h-4 w-4" />
@@ -203,13 +200,11 @@ function textColorChanged(color: string) {
     </MenubarSubContent>
   </MenubarSub>
 
-  <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>
       {{ t('menu.format') }}
     </MenubarTrigger>
     <MenubarContent class="min-w-64" align="start">
-      <!-- 文本格式化 -->
       <MenubarItem @click="addFormat(`${ctrlKey}-B`)">
         <Bold class="mr-2 h-4 w-4" />
         {{ t('menu.bold') }}
@@ -274,7 +269,6 @@ function textColorChanged(color: string) {
 
       <MenubarSeparator />
 
-      <!-- 标题和列表 -->
       <MenubarSub>
         <MenubarSubTrigger>
           <Heading1 class="mr-2 h-4 w-4" />

--- a/apps/web/src/components/editor/editor-header/HelpDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/HelpDropdown.vue
@@ -55,7 +55,6 @@ function openReleases() {
 </script>
 
 <template>
-  <!-- 作为 MenubarSub 使用 -->
   <MenubarSub v-if="asSub">
     <MenubarSubTrigger>
       {{ t('menu.help') }}
@@ -100,7 +99,6 @@ function openReleases() {
     </MenubarSubContent>
   </MenubarSub>
 
-  <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>{{ t('menu.help') }}</MenubarTrigger>
     <MenubarContent align="start" class="min-w-56">

--- a/apps/web/src/components/editor/editor-header/InsertDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/InsertDropdown.vue
@@ -27,7 +27,6 @@ function openFormulaEditor() {
 </script>
 
 <template>
-  <!-- 作为 MenubarSub 使用 -->
   <MenubarSub v-if="asSub">
     <MenubarSubTrigger>
       {{ t('menu.insert') }}
@@ -52,7 +51,6 @@ function openFormulaEditor() {
     </MenubarSubContent>
   </MenubarSub>
 
-  <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>
       {{ t('menu.insert') }}

--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -38,7 +38,6 @@ const form = ref<Post>({
 
 const allowPost = computed(() => extensionInstalled.value && allAccounts.value.some(a => a.checked && a.loggedIn))
 
-// 平台分类配置
 const platformCategories = [
   {
     id: `media`,
@@ -54,7 +53,7 @@ const platformCategories = [
   },
 ]
 
-// 分类折叠状态（默认折叠云平台及开发者社区）
+// Category collapse state (cloud/dev collapsed by default)
 const collapsedCategories = ref<Set<string>>(new Set([`cloud`]))
 
 function toggleCategory(categoryName: string) {
@@ -66,7 +65,6 @@ function toggleCategory(categoryName: string) {
   }
 }
 
-// 按分类获取账号
 const accountsByCategory = computed(() => {
   return platformCategories.map(category => ({
     id: category.id,
@@ -77,20 +75,18 @@ const accountsByCategory = computed(() => {
   }))
 })
 
-// 判断分类是否全选（只考虑已登录的账号）
+// Whether category is fully selected (logged-in only)
 function isCategoryAllSelected(accounts: PostAccount[]) {
   const loggedInAccounts = accounts.filter(a => a.loggedIn)
   return loggedInAccounts.length > 0 && loggedInAccounts.every(a => a.checked)
 }
 
-// 判断分类是否部分选中
 function isCategoryIndeterminate(accounts: PostAccount[]) {
   const loggedInAccounts = accounts.filter(a => a.loggedIn)
   const checkedCount = loggedInAccounts.filter(a => a.checked).length
   return checkedCount > 0 && checkedCount < loggedInAccounts.length
 }
 
-// 切换分类全选
 function toggleCategorySelectAll(accounts: PostAccount[]) {
   const loggedInAccounts = accounts.filter(a => a.loggedIn)
   const allSelected = loggedInAccounts.every(a => a.checked)
@@ -98,9 +94,9 @@ function toggleCategorySelectAll(accounts: PostAccount[]) {
 }
 
 async function prePost() {
-  // 如果扩展已安装且还没有账号数据，则开始检测
+  // Start detection when extension installed but no account data
   if (extensionInstalled.value && allAccounts.value.length === 0) {
-    // 不 await，让检测在后台进行
+    // Fire-and-forget; detection runs in background
     startLoginDetection()
   }
 
@@ -127,7 +123,6 @@ async function prePost() {
     }
   }
   catch {
-    // 静默失败
   }
   finally {
     form.value = {
@@ -136,7 +131,6 @@ async function prePost() {
   }
 }
 
-// 监听对话框打开，自动加载数据
 watch(dialogVisible, (newVal) => {
   if (newVal) {
     prePost()
@@ -151,25 +145,24 @@ declare global {
   }
 }
 
-// 获取初始平台列表（不带登录状态，用于立即显示）
+// Initial platform list without login state for instant display
 function getInitialPlatforms(): PostAccount[] {
   if (window.$cose !== undefined && typeof window.$cose.getPlatforms === 'function') {
     return window.$cose.getPlatforms().map((p: any) => ({
       ...p,
       checked: false,
       loggedIn: false,
-      isChecking: true, // 标记正在检测中
+      isChecking: true,
     }))
   }
   return []
 }
 
-// 开始登录检测（异步，不阻塞 UI，渐进式更新）
+// Async login check with progressive UI updates
 function startLoginDetection() {
   if (window.$cose === undefined)
     return
 
-  // 立即显示平台列表（带检测中状态）
   const initialPlatforms = getInitialPlatforms()
   if (initialPlatforms.length > 0) {
     allAccounts.value = initialPlatforms
@@ -178,7 +171,7 @@ function startLoginDetection() {
   isCheckingLogin.value = true
   let hasReceivedAny = false
 
-  // 设置超时机制：如果 15 秒内没有任何响应，则停止检测
+  // Stop detection after 15s with no response
   const LOGIN_CHECK_TIMEOUT_MS = 15000
   const timeoutId = setTimeout(() => {
     if (!hasReceivedAny) {
@@ -187,20 +180,16 @@ function startLoginDetection() {
     }
   }, LOGIN_CHECK_TIMEOUT_MS)
 
-  // 检查是否支持渐进式 API
   if (typeof window.$cose.getAccountsProgressive === 'function') {
-    // 使用渐进式 API：每个平台检测完成后立即更新 UI
     window.$cose.getAccountsProgressive(
-      // onProgress: 每个平台完成时调用
       (account: PostAccount, _completed: number, _total: number) => {
         hasReceivedAny = true
-        // 更新对应平台的状态
+
         const idx = allAccounts.value.findIndex(a => a.type === account.type)
         if (idx !== -1) {
           allAccounts.value[idx] = { ...account, checked: false, isChecking: false }
         }
       },
-      // onComplete: 所有平台完成时调用
       () => {
         clearTimeout(timeoutId)
         isCheckingLogin.value = false
@@ -208,7 +197,7 @@ function startLoginDetection() {
     )
   }
   else {
-    // 回退到原有 API
+    // Fallback to legacy API
     window.$cose.getAccounts((resp: PostAccount[]) => {
       hasReceivedAny = true
       clearTimeout(timeoutId)
@@ -218,17 +207,15 @@ function startLoginDetection() {
   }
 }
 
-// 兼容旧的 getAccounts 调用（checkExtension 使用）
+// Legacy getAccounts for checkExtension
 async function getAccounts(): Promise<void> {
   return new Promise((resolve) => {
     startLoginDetection()
-    // 立即 resolve，不等待检测完成
     resolve()
   })
 }
 
 function post() {
-  // 从 allAccounts 获取用户选择的平台（checkbox 绑定在 allAccounts 上）
   form.value.accounts = allAccounts.value.filter(a => a.checked && a.loggedIn)
   postTaskDialogVisible.value = true
   dialogVisible.value = false
@@ -287,11 +274,11 @@ function onAvatarError(account: PostAccount, event: Event) {
 function checkExtension() {
   if (window.$cose !== undefined) {
     extensionInstalled.value = true
-    getAccounts() // 立即开始登录检测
+    getAccounts()
     return
   }
 
-  // 如果插件还没加载，5秒内每 500ms 检查一次
+  // Poll every 500ms for 5s if extension not loaded
   const EXTENSION_CHECK_INTERVAL_MS = 500
   const MAX_EXTENSION_CHECKS = 10
   let count = 0
@@ -437,12 +424,10 @@ onBeforeMount(() => {
                         class="inline-block h-[16px] w-[16px] shrink-0"
                       >
                       <span class="truncate text-sm font-medium">{{ account.title }}</span>
-                      <!-- 检测中：显示转圈动画 -->
                       <template v-if="account.isChecking">
                         <Loader2 class="ml-1 h-3.5 w-3.5 animate-spin text-muted-foreground" />
                         <span class="text-xs text-muted-foreground">{{ t('postInfo.checking') }}</span>
                       </template>
-                      <!-- 已登录：显示头像和用户名 -->
                       <template v-else-if="account.loggedIn">
                         <img
                           v-if="account.avatar"
@@ -453,7 +438,6 @@ onBeforeMount(() => {
                         >
                         <span class="truncate text-sm text-muted-foreground">@{{ account.displayName }}</span>
                       </template>
-                      <!-- 未登录：显示登录链接 -->
                       <Primitive
                         v-else
                         as="a"

--- a/apps/web/src/components/editor/editor-header/StyleDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/StyleDropdown.vue
@@ -44,31 +44,30 @@ const {
 
 const { isDark } = storeToRefs(uiStore)
 
-// Theme change handlers
 function themeChanged(newTheme: keyof typeof themeMap) {
   themeStore.theme = newTheme
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   editorRefresh()
 }
 
 function fontChanged(fonts: string) {
   themeStore.fontFamily = fonts
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   editorRefresh()
 }
 
 function sizeChanged(size: string) {
   themeStore.fontSize = size
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   editorRefresh()
 }
 
 function colorChanged(newColor: string) {
   themeStore.primaryColor = newColor
-  // 使用新主题系统
+
   themeStore.applyCurrentTheme()
   editorRefresh()
 }
@@ -108,7 +107,6 @@ function showPicker() {
   colorPicker.value?.show()
 }
 
-// 自定义CSS样式
 function customStyle() {
   toggleShowCssEditor()
 }
@@ -119,7 +117,6 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
 </script>
 
 <template>
-  <!-- 作为 MenubarSub 使用 -->
   <MenubarSub v-if="asSub">
     <MenubarSubTrigger>
       {{ t('menu.style') }}
@@ -209,7 +206,6 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
     </MenubarSubContent>
   </MenubarSub>
 
-  <!-- 作为 MenubarMenu 使用（默认） -->
   <MenubarMenu v-else>
     <MenubarTrigger>
       {{ t('menu.style') }}

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -97,11 +97,9 @@ function fallbackCopyUsingExecCommand(htmlContent: string) {
   return successful
 }
 
-// 复制到微信公众号
 async function copy() {
   isCopying.value = true
 
-  // 如果是 Markdown 源码，直接复制并返回
   if (copyMode.value === `md`) {
     try {
       const mdContent = editor.value?.state.doc.toString() || ``
@@ -117,7 +115,6 @@ async function copy() {
     return
   }
 
-  // 以下处理非 Markdown 的复制流程
   emit(`startCopy`)
 
   setTimeout(() => {
@@ -189,7 +186,6 @@ async function copy() {
           await copyContent(exportStore.editorContent2HTML())
         }
 
-        // 输出提示
         toast.success(
           copyMode.value === `html`
             ? t(`toast.copiedHtml`)
@@ -231,7 +227,6 @@ function copyToWeChat() {
   <header
     class="header-container h-15 flex flex-wrap items-center justify-between px-5 relative"
   >
-    <!-- 桌面端左侧菜单 -->
     <div class="space-x-1 hidden md:flex">
       <Menubar class="menubar border-0">
         <FileDropdown />
@@ -243,7 +238,6 @@ function copyToWeChat() {
       </Menubar>
     </div>
 
-    <!-- 移动端汉堡菜单按钮 -->
     <div class="md:hidden">
       <Menubar class="menubar border-0 p-0">
         <MenubarMenu>
@@ -264,9 +258,7 @@ function copyToWeChat() {
       </Menubar>
     </div>
 
-    <!-- 右侧操作区 -->
     <div class="flex flex-wrap items-center gap-2">
-      <!-- 复制按钮 -->
       <Button
         variant="outline"
         class="h-9"
@@ -278,10 +270,8 @@ function copyToWeChat() {
         <span>{{ t('header.copy') }}</span>
       </Button>
 
-      <!-- 文章信息（移动端隐藏） -->
       <PostInfo class="hidden md:inline-flex" />
 
-      <!-- 样式面板 -->
       <Button
         variant="outline"
         class="h-9"
@@ -294,7 +284,6 @@ function copyToWeChat() {
     </div>
   </header>
 
-  <!-- 对话框组件，嵌套菜单无法正常挂载，需要提取层级 -->
   <AboutDialog v-if="isShowAboutDialog" v-model:open="isShowAboutDialog" />
   <FundDialog v-if="isShowFundDialog" v-model:open="isShowFundDialog" />
   <EditorStateDialog v-if="isShowEditorStateDialog" v-model:open="isShowEditorStateDialog" />

--- a/apps/web/src/components/editor/folder-source-panel/FolderTree.vue
+++ b/apps/web/src/components/editor/folder-source-panel/FolderTree.vue
@@ -46,7 +46,6 @@ function handleToggleClick(node: FileSystemNode, event: MouseEvent) {
 <template>
   <div class="folder-tree">
     <template v-for="node in nodes" :key="node.path">
-      <!-- 节点本身 -->
       <div
         class="tree-node"
         :class="{
@@ -57,7 +56,6 @@ function handleToggleClick(node: FileSystemNode, event: MouseEvent) {
         :style="{ paddingLeft: `${level * 16 + 8}px` }"
         @click="handleNodeClick(node, $event)"
       >
-        <!-- 展开/折叠图标 -->
         <span
           v-if="node.type === 'directory'"
           class="toggle-icon"
@@ -68,20 +66,17 @@ function handleToggleClick(node: FileSystemNode, event: MouseEvent) {
         </span>
         <span v-else class="toggle-icon-placeholder" />
 
-        <!-- 文件/文件夹图标 -->
         <span class="node-icon">
           <Folder v-if="node.type === 'directory' && !isExpanded(node.path)" class="h-4 w-4" />
           <FolderOpen v-else-if="node.type === 'directory' && isExpanded(node.path)" class="h-4 w-4" />
           <File v-else class="h-4 w-4" />
         </span>
 
-        <!-- 节点名称 -->
         <span class="node-name" :title="node.name">
           {{ node.name }}
         </span>
       </div>
 
-      <!-- 递归渲染子节点（紧接在父节点之后） -->
       <FolderTree
         v-if="node.type === 'directory' && isExpanded(node.path) && node.children"
         :nodes="node.children"

--- a/apps/web/src/components/editor/folder-source-panel/index.vue
+++ b/apps/web/src/components/editor/folder-source-panel/index.vue
@@ -22,7 +22,6 @@ const { setCurrentFilePath } = useFolderFileSync()
 
 const { isMobile, isOpenFolderPanel } = storeToRefs(uiStore)
 
-// 控制是否启用动画
 const enableAnimation = ref(false)
 
 watch(isOpenFolderPanel, () => {
@@ -53,15 +52,14 @@ function handleToggleExpand(path: string) {
   else {
     expandedPaths.value.add(path)
   }
-  // 触发响应式更新
+
   expandedPaths.value = new Set(expandedPaths.value)
 }
 
 async function handleSelectFolder() {
   await folderSourceStore.selectFolder()
-  // 等待下一个 tick，确保 fileTree 已经更新
   await nextTick()
-  // 展开根节点
+
   if (fileTree.value.length > 0) {
     expandedPaths.value.add(fileTree.value[0].path)
   }
@@ -82,14 +80,11 @@ function handleCloseFolder() {
 async function handleOpenFile(node: any) {
   try {
     const content = await folderSourceStore.readFile(node.path)
-    // 从文件名中提取标题（移除 .md 扩展名）
     const title = node.name.replace(/\.md$/i, ``)
 
-    // 创建新文章并设置内容
     postStore.addPost(title)
     postStore.updatePostContent(postStore.currentPostId, content)
 
-    // 记录当前文件路径以便自动同步
     setCurrentFilePath(node.path)
 
     toast.success(t('folder.fileLoaded', { name: node.name }))
@@ -101,7 +96,6 @@ async function handleOpenFile(node: any) {
 </script>
 
 <template>
-  <!-- 移动端遮罩层 -->
   <Transition name="fade">
     <div
       v-if="isMobile && isOpenFolderPanel"
@@ -118,7 +112,6 @@ async function handleOpenFile(node: any) {
     }"
     :style="isMobile ? { transform: isOpenFolderPanel ? 'translateX(0)' : 'translateX(-100%)' } : undefined"
   >
-    <!-- 头部工具栏 -->
     <div class="panel-header sticky top-0 z-10 bg-background border-b p-2">
       <div class="flex items-center justify-between mb-2">
         <h3 class="text-sm font-semibold flex items-center gap-2">
@@ -148,7 +141,6 @@ async function handleOpenFile(node: any) {
         </div>
       </div>
 
-      <!-- 操作按钮 -->
       <div class="flex gap-1">
         <Button
           variant="outline"
@@ -175,9 +167,7 @@ async function handleOpenFile(node: any) {
       </div>
     </div>
 
-    <!-- 内容区域 -->
     <div class="panel-content flex-1 overflow-y-auto p-2">
-      <!-- 不支持 API 的提示 -->
       <div
         v-if="!isFileSystemAPISupported"
         class="flex flex-col items-center justify-center h-full text-center p-4 text-muted-foreground"
@@ -191,7 +181,6 @@ async function handleOpenFile(node: any) {
         </p>
       </div>
 
-      <!-- 加载中 -->
       <div
         v-else-if="isLoading"
         class="flex flex-col items-center justify-center h-full"
@@ -202,7 +191,6 @@ async function handleOpenFile(node: any) {
         </p>
       </div>
 
-      <!-- 错误提示 -->
       <div
         v-else-if="loadError"
         class="flex flex-col items-center justify-center h-full text-center p-4 text-destructive"
@@ -212,7 +200,6 @@ async function handleOpenFile(node: any) {
         </p>
       </div>
 
-      <!-- 空状态 -->
       <div
         v-else-if="!currentFolderHandle"
         class="flex flex-col items-center justify-center h-full text-center p-4 text-muted-foreground"
@@ -226,7 +213,6 @@ async function handleOpenFile(node: any) {
         </p>
       </div>
 
-      <!-- 文件树 -->
       <div v-else class="file-tree-container">
         <div class="text-xs text-muted-foreground mb-2 px-2">
           {{ currentFolderHandle.name }}
@@ -260,12 +246,10 @@ async function handleOpenFile(node: any) {
   min-height: 100%;
 }
 
-/* 移动端侧边栏动画 */
 .animate-slider {
   transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* 遮罩动画 */
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 200ms ease;

--- a/apps/web/src/components/editor/post-slider/VersionDiffViewer.vue
+++ b/apps/web/src/components/editor/post-slider/VersionDiffViewer.vue
@@ -99,7 +99,6 @@ const lineNumbers = computed(() => {
   })
 })
 
-// ---- minimap ----
 const scrollContainer = ref<HTMLElement | null>(null)
 const minimapRef = ref<HTMLElement | null>(null)
 const viewportTop = ref(0)
@@ -133,21 +132,17 @@ onMounted(() => {
 
 <template>
   <div class="flex flex-col h-full">
-    <!-- 统计 -->
     <div class="flex items-center gap-3 px-3 py-1.5 border-b text-xs text-muted-foreground shrink-0">
       <span class="flex-1" />
       <span class="text-green-600 dark:text-green-400">+{{ stats.ins }}</span>
       <span class="text-red-600 dark:text-red-400">-{{ stats.del }}</span>
     </div>
 
-    <!-- 无差异 -->
     <div v-if="isIdentical" class="flex-1 flex items-center justify-center text-sm text-muted-foreground">
       {{ t('versionDiff.identical') }}
     </div>
 
-    <!-- 差异内容 -->
     <div v-else class="flex-1 flex overflow-hidden">
-      <!-- 主内容 -->
       <div ref="scrollContainer" class="flex-1 overflow-y-auto thin-scrollbar" @scroll="updateViewport">
         <div class="font-mono text-xs leading-5">
           <div
@@ -179,13 +174,11 @@ onMounted(() => {
         </div>
       </div>
 
-      <!-- 缩略图 -->
       <div
         ref="minimapRef"
         class="shrink-0 w-[18px] border-l border-border/50 relative cursor-pointer select-none bg-muted/20"
         @click="onMinimapClick"
       >
-        <!-- 变更标记 -->
         <div class="absolute inset-0 flex flex-col">
           <div
             v-for="(line, idx) in diffLines"
@@ -197,7 +190,6 @@ onMounted(() => {
             }"
           />
         </div>
-        <!-- 视口指示器 -->
         <div
           class="absolute left-0 right-0 border border-foreground/20 bg-foreground/5 rounded-sm pointer-events-none transition-[top,height] duration-100"
           :style="{ top: `${viewportTop}%`, height: `${Math.max(viewportHeight, 4)}%` }"

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -33,10 +33,8 @@ const { posts, sortMode } = storeToRefs(postStore)
 const editorStore = useEditorStore()
 const { editor } = storeToRefs(editorStore)
 
-// 控制是否启用动画
 const enableAnimation = ref(false)
 
-// 监听 PostSlider 开关状态变化
 watch(isOpenPostSlider, (open) => {
   if (!open)
     postSliderMenu.closeMenu()
@@ -44,13 +42,11 @@ watch(isOpenPostSlider, (open) => {
     enableAnimation.value = true
 })
 
-// 监听设备类型变化，重置动画状态
 watch(isMobile, () => {
   enableAnimation.value = false
   postSliderMenu.closeMenu()
 })
 
-/* ============ 新增内容 ============ */
 const parentId = ref<string | null>(null)
 const isOpenAddDialog = ref(false)
 const addPostInputVal = ref(``)
@@ -79,7 +75,6 @@ function openCreatePostDialog() {
   isOpenAddDialog.value = true
 }
 
-/* ============ 重命名 / 删除 / 历史 对象 ============ */
 const editId = ref<string | null>(null)
 const isOpenEditDialog = ref(false)
 const renamePostInputVal = ref(``)
@@ -133,7 +128,6 @@ function delPost() {
   toast.success(t('post.deleteSuccess'))
 }
 
-/* ============ 历史记录 ============ */
 const isOpenHistoryDialog = ref(false)
 const currentPostId = ref<string | null>(null)
 const currentHistoryIndex = ref(0)
@@ -153,7 +147,7 @@ const currentHistoryList = computed(() => {
   return postStore.getPostById(currentPostId.value!)?.history ?? []
 })
 
-// 当选中版本与对比目标冲突时，自动调整对比目标
+// Auto-adjust diff target when it conflicts with selected version
 watch(currentHistoryIndex, (idx) => {
   if (Number(compareTargetIndex.value) === idx) {
     const len = currentHistoryList.value.length
@@ -187,7 +181,6 @@ function confirmRestoreHistory() {
   })
 }
 
-/* ============ 全局搜索与替换 ============ */
 const isSearching = ref(false)
 const searchQuery = ref(``)
 const searchInputRef = ref<HTMLInputElement | null>(null)
@@ -397,7 +390,6 @@ function replaceAll() {
     toast.success(t('post.replacedCount', { count }))
 }
 
-/* ============ 排序 ============ */
 const sortedPosts = computed(() => {
   return [...posts.value].sort((a, b) => {
     switch (sortMode.value) {
@@ -412,18 +404,15 @@ const sortedPosts = computed(() => {
       case `create-new-old`:
         return +new Date(b.createDatetime) - +new Date(a.createDatetime)
       default:
-        /* create-old-new */
         return +new Date(a.createDatetime) - +new Date(b.createDatetime)
     }
   })
 })
 
-/* ============ 拖拽功能 ============ */
 const dragover = ref(false)
 const dragSourceId = ref<string | null>(null)
 const dropTargetId = ref<string | null>(null)
 
-/* ============ 选择模式 ============ */
 const isSelectMode = ref(false)
 const selectedPostIds = ref<string[]>([])
 
@@ -476,7 +465,6 @@ async function exportSelected() {
   selectedPostIds.value = []
 }
 
-/* ============ 批量导入 / 导出全部 ============ */
 function openImportDialog() {
   postSliderMenu.closeMenu()
   toggleShowImportMdDialog(true)
@@ -517,14 +505,12 @@ function openBatchDelConfirm() {
   })
 }
 
-/* ============ 批量复制 ============ */
 function duplicateSelected() {
   if (!selectedPostIds.value.length)
     return
   selectedPostIds.value.forEach((id) => {
     const p = postStore.getPostById(id)!
     postStore.addPost(`${p.title} ${t('post.copySuffix')}`, p.parentId ?? null)
-    // 覆盖刚创建的那篇内容
     const newPost = posts.value[posts.value.length - 1]
     postStore.updatePostContent(newPost.id, p.content)
   })
@@ -533,7 +519,6 @@ function duplicateSelected() {
   selectedPostIds.value = []
 }
 
-/* ============ 合并为一篇 ============ */
 const isOpenMergeDialog = ref(false)
 const mergeTitle = ref(``)
 
@@ -568,7 +553,7 @@ function handleDrop(targetId: string | null) {
     return
   }
 
-  // 递归检索 ID，是不是父文件拖拽到了子文件上面
+  // Check if parent was dropped onto its own descendant
   const isParent = (id: string | null | undefined) => {
     if (!id) {
       return false
@@ -608,7 +593,6 @@ function handleDragEnd() {
 </script>
 
 <template>
-  <!-- 移动端遮罩层 -->
   <Transition name="fade">
     <div
       v-if="isMobile && isOpenPostSlider"
@@ -617,7 +601,6 @@ function handleDragEnd() {
     />
   </Transition>
 
-  <!-- 侧栏容器 -->
   <div
     class="h-full w-full overflow-hidden"
     :class="{
@@ -641,7 +624,6 @@ function handleDragEnd() {
       @dragover="handleDragOver"
       @drop.prevent="handleDrop(null)"
     >
-      <!-- 标题栏 -->
       <div
         class="flex items-center shrink-0 bg-background flex-nowrap"
         :class="isMobile
@@ -660,7 +642,6 @@ function handleDragEnd() {
         <span class="flex-1 min-w-0" />
 
         <div class="flex shrink-0 items-center gap-0.5">
-          <!-- 搜索 -->
           <button
             class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
             :class="[
@@ -672,7 +653,6 @@ function handleDragEnd() {
             <Search class="size-4" />
           </button>
 
-          <!-- 多选 -->
           <button
             class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
             :class="[
@@ -685,7 +665,6 @@ function handleDragEnd() {
             <CheckSquare class="size-4" />
           </button>
 
-          <!-- 批量导入（移动端快捷入口，桌面端在更多菜单中） -->
           <button
             v-if="isMobile"
             class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150 size-8"
@@ -695,7 +674,6 @@ function handleDragEnd() {
             <Upload class="size-4" />
           </button>
 
-          <!-- 新增 -->
           <button
             class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150"
             :class="isMobile ? 'size-8' : 'size-7'"
@@ -704,7 +682,6 @@ function handleDragEnd() {
             <Plus class="size-4" />
           </button>
 
-          <!-- 更多操作 -->
           <DropdownMenu :open="headerMenuOpen" @update:open="onHeaderMenuOpenChange">
             <DropdownMenuTrigger as-child>
               <button
@@ -762,7 +739,6 @@ function handleDragEnd() {
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <!-- 关闭（移动端全屏抽屉） -->
           <button
             v-if="isMobile"
             class="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-150 ml-0.5 size-8"
@@ -773,7 +749,6 @@ function handleDragEnd() {
         </div>
       </div>
 
-      <!-- 搜索栏 -->
       <div v-if="isSearching" class="px-2 pb-1.5 shrink-0 space-y-1">
         <div class="relative">
           <input
@@ -810,7 +785,6 @@ function handleDragEnd() {
           </div>
         </div>
 
-        <!-- 替换栏 -->
         <div class="relative">
           <textarea
             v-model="replaceQuery"
@@ -840,9 +814,7 @@ function handleDragEnd() {
         </div>
       </div>
 
-      <!-- 搜索结果 -->
       <div v-if="isSearching && searchQuery.trim()" class="flex-1 overflow-y-auto px-1.5 py-0.5 thin-scrollbar">
-        <!-- 匹配统计 -->
         <div v-if="totalMatches > 0" class="px-2 py-1 text-xs text-muted-foreground/60">
           {{ t('post.matchStats', { matches: totalMatches, posts: searchResults.length }) }}
         </div>
@@ -886,7 +858,6 @@ function handleDragEnd() {
         </div>
       </div>
 
-      <!-- 内容列表 -->
       <div v-else class="flex-1 overflow-y-auto px-1.5 py-0.5 thin-scrollbar">
         <PostItem
           v-if="sortedPosts.length"
@@ -909,7 +880,6 @@ function handleDragEnd() {
           :select="selectProps"
         />
 
-        <!-- 空状态 -->
         <div v-else class="flex flex-col items-center justify-center gap-4 py-20 px-6">
           <div class="flex items-center justify-center size-12 rounded-xl bg-muted/50">
             <FileText class="size-6 text-muted-foreground/40" />
@@ -925,7 +895,6 @@ function handleDragEnd() {
         </div>
       </div>
 
-      <!-- 选择模式底部操作栏 -->
       <Transition name="slide-up">
         <div
           v-if="isSelectMode"
@@ -934,7 +903,6 @@ function handleDragEnd() {
             ? 'pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]'
             : 'pb-3'"
         >
-          <!-- 选中信息行 -->
           <div class="flex items-center justify-between text-xs">
             <span class="text-muted-foreground">
               {{ t('post.selectedCount') }}
@@ -954,9 +922,7 @@ function handleDragEnd() {
               </button>
             </div>
           </div>
-          <!-- 操作工具栏 -->
           <div class="flex">
-            <!-- 导出 -->
             <button
               class="flex flex-1 items-center justify-center rounded-md py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
               :title="t('common.export')"
@@ -967,7 +933,6 @@ function handleDragEnd() {
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
               </svg>
             </button>
-            <!-- 复制 -->
             <button
               class="flex flex-1 items-center justify-center rounded-md py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
               :title="t('common.copy')"
@@ -978,7 +943,6 @@ function handleDragEnd() {
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
               </svg>
             </button>
-            <!-- 合并 -->
             <button
               class="flex flex-1 items-center justify-center rounded-md py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
               :title="selectedPostIds.length < 2 ? t('post.mergeMinTwo') : t('common.merge')"
@@ -989,9 +953,7 @@ function handleDragEnd() {
                 <path d="M8 6H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h3" /><path d="M16 6h3a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-3" /><line x1="12" y1="2" x2="12" y2="22" />
               </svg>
             </button>
-            <!-- 分隔 -->
             <div class="mx-1 self-center h-5 w-px bg-border/60 shrink-0" />
-            <!-- 删除 -->
             <button
               class="flex flex-1 items-center justify-center rounded-md py-2 text-destructive/60 transition-colors hover:bg-destructive/8 hover:text-destructive disabled:pointer-events-none disabled:opacity-35"
               :title="selectedPostIds.length >= posts.length ? t('post.keepOnePost') : t('common.delete')"
@@ -1008,7 +970,6 @@ function handleDragEnd() {
     </nav>
   </div>
 
-  <!-- 新增弹窗 -->
   <Dialog v-model:open="isOpenAddDialog">
     <DialogContent>
       <DialogHeader>
@@ -1024,7 +985,6 @@ function handleDragEnd() {
     </DialogContent>
   </Dialog>
 
-  <!-- 重命名弹窗 -->
   <Dialog v-model:open="isOpenEditDialog">
     <DialogContent class="sm:max-w-[425px]">
       <DialogHeader>
@@ -1043,7 +1003,6 @@ function handleDragEnd() {
     </DialogContent>
   </Dialog>
 
-  <!-- 删除确认 -->
   <AlertDialog v-model:open="isOpenDelPostConfirmDialog">
     <AlertDialogContent>
       <AlertDialogHeader>
@@ -1073,7 +1032,6 @@ function handleDragEnd() {
     </AlertDialogContent>
   </AlertDialog>
 
-  <!-- 合并弹窗 -->
   <Dialog v-model:open="isOpenMergeDialog">
     <DialogContent class="sm:max-w-[425px]">
       <DialogHeader>
@@ -1092,7 +1050,6 @@ function handleDragEnd() {
     </DialogContent>
   </Dialog>
 
-  <!-- 历史记录 -->
   <Dialog v-model:open="isOpenHistoryDialog">
     <DialogContent class="sm:max-w-4xl">
       <DialogHeader>
@@ -1101,7 +1058,6 @@ function handleDragEnd() {
       </DialogHeader>
 
       <div class="h-[50vh] flex gap-3">
-        <!-- 左侧时间轴 -->
         <ul class="w-[160px] shrink-0 space-y-0.5 overflow-y-auto thin-scrollbar">
           <li
             v-for="(item, idx) in currentHistoryList"
@@ -1116,7 +1072,6 @@ function handleDragEnd() {
 
         <Separator orientation="vertical" />
 
-        <!-- 右侧内容（带 Tabs） -->
         <div class="flex-1 flex flex-col overflow-hidden">
           <Tabs v-model="historyViewMode" class="flex flex-col h-full">
             <TabsList class="shrink-0 w-fit">
@@ -1177,12 +1132,10 @@ function handleDragEnd() {
 </template>
 
 <style scoped>
-/* 移动端侧边栏动画 */
 .animate-slider {
   transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* 细滚动条 — 默认隐藏，hover 时显示 */
 .thin-scrollbar {
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
@@ -1191,7 +1144,6 @@ function handleDragEnd() {
   scrollbar-color: hsl(var(--border)) transparent;
 }
 
-/* 遮罩动画 */
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 200ms ease;
@@ -1202,7 +1154,6 @@ function handleDragEnd() {
   opacity: 0;
 }
 
-/* 底部操作栏动画 */
 .slide-up-enter-active,
 .slide-up-leave-active {
   transition: transform 200ms ease, opacity 200ms ease;

--- a/apps/web/src/components/ui/search-tab/SearchTab.vue
+++ b/apps/web/src/components/ui/search-tab/SearchTab.vue
@@ -33,10 +33,8 @@ const currentMatchPosition = computed(() => {
   return matchPositions.value[indexOfMatch.value]
 })
 
-// 定义高亮样式的 StateEffect
 const setSearchHighlights = StateEffect.define<DecorationSet>()
 
-// 创建搜索高亮的 StateField（需要在编辑器初始化时添加）
 const searchHighlightField = StateField.define<DecorationSet>({
   create() {
     return Decoration.none
@@ -52,11 +50,8 @@ const searchHighlightField = StateField.define<DecorationSet>({
   provide: f => EditorView.decorations.from(f),
 })
 
-// 在组件挂载时动态添加 searchHighlightField
 onMounted(() => {
-  // 检查编辑器是否已经有这个 field
   if (!props.editorView.state.field(searchHighlightField, false)) {
-    // 动态添加 extension
     props.editorView.dispatch({
       effects: StateEffect.appendConfig.of(searchHighlightField),
     })
@@ -90,16 +85,16 @@ watch(showSearchTab, async () => {
     selectionRange.value = null
   }
   else {
-    // 如果有选中文本，自动启用 find in selection
+    // Auto-enable find-in-selection when text is selected
     const selection = props.editorView.state.selection.main
     if (!selection.empty) {
       findInSelection.value = true
       selectionRange.value = { from: selection.from, to: selection.to }
     }
     markMatch()
-    // 等待DOM更新后聚焦输入框，但不触发编辑器失焦
+    // Focus search input after DOM update without losing editor selection
     await nextTick()
-    // 使用 setTimeout 确保编辑器的选区不会因为输入框聚焦而丢失
+    // setTimeout keeps editor selection when input focuses
     setTimeout(() => {
       searchInputRef.value?.focus()
       searchInputRef.value?.select()
@@ -108,17 +103,14 @@ watch(showSearchTab, async () => {
 })
 
 function clearAllMarks() {
-  // 清除所有搜索高亮
   props.editorView.dispatch({
     effects: setSearchHighlights.of(Decoration.none),
   })
 }
 
 function markMatch() {
-  // 清除旧的高亮
   const decorations: any[] = []
 
-  // 为所有匹配项添加高亮装饰
   matchPositions.value.forEach((match, idx) => {
     const from = match[0]
     const to = match[1]
@@ -127,7 +119,6 @@ function markMatch() {
     const fromPos = fromLine.from + from.ch
     const toPos = toLine.from + to.ch
 
-    // 当前选中的匹配项使用不同的样式
     const isCurrentMatch = idx === indexOfMatch.value
     const mark = Decoration.mark({
       class: isCurrentMatch ? `cm-searchMatch-selected` : `cm-searchMatch`,
@@ -136,13 +127,11 @@ function markMatch() {
     decorations.push(mark.range(fromPos, toPos))
   })
 
-  // 应用装饰
   const decorationSet = Decoration.set(decorations, true)
   props.editorView.dispatch({
     effects: setSearchHighlights.of(decorationSet),
   })
 
-  // 滚动到当前匹配位置
   if (matchPositions.value[indexOfMatch.value]?.[0]) {
     const pos = matchPositions.value[indexOfMatch.value][0]
     const docLine = props.editorView.state.doc.line(pos.line + 1)
@@ -158,7 +147,6 @@ function findAllMatches() {
   if (!searchWord.value || !showSearchTab.value)
     return
 
-  // 确定搜索范围
   let searchFrom = 0
   let searchTo = props.editorView.state.doc.length
   if (findInSelection.value && selectionRange.value) {
@@ -253,18 +241,16 @@ function toggleCaseSensitive() {
 
 function toggleFindInSelection() {
   if (!findInSelection.value) {
-    // 启用时，保存当前选区
     const selection = props.editorView.state.selection.main
     if (!selection.empty) {
       selectionRange.value = { from: selection.from, to: selection.to }
     }
     else {
-      // 如果没有选区，使用整个文档
+      // Use full document when selection is empty
       selectionRange.value = { from: 0, to: props.editorView.state.doc.length }
     }
   }
   else {
-    // 禁用时，清除选区
     selectionRange.value = null
   }
   findInSelection.value = !findInSelection.value
@@ -336,7 +322,7 @@ function handleReplaceAll() {
   if (!currentMatchPosition.value)
     return
 
-  // 从后往前替换，避免位置偏移
+  // Replace from end to start to avoid position drift
   const sortedPositions = [...matchPositions.value].sort((a, b) => {
     if (a[0].line !== b[0].line) {
       return b[0].line - a[0].line
@@ -384,7 +370,7 @@ function setSearchWord(word: string) {
 }
 
 /**
- * 打开搜索面板并展开替换功能
+ * Open search panel with replace expanded
  */
 function setSearchWithReplace(word: string) {
   searchWord.value = word
@@ -401,14 +387,13 @@ function setSearchWithReplace(word: string) {
 }
 
 onUnmounted(() => {
-  // 清理搜索高亮
   clearAllMarks()
 })
 
 /**
- * 检查是否有匹配项
- * 返回 false 表示没有匹配项
- * 返回 true 表示有匹配项
+ * Check whether any matches exist
+ * Returns false when there are no matches
+ * Returns true when matches exist
  */
 function checkMatchNumber(): boolean {
   return numberOfMatches.value > 0
@@ -430,7 +415,6 @@ defineExpose({
       class="bg-background absolute right-0 top-0 z-50 flex max-w-[calc(100%-1rem)] gap-1 rounded-lg border px-2 py-1 shadow-md transition-all"
       :class="showReplace ? 'items-start' : 'items-center'"
     >
-      <!-- 折叠/展开按钮 -->
       <Button
         variant="ghost"
         :title="t('search.toggleReplace')"
@@ -441,9 +425,7 @@ defineExpose({
         <component :is="showReplace ? ChevronDown : ChevronRight" class="h-3.5 w-3.5" />
       </Button>
 
-      <!-- 查找 / 替换主体 -->
       <div class="grid min-w-0 flex-1 grid-cols-[1fr_auto] items-center gap-0.5">
-        <!-- 查找行 -->
         <div class="relative min-w-0">
           <Input
             ref="searchInputRef"
@@ -524,7 +506,6 @@ defineExpose({
           </Button>
         </div>
 
-        <!-- 替换行（可折叠） -->
         <template v-if="showReplace">
           <textarea
             v-model="replaceWord"
@@ -575,7 +556,6 @@ defineExpose({
 </style>
 
 <style lang="less">
-/* 搜索匹配项高亮样式（全局，不使用 scoped） */
 .cm-searchMatch {
   background-color: rgba(255, 237, 100, 0.4);
   border-radius: 2px;
@@ -589,7 +569,6 @@ defineExpose({
   font-weight: 500;
 }
 
-/* 暗色主题适配 */
 .dark .cm-searchMatch {
   background-color: rgba(255, 235, 59, 0.3);
   box-shadow: 0 0 0 1px rgba(255, 235, 59, 0.4);

--- a/apps/web/src/composables/useAccountSyncBootstrap.ts
+++ b/apps/web/src/composables/useAccountSyncBootstrap.ts
@@ -1,7 +1,7 @@
 import { isAccountConfigured } from '@/services/account/config'
 import { isSyncUiEnabled } from '@/services/sync/client'
 
-/** 初始化账户与云同步（需在 Pinia 就绪后调用） */
+/** Bootstrap account and cloud sync (call after Pinia is ready). */
 export function useAccountSyncBootstrap() {
   const authStore = useAuthStore()
   const syncStore = useSyncStore()

--- a/apps/web/src/composables/useCommandPaletteHotkey.ts
+++ b/apps/web/src/composables/useCommandPaletteHotkey.ts
@@ -1,6 +1,6 @@
 import { useUIStore } from '@/stores/ui'
 
-/** 注册命令面板全局快捷键 Mod+Shift+P */
+/** Register global command palette shortcut Mod+Shift+P */
 export function useCommandPaletteHotkey() {
   const uiStore = useUIStore()
 

--- a/apps/web/src/composables/useCursorSync.ts
+++ b/apps/web/src/composables/useCursorSync.ts
@@ -2,9 +2,7 @@ import type { MaybeRefOrGetter } from 'vue'
 import { EditorView } from '@codemirror/view'
 import { useUIStore } from '@/stores/ui'
 
-/**
- * 点击预览区元素时，定位回编辑器对应位置。
- */
+/** Click preview element to jump to the matching editor position. */
 export function useCursorSync(
   codeMirrorViewRef: MaybeRefOrGetter<EditorView | null>,
 ) {
@@ -127,7 +125,7 @@ export function useCursorSync(
     if (!target)
       return
 
-    // 拦截预览区角标 a 标签（以及其他内部锚点链接，如脚注），手动平滑滚动
+    // Intercept footnote/anchor links in preview for smooth scroll
     const linkEl = target.closest(`a`) as HTMLAnchorElement | null
     if (linkEl) {
       const href = linkEl.getAttribute(`href`)

--- a/apps/web/src/composables/useEditorFormat.ts
+++ b/apps/web/src/composables/useEditorFormat.ts
@@ -12,10 +12,7 @@ import {
 } from '@md/shared/editor'
 import { unref } from 'vue'
 
-/**
- * 编辑器格式化操作 composable
- * 使用泛型和 unref 来支持任意类型的 ref（包括 readonly ref）
- */
+/** Editor formatting actions; generic unref supports readonly refs. */
 export function useEditorFormat<T extends { value: any }>(editor: T) {
   function addFormat(cmd: string) {
     const editorView = unref(editor) as EditorView

--- a/apps/web/src/composables/useEditorRefresh.ts
+++ b/apps/web/src/composables/useEditorRefresh.ts
@@ -8,8 +8,8 @@ const EDITOR_REFRESH_DEBOUNCE_MS = 300
 const EDITOR_REFRESH_MAX_WAIT_MS = 800
 
 /**
- * 触发编辑器预览重渲染（应用当前主题与样式配置）。
- * scheduleEditorRefresh 用于连续输入/调样式时合并多次渲染（debounce + max-wait）。
+ * Trigger editor preview re-render (current theme and style config).
+ * scheduleEditorRefresh coalesces rapid edits via debounce + max-wait.
  */
 export function useEditorRefresh(options?: {
   debounceMs?: number

--- a/apps/web/src/composables/useFolderFileSync.ts
+++ b/apps/web/src/composables/useFolderFileSync.ts
@@ -1,33 +1,21 @@
 import { useFolderSourceStore } from '@/stores/folderSource'
 import { usePostStore } from '@/stores/post'
 
-/**
- * 文件夹文件同步 Composable
- * 监听编辑器内容变化，实时同步到本地文件夹
- */
+/** Sync editor content changes to the open local folder file (debounced). */
 export function useFolderFileSync() {
   const postStore = usePostStore()
   const folderStore = useFolderSourceStore()
 
-  // 当前打开的文件路径
   const currentFilePath = ref<string | null>(null)
 
-  // 防抖定时器
   let syncTimeoutId: ReturnType<typeof setTimeout> | null = null
 
-  // 同步延迟（毫秒）
   const SYNC_DELAY = 1000
 
-  /**
-   * 设置当前文件路径
-   */
   function setCurrentFilePath(filePath: string | null) {
     currentFilePath.value = filePath
   }
 
-  /**
-   * 执行同步
-   */
   async function performSync(filePath: string, content: string) {
     if (!filePath) {
       return
@@ -41,29 +29,21 @@ export function useFolderFileSync() {
     }
   }
 
-  /**
-   * 防抖同步
-   */
   function debouncedSync() {
     if (!currentFilePath.value || !postStore.currentPost) {
       return
     }
 
-    // 清除之前的定时器
     if (syncTimeoutId) {
       clearTimeout(syncTimeoutId)
     }
 
-    // 设置新的定时器
     syncTimeoutId = setTimeout(() => {
       const content = postStore.currentPost?.content || ''
       performSync(currentFilePath.value!, content)
     }, SYNC_DELAY)
   }
 
-  /**
-   * 监听当前文章内容变化
-   */
   watch(
     () => postStore.currentPost?.content,
     () => {
@@ -72,13 +52,9 @@ export function useFolderFileSync() {
     { deep: false },
   )
 
-  /**
-   * 当切换文件时，同步旧文件
-   */
   watch(
     () => currentFilePath.value,
     (newPath, oldPath) => {
-      // 如果从一个文件切换到另一个文件，先同步旧文件
       if (oldPath && newPath !== oldPath && syncTimeoutId) {
         clearTimeout(syncTimeoutId)
         syncTimeoutId = null
@@ -86,9 +62,6 @@ export function useFolderFileSync() {
     },
   )
 
-  /**
-   * 清理
-   */
   onBeforeUnmount(() => {
     if (syncTimeoutId) {
       clearTimeout(syncTimeoutId)

--- a/apps/web/src/composables/useImageUploader.ts
+++ b/apps/web/src/composables/useImageUploader.ts
@@ -10,7 +10,6 @@ export function useImageUploader() {
   const isUploading = ref(false)
   const error = ref<string | null>(null)
 
-  // 获取本地缓存
   const getStorageMap = async (): Promise<Record<string, string>> => {
     return (await store.getJSON<Record<string, string>>(STORAGE_KEY, {})) ?? {}
   }
@@ -21,19 +20,19 @@ export function useImageUploader() {
     await store.setJSON(STORAGE_KEY, map)
   }
 
-  // 计算 Blob/File 的 SHA-256（Web Crypto，替代 spark-md5）
+  // SHA-256 for Blob/File via Web Crypto (replaces spark-md5)
   const calculateHash = async (file: Blob): Promise<string> => {
     const buffer = await file.arrayBuffer()
     const digest = await crypto.subtle.digest(`SHA-256`, buffer)
     return Array.from(new Uint8Array(digest), b => b.toString(16).padStart(2, `0`)).join(``)
   }
 
-  // URL 转 File (需注意 CORS)
+  // URL → File (watch CORS)
   const urlToFile = async (url: string): Promise<File> => {
     const getFilename = (u: string) => u.split('/').pop()?.split('?')[0] || `image-${Date.now()}.png`
     const filename = getFilename(url)
 
-    // 将 http:// 升级为 https://，避免 Mixed Content 被浏览器拦截
+    // Upgrade http:// to https:// to avoid mixed-content blocking
     const safeUrl = url.replace(/^http:\/\//i, 'https://')
 
     const fetchBlob = async (targetUrl: string, options?: RequestInit) => {
@@ -66,7 +65,6 @@ export function useImageUploader() {
     }
   }
 
-  // 核心上传方法
   const upload = async (resource: string | File): Promise<string> => {
     isUploading.value = true
     error.value = null

--- a/apps/web/src/composables/useInitialPreviewBoot.ts
+++ b/apps/web/src/composables/useInitialPreviewBoot.ts
@@ -11,7 +11,7 @@ function delay(ms: number) {
   return new Promise<void>(resolve => window.setTimeout(resolve, ms))
 }
 
-/** 等待 PreviewPanel 挂载并将 #output 写入 DOM */
+/** Wait for PreviewPanel mount and #output in the DOM. */
 async function waitForOutputElement(timeoutMs = OUTPUT_WAIT_TIMEOUT_MS) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -23,7 +23,7 @@ async function waitForOutputElement(timeoutMs = OUTPUT_WAIT_TIMEOUT_MS) {
   return document.getElementById(`output`)
 }
 
-/** 首次 Markdown 渲染进预览区后，等待异步图表/公式就绪再关闭启动屏 */
+/** After first preview render, wait for async diagrams/math before dismissing loader. */
 export async function completeInitialPreviewBoot() {
   if (initialPreviewBootstrapped)
     return

--- a/apps/web/src/composables/usePlatformEnv.ts
+++ b/apps/web/src/composables/usePlatformEnv.ts
@@ -1,4 +1,4 @@
-/** 检测 uTools 环境并标记根元素（setup 阶段同步执行，尽早生效） */
+/** Detect uTools and tag root element (sync during setup for early effect). */
 export function usePlatformEnv() {
   if (window.__MD_UTOOLS__)
     document.documentElement.classList.add(`is-utools`)

--- a/apps/web/src/composables/usePreferencesHotkey.ts
+++ b/apps/web/src/composables/usePreferencesHotkey.ts
@@ -1,6 +1,6 @@
 import { useUIStore } from '@/stores/ui'
 
-/** 注册偏好设置全局快捷键 Mod+, */
+/** Register global preferences shortcut Mod+, */
 export function usePreferencesHotkey() {
   const uiStore = useUIStore()
 

--- a/apps/web/src/composables/useScrollSync.ts
+++ b/apps/web/src/composables/useScrollSync.ts
@@ -10,14 +10,14 @@ import {
 } from '@/lib/preview/scroll-sync-blocks'
 
 /**
- * 同步滚动：编辑器滚动时同步预览区，预览区滚动时同步编辑器。
+ * Bidirectional scroll sync between editor and preview.
  *
- * 使用基于块的映射（而非简单的像素比例），解决两端内容量差异巨大时
- * 同步不准的问题。核心思路：
- *   1. 源文档按空行分隔为逻辑"块"
- *   2. 预览 DOM 中提取对应的块级元素
- *   3. 通过比例索引映射两端
- *   4. 滚动时定位到对应块
+ * Uses block-based mapping (not simple pixel ratio) so large content skew
+ * between panes stays accurate:
+ *   1. Split source doc into logical blocks on blank lines
+ *   2. Collect matching block-level elements from preview DOM
+ *   3. Map indices proportionally between panes
+ *   4. Scroll to the mapped block on each side
  */
 export function useScrollSync(
   codeMirrorViewRef: MaybeRefOrGetter<EditorView | null>,
@@ -26,15 +26,12 @@ export function useScrollSync(
 ) {
   let isSyncingFromEditor = false
   let isSyncingFromPreview = false
-  // 用程序性目标值过滤"回弹 scroll 事件"，而非依赖时间窗口：
-  // Chrome / Firefox 都会把 scrollTop 赋值产生的 scroll 事件推迟到下一帧，
-  // 届时 rAF 已清除 flag，直接比对位置即可精准拦截，不误伤用户真实滚动。
+  // Filter bounce scroll events via programmatic target values (not a time window):
+  // Chrome/Firefox defer scroll events from scrollTop assignment to the next frame,
+  // after rAF clears flags — compare positions to intercept without blocking user scroll.
   let pendingPreviewScrollTop = -1
   let pendingEditorScrollTop = -1
 
-  // ============================================================
-  // 源文档块解析（缓存以文档对象为 key）
-  // ============================================================
   let cachedDoc: Text | null = null
   let cachedSourceBlocks: SourceBlock[] | null = null
 
@@ -46,9 +43,6 @@ export function useScrollSync(
     return cachedSourceBlocks
   }
 
-  // ============================================================
-  // 预览块元素提取（用 MutationObserver + 版本号代替 innerHTML 缓存 key）
-  // ============================================================
   let previewVersion = 0
   let cachedPreviewVersion = -1
   let cachedPreviewBlocks: HTMLElement[] = []
@@ -71,7 +65,7 @@ export function useScrollSync(
   }
 
   function getPreviewBlockElements(preview: HTMLElement): { blocks: HTMLElement[], offsetTops: number[] } {
-    // 懒初始化：若 watchEffect 首次运行时 #output 尚未就绪，在此补偿
+    // Lazy init when #output was not ready on first watchEffect run
     if (!mutationObserver)
       setupMutationObserver(preview)
 
@@ -102,11 +96,11 @@ export function useScrollSync(
       if (tag === 'STYLE')
         continue
 
-      // 仅跳过阅读时间 blockquote（通过 class 判断，避免误删用户正文首个引用块）
+      // Skip reading-time blockquote only (class-based; avoids dropping user blockquotes)
       if (tag === 'BLOCKQUOTE' && (child as HTMLElement).classList.contains('md-blockquote'))
         continue
 
-      // 遇到脚注区域停止收集（结构特征判断，不依赖文本，避免与用户自定义 H4 冲突）
+      // Stop at footnotes (structural; no text match to avoid custom H4 conflicts)
       if (tag === 'H4' && (child as HTMLElement).dataset.heading === 'true') {
         const next = child.nextElementSibling
         if (next && (next as HTMLElement).classList.contains('footnotes'))
@@ -118,7 +112,6 @@ export function useScrollSync(
       blocks.push(child as HTMLElement)
     }
 
-    // 批量计算各块相对 preview 容器的偏移量，仅在内容变化时执行（非每次滚动）
     const previewRect = preview.getBoundingClientRect()
     const offsetTops = blocks.map(el =>
       el.getBoundingClientRect().top - previewRect.top + preview.scrollTop,
@@ -130,9 +123,6 @@ export function useScrollSync(
     return { blocks, offsetTops }
   }
 
-  // ============================================================
-  // 编辑器 → 预览
-  // ============================================================
   function onEditorScroll() {
     if (!enableScrollSync.value || isSyncingFromPreview)
       return
@@ -147,7 +137,6 @@ export function useScrollSync(
     if (scrollable <= 0)
       return
 
-    // 过滤由 onPreviewScroll 程序性设置 editor.scrollTop 产生的回弹事件
     if (pendingEditorScrollTop >= 0 && Math.abs(scroller.scrollTop - pendingEditorScrollTop) < 2) {
       pendingEditorScrollTop = -1
       return
@@ -156,7 +145,6 @@ export function useScrollSync(
 
     isSyncingFromEditor = true
 
-    // 边缘吸附：滚到顶 / 底时直接强制对齐，避免块映射偏差
     if (scroller.scrollTop <= 0) {
       pendingPreviewScrollTop = 0
       preview.scrollTop = 0
@@ -177,13 +165,11 @@ export function useScrollSync(
       return
     }
 
-    // 找到编辑器顶部可见行号
     const lineBlock = view.lineBlockAtHeight(scroller.scrollTop)
     const lineNo = view.state.doc.lineAt(lineBlock.from).number
 
     const srcIndex = sourceBlockIndexForLine(sourceBlocks, lineNo)
 
-    // 获取预览块并映射
     const { blocks: previewBlocks, offsetTops: previewOffsetTops } = getPreviewBlockElements(preview)
     if (previewBlocks.length === 0) {
       isSyncingFromEditor = false
@@ -199,9 +185,6 @@ export function useScrollSync(
     requestAnimationFrame(() => { isSyncingFromEditor = false })
   }
 
-  // ============================================================
-  // 预览 → 编辑器
-  // ============================================================
   function onPreviewScroll() {
     if (!enableScrollSync.value || isSyncingFromEditor)
       return
@@ -211,7 +194,6 @@ export function useScrollSync(
     if (!view || !preview)
       return
 
-    // 过滤由 onEditorScroll 程序性设置 preview.scrollTop 产生的回弹事件
     if (pendingPreviewScrollTop >= 0 && Math.abs(preview.scrollTop - pendingPreviewScrollTop) < 2) {
       pendingPreviewScrollTop = -1
       return
@@ -224,7 +206,6 @@ export function useScrollSync(
 
     isSyncingFromPreview = true
 
-    // 边缘吸附：滚到顶 / 底时直接强制对齐，避免块映射偏差
     if (preview.scrollTop <= 0) {
       pendingEditorScrollTop = 0
       view.scrollDOM.scrollTop = 0
@@ -245,7 +226,6 @@ export function useScrollSync(
       return
     }
 
-    // 二分查找：找最后一个 offsetTop ≤ scrollTop 的块（顶部可见块），避免 O(n) 强制布局
     const scrollTop = preview.scrollTop
     let lo = 0
     let hi = previewOffsetTops.length - 1
@@ -278,9 +258,6 @@ export function useScrollSync(
     requestAnimationFrame(() => { isSyncingFromPreview = false })
   }
 
-  // ============================================================
-  // 绑定/解绑事件
-  // ============================================================
   watchEffect((onCleanup) => {
     if (!enableScrollSync.value)
       return

--- a/apps/web/src/composables/useSyncStatusMeta.ts
+++ b/apps/web/src/composables/useSyncStatusMeta.ts
@@ -98,7 +98,7 @@ export function useSyncStatusMeta(options?: { errorHint?: `detail` | `generic` }
   }
 }
 
-/** Footer 云同步图标：依赖登录态，与弹窗内 meta 分离 */
+/** Footer cloud-sync icon: login-gated, separate from dialog meta. */
 export function useSyncFooterMeta() {
   const authStore = useAuthStore()
   const { isLoggedIn } = storeToRefs(authStore)

--- a/apps/web/src/lib/bootstrap/dismiss-initial-loader.ts
+++ b/apps/web/src/lib/bootstrap/dismiss-initial-loader.ts
@@ -4,7 +4,7 @@ const DISMISS_FALLBACK_MS = 25_000
 let dismissed = false
 let fallbackTimer: ReturnType<typeof setTimeout> | undefined
 
-/** 兜底：避免预览初始化异常导致启动屏一直不消失 */
+/** Fallback so a broken preview init cannot leave the splash screen forever. */
 export function scheduleInitialLoaderFallback() {
   if (fallbackTimer)
     return
@@ -14,7 +14,7 @@ export function scheduleInitialLoaderFallback() {
   }, DISMISS_FALLBACK_MS)
 }
 
-/** 移除 index.html 中的静态启动屏（预览就绪后调用） */
+/** Remove the static splash from index.html (call when preview is ready). */
 export function dismissInitialLoader() {
   if (dismissed)
     return

--- a/apps/web/src/lib/preview/preview-ready.ts
+++ b/apps/web/src/lib/preview/preview-ready.ts
@@ -43,12 +43,12 @@ function isMathStillLoading(output: HTMLElement): boolean {
   return false
 }
 
-/** 等待预览区异步图表与公式渲染完成；超时返回 false */
+/** Wait for async diagrams and math in preview; returns false on timeout. */
 export async function waitForPreviewReady(
   timeoutMs = PREVIEW_READY_TIMEOUT_MS,
   options?: WaitForPreviewReadyOptions,
 ): Promise<boolean> {
-  // 等待 Vue 将 renderStore.output 同步到 #output，避免检测到旧 DOM 后提前返回
+  // Wait for Vue to sync renderStore.output into #output (avoid stale DOM)
   await nextTick()
   await nextTick()
 
@@ -72,7 +72,7 @@ export async function waitForPreviewReady(
   return !isDiagramStillLoading(output) && !isMathStillLoading(output)
 }
 
-/** 移除仍未渲染完成的占位内容，避免复制/导出时出现「正在加载…」文案 */
+/** Strip unresolved async placeholders so copy/export omit loading text. */
 export function stripUnresolvedAsyncPlaceholders(root: ParentNode) {
   root.querySelectorAll<HTMLElement>(ASYNC_DIAGRAM_SELECTOR).forEach((el) => {
     if (el.querySelector(`svg, img`))

--- a/apps/web/src/services/account/client.ts
+++ b/apps/web/src/services/account/client.ts
@@ -12,7 +12,7 @@ export class ApiError extends Error {
   }
 }
 
-/** md-api 通用客户端（账户、云同步等接口共用鉴权） */
+/** Shared md-api client (account, cloud sync, shared auth). */
 export class MdApiClient {
   constructor(private getToken: () => string | null) {}
 

--- a/apps/web/src/services/account/config.ts
+++ b/apps/web/src/services/account/config.ts
@@ -1,18 +1,18 @@
-/** md-api 后端地址（云同步、账户登录等共用） */
+/** md-api base URL (cloud sync, account login, etc.). */
 export const MD_API_URL = (
   import.meta.env.VITE_MD_API_URL
     ?? import.meta.env.VITE_SYNC_API_URL
     ?? ``
 ).replace(/\/$/, ``)
 
-/** OAuth 回跳 fragment 参数名 */
+/** OAuth redirect fragment parameter name. */
 export const OAUTH_TOKEN_HASH_KEY = `account_token`
 
 export function isAccountConfigured(): boolean {
   return Boolean(MD_API_URL)
 }
 
-/** 是否在 UI 展示账户入口（登录/账户信息） */
+/** Whether to show account entry in UI (login / profile). */
 export function isAccountUiEnabled(): boolean {
   const flag = import.meta.env.VITE_ACCOUNT_UI_ENABLED
   if (flag === `false` || flag === `0`)
@@ -20,7 +20,7 @@ export function isAccountUiEnabled(): boolean {
   return isAccountConfigured()
 }
 
-/** 发起 GitHub 登录 */
+/** Start GitHub OAuth login. */
 export function gotoLogin(): void {
   const entry = `${window.location.origin}${window.location.pathname}`
   const redirect = encodeURIComponent(entry)

--- a/apps/web/src/services/account/extension.ts
+++ b/apps/web/src/services/account/extension.ts
@@ -23,7 +23,7 @@ function getExtensionRuntimeId(): string | undefined {
   return g.browser?.runtime?.id ?? g.chrome?.runtime?.id
 }
 
-/** 是否在浏览器扩展页面内运行（chrome-extension:// / moz-extension://） */
+/** Running inside a browser extension page (chrome-extension:// / moz-extension://). */
 export function isExtensionContext(): boolean {
   if (!EXTENSION_PROTOCOLS.has(window.location.protocol))
     return false
@@ -53,7 +53,7 @@ function isOAuthFlowCancelled(error: unknown): boolean {
   return /cancell?ed|did not approve|closed|aborted/i.test(message)
 }
 
-/** 通过 chrome.identity / browser.identity 在扩展内完成 OAuth，不离开当前页面 */
+/** OAuth via chrome.identity / browser.identity without leaving the extension page. */
 export async function loginViaExtensionIdentity(): Promise<ExtensionLoginResult> {
   const identity = getIdentityApi()
   if (!identity || !MD_API_URL)

--- a/apps/web/src/services/account/features.ts
+++ b/apps/web/src/services/account/features.ts
@@ -1,9 +1,9 @@
 import type { UserPlan } from './types'
 
-/** 暂时关闭 Pro 能力与升级入口 */
+/** Pro features and upgrade entry temporarily disabled. */
 export const SYNC_PRO_ENABLED = false
 
-/** Pro 实时云同步防抖间隔（毫秒） */
+/** Pro live cloud sync debounce interval (ms). */
 export const SYNC_DEBOUNCE_MS_PRO = 3000
 
 export function isProPlan(plan: UserPlan | undefined): boolean {

--- a/apps/web/src/services/account/oauth.ts
+++ b/apps/web/src/services/account/oauth.ts
@@ -4,7 +4,7 @@ import { OAUTH_TOKEN_HASH_KEY } from './config'
 
 export const ACCOUNT_TOKEN_KEY = addPrefix(`account_token`)
 
-/** 从 URL fragment 捕获 OAuth 回跳 token，捕获后清理地址栏 */
+/** Capture OAuth redirect token from URL fragment and clean the address bar. */
 export function captureOAuthToken(setToken: (token: string) => void): boolean {
   const hash = window.location.hash.replace(/^#/, ``)
   const params = new URLSearchParams(hash)

--- a/apps/web/src/services/account/types.ts
+++ b/apps/web/src/services/account/types.ts
@@ -1,7 +1,7 @@
-/** 用户套餐（后续可扩展更多高级能力） */
+/** User plan (extensible for future premium features). */
 export type UserPlan = `free` | `pro`
 
-/** 账户用户信息（与 md-api /me 一致） */
+/** Account user profile (matches md-api /me). */
 export interface AccountUser {
   id: string
   login: string

--- a/apps/web/src/services/export/html-content.ts
+++ b/apps/web/src/services/export/html-content.ts
@@ -7,7 +7,7 @@ export interface GetHtmlContentOptions {
   staticLayout?: boolean
 }
 
-/** 获取 HTML 内容 */
+/** Get export HTML content. */
 export function getHtmlContent(options?: GetHtmlContentOptions): string {
   const element = document.querySelector(`#output`)
   if (!element)

--- a/apps/web/src/services/export/html.ts
+++ b/apps/web/src/services/export/html.ts
@@ -6,7 +6,7 @@ import { EXPORT_LAYOUT_CSS } from './apply-export-layout'
 import { getHtmlContent } from './html-content'
 import { getStylesToAdd, SHARE_SHELL_VARS_CSS } from './share-styles'
 
-/** 导出 HTML 生成内容 */
+/** Export rendered HTML content. */
 export async function exportHTML(title: string = `untitled`) {
   await waitForPreviewReady()
   const htmlStr = getHtmlContent({ staticLayout: true })
@@ -33,7 +33,7 @@ export async function exportHTML(title: string = `untitled`) {
 
 export { generatePureHTML }
 
-/** 导出无样式 HTML 文件 */
+/** Export unstyled HTML file. */
 export async function exportPureHTML(raw: string, title: string = `untitled`) {
   const safeTitle = sanitizeTitle(title)
   const pureHtml = await generatePureHTML(raw)

--- a/apps/web/src/services/export/markdown.ts
+++ b/apps/web/src/services/export/markdown.ts
@@ -1,13 +1,13 @@
 import { sanitizeTitle } from '@md/shared/utils/basicHelpers'
 import { downloadFile } from '@md/shared/utils/fileHelpers'
 
-/** 导出原始 Markdown 文档 */
+/** Export raw Markdown document. */
 export function downloadMD(doc: string, title: string = `untitled`) {
   const safeTitle = sanitizeTitle(title)
   downloadFile(doc, `${safeTitle}.md`, `text/markdown;charset=utf-8`)
 }
 
-/** 批量导出多篇文章为 ZIP */
+/** Batch-export multiple posts as a ZIP archive. */
 export async function exportPostsAsZip(posts: Array<{ title: string, content: string }>) {
   const JSZip = (await import(`jszip`)).default
   const zip = new JSZip()

--- a/apps/web/src/services/export/pdf.ts
+++ b/apps/web/src/services/export/pdf.ts
@@ -5,7 +5,7 @@ import { EXPORT_LAYOUT_CSS } from './apply-export-layout'
 import { getHtmlContent } from './html-content'
 import { getStylesToAdd, SHARE_SHELL_VARS_CSS } from './share-styles'
 
-/** 导出 PDF 文档（新主题系统） */
+/** Export PDF document (current theme system). */
 export async function exportPDF(title: string = `untitled`) {
   await waitForPreviewReady()
   const htmlStr = getHtmlContent({ staticLayout: true })
@@ -22,14 +22,14 @@ export async function exportPDF(title: string = `untitled`) {
   ${stylesToAdd}
   <style>${EXPORT_LAYOUT_CSS}</style>
   <style>
-    /* 强制打印背景颜色和图片 */
+    /* Force print backgrounds and images */
     * {
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
       color-adjust: exact !important;
     }
 
-    /* 打印页面设置 */
+    /* @page margin boxes */
     @page {
       @top-center {
         content: "${safeTitle}";

--- a/apps/web/src/services/export/png.ts
+++ b/apps/web/src/services/export/png.ts
@@ -57,7 +57,7 @@ async function createOffScreenPreviewElement(
   }
 }
 
-/** 导出 PNG 卡片图片 */
+/** Export PNG card image. */
 export async function exportPNG(
   title: string = `untitled`,
   options: { previewDevice: `desktop` | `mobile` },

--- a/apps/web/src/services/export/share-styles.ts
+++ b/apps/web/src/services/export/share-styles.ts
@@ -1,8 +1,8 @@
 /**
- * 导出 / 分享 / 独立预览的 shell 变量。
- * 这些变量原本由 Web App 的全局样式（index.css 的 :root）提供，主题 CSS 通过
- * hsl(var(--foreground)) / var(--blockquote-background) 引用它们。脱离 App 后
- * 需手动补上，否则表格边框、引用块背景等会因变量未定义而失效。
+ * Shell CSS variables for export / share / standalone preview.
+ * Normally provided by the app global styles (:root in index.css); theme CSS references
+ * hsl(var(--foreground)) / var(--blockquote-background). Outside the app they must be
+ * inlined or table borders, blockquote backgrounds, etc. break.
  */
 export const SHARE_SHELL_VARS_CSS = `:root {
   --foreground: 0 0% 3.9%;
@@ -33,7 +33,7 @@ function scopeThemeCss(cssContent: string, scope: string): string {
   return css
 }
 
-/** 复制/导出：剥离 #output 前缀，使 juice 能匹配片段内元素（无 body/#output 祖先） */
+/** Strip #output scope so juice matches fragment nodes without a body/#output ancestor. */
 function stripOutputScope(cssContent: string): string {
   let css = cssContent
   css = css.replace(/#output\s*\{/g, `body {`)
@@ -46,7 +46,7 @@ function getThemeStyles(): string {
   const themeStyle = document.querySelector(`#md-theme`) as HTMLStyleElement
 
   if (!themeStyle || !themeStyle.textContent) {
-    console.warn('[getThemeStyles] 未找到主题样式')
+    console.warn('[getThemeStyles] theme styles not found')
     return ``
   }
 
@@ -54,11 +54,11 @@ function getThemeStyles(): string {
   return `<style>${cssContent}</style>`
 }
 
-/** 分享页专用样式（固定浅色，作用域到 .share-content） */
+/** Share page styles (fixed light theme, scoped to .share-content). */
 export async function getShareExportStyles(): Promise<string> {
   const themeStyle = document.querySelector(`#md-theme`) as HTMLStyleElement
   if (!themeStyle?.textContent) {
-    console.warn('[getShareExportStyles] 未找到主题样式')
+    console.warn('[getShareExportStyles] theme styles not found')
     return ``
   }
 
@@ -74,7 +74,7 @@ export async function getShareExportStyles(): Promise<string> {
   return parts.join(``)
 }
 
-/** 获取需要添加的样式（导出 / 分享页使用） */
+/** Styles bundled for export and share pages. */
 export async function getExportStyles(): Promise<string> {
   return getStylesToAdd()
 }

--- a/apps/web/src/services/share/capture-snapshot.ts
+++ b/apps/web/src/services/share/capture-snapshot.ts
@@ -4,7 +4,7 @@ import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
 
-/** 捕获浅色模式分享快照（编辑器处于深色模式时会临时按浅色重渲染） */
+/** Capture a light-theme share snapshot (re-renders temporarily if editor is in dark mode). */
 export async function captureShareSnapshot(): Promise<{ bodyHtml: string, stylesHtml: string }> {
   const renderStore = useRenderStore()
   const editorStore = useEditorStore()

--- a/apps/web/src/services/share/client.ts
+++ b/apps/web/src/services/share/client.ts
@@ -7,14 +7,14 @@ export function isShareConfigured(): boolean {
   return isAccountConfigured()
 }
 
-/** 是否为有效 Pro 用户（分享「我的分享」等 Pro 能力） */
+/** Whether user has active Pro (share "My shares" and related features). */
 export function isShareProUser(user: Pick<AccountUser, `plan` | `planExpiresAt`> | null | undefined): boolean {
   if (!user || user.plan !== `pro`)
     return false
   return user.planExpiresAt != null && user.planExpiresAt > Date.now()
 }
 
-/** 是否在 UI 中展示分享入口 */
+/** Whether to show share entry in UI. */
 export function isShareUiEnabled(): boolean {
   const flag = import.meta.env.VITE_SHARE_UI_ENABLED
   if (flag === `false` || flag === `0`)

--- a/apps/web/src/services/sync/afdian.ts
+++ b/apps/web/src/services/sync/afdian.ts
@@ -1,6 +1,6 @@
 import { t } from '@/i18n/translate'
 
-/** 爱发电 Pro 赞助方案（doocs 官方） */
+/** Afdian Pro sponsorship plan (doocs official). */
 export function getAfdianProPlans() {
   return [
     { label: t(`store.afdian.monthly`), planId: `81efdc48655711f18b6d52540025c377` },
@@ -11,7 +11,7 @@ export function getAfdianProPlans() {
 
 const ORDER_BASE = (import.meta.env.VITE_AFDIAN_ORDER_BASE ?? `https://ifdian.net`).replace(/\/$/, ``)
 
-/** 生成带备注的爱发电下单链接（备注用于绑定 GitHub 账号） */
+/** Build Afdian checkout URL with remark (used to bind GitHub account). */
 export function buildAfdianOrderUrl(planId: string, githubLogin: string): string {
   const params = new URLSearchParams({
     plan_id: planId,

--- a/apps/web/src/services/sync/client.ts
+++ b/apps/web/src/services/sync/client.ts
@@ -2,14 +2,14 @@ import type { ActivateProResponse, PullResponse, PushRequest, PushResponse } fro
 import { MdApiClient } from '@/services/account/client'
 import { isAccountConfigured } from '@/services/account/config'
 
-/** 爱发电创作者主页，用于 Pro 升级跳转 */
+/** Afdian creator page URL for Pro upgrade. */
 export const AFDIAN_PAGE_URL = (import.meta.env.VITE_AFDIAN_PAGE_URL ?? ``).replace(/\/$/, ``)
 
 export function isSyncConfigured(): boolean {
   return isAccountConfigured()
 }
 
-/** 是否在 UI 中展示云同步入口 */
+/** Whether to show cloud sync entry in UI. */
 export function isSyncUiEnabled(): boolean {
   const flag = import.meta.env.VITE_SYNC_UI_ENABLED
   if (flag === `false` || flag === `0`)

--- a/apps/web/src/services/sync/hydrate.ts
+++ b/apps/web/src/services/sync/hydrate.ts
@@ -50,7 +50,7 @@ async function refreshPreview(keys: Set<string>): Promise<void> {
   renderStore.render(editorStore.getContent())
 }
 
-/** 将已写入本地存储的远端设置同步到各 Pinia Store，无需整页刷新 */
+/** Hydrate Pinia stores from remote settings already written to local storage (no full reload). */
 export async function hydrateSyncedSettings(appliedKeys: string[]): Promise<void> {
   if (!appliedKeys.length)
     return

--- a/apps/web/src/services/sync/merge.ts
+++ b/apps/web/src/services/sync/merge.ts
@@ -35,7 +35,7 @@ function docToPost(doc: SyncDocument): Post {
   }
 }
 
-/** 把败方内容并入胜方历史，避免数据丢失（按内容去重）。有新增时返回 true。 */
+/** Merge loser content into winner history (dedupe by content). Returns true when entries were added. */
 function mergeHistory(winner: Post, loserContent: string, loserDatetime: number): boolean {
   if (!loserContent)
     return false
@@ -57,10 +57,10 @@ export interface MergeResult {
 }
 
 /**
- * 将远端文档合并进本地文章列表。
- * - 按 updateDatetime 做 last-write-wins
- * - 败方内容并入胜方 history 兜底
- * - 远端软删除且更新时间较新时，从本地移除
+ * Merge remote documents into the local post list.
+ * - Last-write-wins by updateDatetime
+ * - Loser content is appended to winner history as a safety net
+ * - Remote soft-delete with newer timestamp removes the local post
  */
 export function mergeRemoteIntoLocal(localPosts: Post[], remoteDocs: SyncDocument[]): MergeResult {
   const localMap = new Map(localPosts.map(p => [p.id, p]))
@@ -70,7 +70,6 @@ export function mergeRemoteIntoLocal(localPosts: Post[], remoteDocs: SyncDocumen
     const local = localMap.get(doc.id)
 
     if (!local) {
-      // 本地不存在
       if (!doc.deleted) {
         localMap.set(doc.id, docToPost(doc))
         changed = true
@@ -82,7 +81,6 @@ export function mergeRemoteIntoLocal(localPosts: Post[], remoteDocs: SyncDocumen
     const remoteMs = doc.updateDatetime
 
     if (remoteMs > localMs) {
-      // 远端较新
       if (doc.deleted) {
         localMap.delete(doc.id)
         changed = true
@@ -96,7 +94,6 @@ export function mergeRemoteIntoLocal(localPosts: Post[], remoteDocs: SyncDocumen
       }
     }
     else {
-      // 本地较新（或同时）：保留本地，远端内容并入历史兜底
       if (!doc.deleted && doc.content !== local.content) {
         if (mergeHistory(local, doc.content, remoteMs))
           changed = true

--- a/apps/web/src/services/sync/settings.ts
+++ b/apps/web/src/services/sync/settings.ts
@@ -8,12 +8,12 @@ export interface ApplyRemoteSettingsResult {
 }
 
 /**
- * 允许同步的偏好设置 key 白名单（显式枚举，避免泄露密钥）。
- * 刻意不包含：图床配置（githubConfig/aliOSSConfig/s3Config 等）、
- * AI 密钥（openai_key_*）、运行时/临时状态。
+ * Whitelist of preference keys allowed to sync (explicit enum; excludes secrets).
+ * Excludes image-host configs (githubConfig/aliOSSConfig/s3Config, etc.),
+ * AI keys (openai_key_*), and runtime/ephemeral state.
  */
 export const SYNC_SETTING_KEYS: string[] = [
-  // 主题与样式
+  // Theme and styling
   addPrefix(`theme`),
   addPrefix(`themeSettings`),
   addPrefix(`use_indent`),
@@ -22,7 +22,7 @@ export const SYNC_SETTING_KEYS: string[] = [
   `isCountStatus`,
   `legend`,
   `previewWidth`,
-  // 编辑器 / UI 偏好
+  // Editor / UI preferences
   `locale`,
   `showAIToolbox`,
   `viewMode`,
@@ -31,11 +31,11 @@ export const SYNC_SETTING_KEYS: string[] = [
   addPrefix(`sort_mode`),
   addPrefix(`enableImageReupload`),
   addPrefix(`enableScrollSync`),
-  // AI 非敏感参数（不含 key、不含 model）
+  // Non-sensitive AI params (no keys, no model)
   `openai_type`,
   `openai_temperature`,
   `openai_max_token`,
-  // 自定义内容
+  // Custom content
   addPrefix(`css_content_config`),
   addPrefix(`templates`),
   addPrefix(`custom_components`),
@@ -72,8 +72,8 @@ function readLocal(key: string): string | null {
 }
 
 /**
- * 收集本地发生变化的设置项（与上次同步快照比对），并刷新元数据时间戳。
- * 返回需要推送的设置列表。
+ * Collect locally changed settings (vs last sync snapshot) and refresh meta timestamps.
+ * Returns the list to push upstream.
  */
 export function collectChangedSettings(): SyncSetting[] {
   const meta = readMeta()
@@ -94,8 +94,8 @@ export function collectChangedSettings(): SyncSetting[] {
 }
 
 /**
- * 应用远端设置到本地（LWW，仅当远端更新时间较新时写入）。
- * 返回实际应用的 key 列表，供 hydrateSyncedSettings 热更新 Store。
+ * Apply remote settings locally (LWW; write only when remote is newer).
+ * Returns applied keys for hydrateSyncedSettings to hot-reload stores.
  */
 export async function applyRemoteSettings(remote: SyncSetting[]): Promise<ApplyRemoteSettingsResult> {
   const meta = readMeta()

--- a/apps/web/src/services/sync/types.ts
+++ b/apps/web/src/services/sync/types.ts
@@ -1,6 +1,6 @@
 /**
- * 云同步前后端共享契约（与 @md/api 保持一致）。
- * 时间字段统一为 epoch 毫秒。
+ * Cloud sync contract shared with backend (aligned with @md/api).
+ * Timestamps are epoch milliseconds.
  */
 
 import type { UserPlan } from '@/services/account/types'
@@ -20,7 +20,7 @@ export interface SyncDocument {
 
 export interface SyncSetting {
   key: string
-  /** localStorage 中的原始字符串值（保持原样回写，避免二次编解码） */
+  /** Raw localStorage string value (written back as-is to avoid double encode/decode). */
   value: string | null
   updatedAt: number
 }

--- a/apps/web/src/services/upload/client.ts
+++ b/apps/web/src/services/upload/client.ts
@@ -76,7 +76,7 @@ async function uploadImageViaApi(file: File, token?: string | null): Promise<str
   return data.url
 }
 
-/** 默认图床：经 md-api 上传，登录可选（登录后享更高限流） */
+/** Default image host via md-api; login optional (higher rate limit when logged in). */
 export async function uploadDefaultImage(file: File): Promise<string> {
   if (!isUploadViaApiEnabled())
     throw new Error(t('store.uploader.defaultHostRequiresApi'))

--- a/apps/web/src/services/upload/providers.ts
+++ b/apps/web/src/services/upload/providers.ts
@@ -52,10 +52,7 @@ async function getConfig(platform: string) {
   }
 }
 
-/**
- * 获取 `年/月/日` 形式的目录
- * @returns string
- */
+/** Directory path as YYYY/MM/DD. */
 function getDir() {
   const date = new Date()
   const year = date.getFullYear()
@@ -64,14 +61,9 @@ function getDir() {
   return `${year}/${month}/${day}`
 }
 
-/**
- * 根据文件名获取它以 `时间戳+uuid` 的形式
- * @param {string} filename 文件名
- * @returns {string} `时间戳+uuid`
- */
+/** Filename as timestamp-uuid with the original extension. */
 function getDateFilename(filename: string) {
   const currentTimestamp = Date.now()
-  // 获取最后一个点号后的内容作为文件扩展名
   const fileSuffix = filename.split(`.`).pop()
   return `${currentTimestamp}-${uuidv4()}.${fileSuffix}`
 }
@@ -460,13 +452,12 @@ async function getMpToken(appID: string, appsecret: string, proxyOrigin?: string
   }
   return ``
 }
-// Cloudflare Workers 环境
 const isCfWorkers = import.meta.env.CF_WORKERS === `1`
 
 async function mpFileUpload(file: File) {
   const configStr = await store.get(`mpConfig`)
   let { appID, appsecret, proxyOrigin } = safeJsonParse<{ appID: string, appsecret: string, proxyOrigin?: string }>(configStr, `mp config`)
-  // 未填写代理域名且是 Cloudflare Workers 环境时，使用当前域名作为代理域名
+  // When no proxy is configured on CF Workers, use the current origin
   if (!proxyOrigin && isCfWorkers) {
     proxyOrigin = window.location.origin
   }
@@ -597,7 +588,6 @@ async function telegramUpload(file: File): Promise<string> {
   if (!sendRes.ok || !sendRes.result.photo.length) {
     throw new Error(t(`upload.provider.telegramSendPhotoFailed`))
   }
-  // 取最大的分辨率那张图
   const fileId = sendRes.result.photo[sendRes.result.photo.length - 1].file_id
 
   // 2. getFile
@@ -613,7 +603,6 @@ async function telegramUpload(file: File): Promise<string> {
   }
 
   const filePath = fileRes.result.file_path
-  // 3. 拼出下载地址
   return `https://api.telegram.org/file/bot${token}/${filePath}`
 }
 
@@ -622,14 +611,14 @@ async function telegramUpload(file: File): Promise<string> {
 // -----------------------------------------------------------------------
 
 /**
- * cloudinaryConfig 配置示例：
+ * cloudinaryConfig example:
  * {
  *   "cloudName": "demo",
  *   "apiKey": "1234567890",
- *   "apiSecret": "abcdefg1234567890",     // 可选：若未填写则走 unsigned preset
- *   "uploadPreset": "unsigned_preset",     // 可选：有 apiSecret 时可省略
- *   "folder": "blog/image",                // 可选：Cloudinary 目录，留空则根路径
- *   "domain": "https://cdn.example.com"    // 可选：自定义访问域名 / CDN 域名
+ *   "apiSecret": "abcdefg1234567890",     // optional: omit for unsigned preset
+ *   "uploadPreset": "unsigned_preset",     // optional when apiSecret is set
+ *   "folder": "blog/image",                // optional Cloudinary folder
+ *   "domain": "https://cdn.example.com"    // optional custom CDN host
  * }
  */
 async function cloudinaryUpload(file: File): Promise<string> {
@@ -646,15 +635,14 @@ async function cloudinaryUpload(file: File): Promise<string> {
   if (!cloudName || !apiKey)
     throw new Error(t(`upload.provider.cloudinaryMissingConfig`))
 
-  const timestamp = Math.floor(Date.now() / 1000) // Cloudinary 要求秒级时间戳
+  const timestamp = Math.floor(Date.now() / 1000) // Cloudinary expects seconds
   const formData = new FormData()
   formData.append(`file`, file)
   formData.append(`api_key`, apiKey)
   formData.append(`timestamp`, `${timestamp}`)
 
-  // ---------- 1) 需要签名的场景 ----------
   if (apiSecret) {
-    // 参与签名的字段需按字典序排列并拼接成 a=b&c=d… 的格式
+    // Signed upload: sort params lexicographically as a=b&c=d…
     const params: string[] = []
     if (folder)
       params.push(`folder=${folder}`)
@@ -688,7 +676,6 @@ async function cloudinaryUpload(file: File): Promise<string> {
   if (!originUrl)
     throw new Error(t(`upload.provider.cloudinaryMissingUrl`))
 
-  // 如果配置了自定义域名，则把 host 换掉
   if (domain) {
     const { pathname, search } = new URL(originUrl)
     return `${domain}${pathname}${search}`
@@ -716,25 +703,25 @@ async function formCustomUpload(content: string, file: File) {
   `
   return new Promise<string>((resolve, reject) => {
     const exportObj = {
-      content, // 待上传图片的 base64
-      file, // 待上传图片的 file 对象
+      content,
+      file,
       util: {
-        axios: fetch, // axios-compatible fetch wrapper
-        CryptoJS, // 加密库
-        Buffer, // buffer-from
-        uuidv4, // uuid
-        qiniu, // qiniu-js
-        tokenTools, // 一些编码转换函数
-        getDir, // 获取 年/月/日 形式的目录
-        getDateFilename, // 根据文件名获取它以 时间戳+uuid 的形式
+        axios: fetch,
+        CryptoJS,
+        Buffer,
+        uuidv4,
+        qiniu,
+        tokenTools,
+        getDir,
+        getDateFilename,
         S3: {
           S3Client,
           PutObjectCommand,
           getSignedUrl,
         },
       },
-      okCb: resolve, // 重要: 上传成功后给此回调传 url 即可
-      errCb: reject, // 上传失败调用的函数
+      okCb: resolve, // pass uploaded URL on success
+      errCb: reject,
     }
     // Use Function constructor instead of eval
     // eslint-disable-next-line no-new-func

--- a/apps/web/src/storage/engine.ts
+++ b/apps/web/src/storage/engine.ts
@@ -1,5 +1,5 @@
 /**
- * 存储引擎接口 - 完全异步化，支持同步读缓存（initStorage 预加载后）
+ * Storage engine interface — fully async with sync read cache after initStorage preload.
  */
 export interface StorageEngine {
   get: (key: string) => Promise<string | null>
@@ -8,7 +8,7 @@ export interface StorageEngine {
   has: (key: string) => Promise<boolean>
   clear: () => Promise<void>
   keys: () => Promise<string[]>
-  /** 预加载完成后可用于 store.reactive 同步初始化 */
+  /** After preload, supports synchronous store.reactive initialization. */
   getSync?: (key: string) => string | null
   supportsSyncRead?: () => boolean
 }

--- a/apps/web/src/storage/engines/indexed-db.ts
+++ b/apps/web/src/storage/engines/indexed-db.ts
@@ -7,8 +7,8 @@ import { isStorageQuotaError, warnStorageQuota } from '@/storage/quota'
 type StoreName = ReturnType<typeof resolveStoreName>
 
 /**
- * IndexedDB KV 引擎：settings / secrets / cache 三个 store。
- * 内存 cache 在 preload 后支持同步读，供 store.reactive 首屏初始化。
+ * IndexedDB KV engine: settings / secrets / cache stores.
+ * In-memory cache enables sync reads after preload for store.reactive boot.
  */
 export class IndexedDBEngine implements StorageEngine {
   private cache = new Map<string, string>()
@@ -132,7 +132,7 @@ export class LocalStorageEngine implements StorageEngine {
   }
 }
 
-/** RESTful API 存储引擎 - 用于远程存储（保留扩展点） */
+/** REST API storage engine for remote storage (extension point). */
 export class RestfulStorageEngine implements StorageEngine {
   constructor(
     private baseURL: string,

--- a/apps/web/src/storage/index.ts
+++ b/apps/web/src/storage/index.ts
@@ -35,7 +35,7 @@ async function initLegacyFallback(reason: string): Promise<void> {
   initComplete = true
 }
 
-/** 初始化 IndexedDB 存储（在 createApp 之前 await） */
+/** Initialize IndexedDB storage (await before createApp). */
 export function initStorage(): Promise<void> {
   if (readyPromise)
     return readyPromise

--- a/apps/web/src/storage/keys.ts
+++ b/apps/web/src/storage/keys.ts
@@ -1,7 +1,7 @@
 import { prefix } from '@md/shared/configs'
 import { addPrefix } from '@/storage/prefix'
 
-/** IndexedDB 数据库名 */
+/** IndexedDB database name */
 export const DB_NAME = `doocs-md`
 export const DB_VERSION = 2
 
@@ -14,10 +14,10 @@ export const STORE_META = `meta`
 export const MIGRATION_V1_KEY = addPrefix(`storage_migrated_v1`)
 export const LOCALSTORAGE_CLEANED_KEY = addPrefix(`storage_localstorage_cleaned_v1`)
 
-/** localStorage 中本应用写入的 key 前缀（MD__） */
+/** localStorage key prefix written by this app (MD__) */
 export const LOCALSTORAGE_KEY_PREFIX = `${prefix}__`
 
-/** 未加 MD__ 前缀、但仍属于本应用的 localStorage key */
+/** App localStorage keys without the MD__ prefix */
 export const UNPREFIXED_APP_KEYS = new Set([
   `isCiteStatus`,
   `isCountStatus`,
@@ -39,11 +39,11 @@ export const UNPREFIXED_APP_KEYS = new Set([
   `formCustomConfig`,
 ])
 
-/** 文档相关 settings key（仅存 IDB settings，不存 documents 表） */
+/** Document-related settings keys (IDB settings only, not the documents table) */
 export const KEY_CURRENT_POST_ID = addPrefix(`current_post_id`)
 export const KEY_SORT_MODE = addPrefix(`sort_mode`)
 
-/** 旧版 localStorage 中的 posts 整包 key（仅迁移用） */
+/** Legacy localStorage posts bundle key (migration only) */
 export const LEGACY_POSTS_KEY = addPrefix(`posts`)
 
 const SECRET_SUFFIXES = [`Config`] as const
@@ -68,21 +68,21 @@ const CACHE_EXACT_KEYS = new Set([
 
 const CACHE_PREFIXES = [`ai_conversation_`] as const
 
-/** 图床 / AI 密钥等敏感配置 */
+/** Image host / AI secret configuration keys */
 export function isSecretKey(key: string): boolean {
   if (SECRET_SUFFIXES.some(s => key.endsWith(s)))
     return true
   return SECRET_PREFIXES.some(p => key.startsWith(p))
 }
 
-/** 可清除的缓存数据 */
+/** Clearable cache data keys */
 export function isCacheKey(key: string): boolean {
   if (CACHE_EXACT_KEYS.has(key))
     return true
   return CACHE_PREFIXES.some(p => key.startsWith(p))
 }
 
-/** 选择 IndexedDB object store */
+/** IndexedDB object store names */
 export function resolveStoreName(key: string): typeof STORE_SETTINGS | typeof STORE_SECRETS | typeof STORE_CACHE {
   if (isSecretKey(key))
     return STORE_SECRETS
@@ -91,10 +91,10 @@ export function resolveStoreName(key: string): typeof STORE_SETTINGS | typeof ST
   return STORE_SETTINGS
 }
 
-/** legacy theme keys（迁移后删除） */
+/** Legacy theme keys (removed after migration) */
 export const LEGACY_THEME_KEYS = [`fonts`, `size`, `color`, `codeBlockTheme`, `headingStyles`, `isMacCodeBlock`, `isShowLineNumber`] as const
 
-/** 是否为本应用写入的 localStorage key（迁移后可安全删除） */
+/** Whether a localStorage key belongs to this app (safe to delete after migration) */
 export function isAppLocalStorageKey(key: string): boolean {
   if (key.startsWith(LOCALSTORAGE_KEY_PREFIX))
     return true
@@ -113,8 +113,8 @@ export const KEY_THEME_SETTINGS = addPrefix(`themeSettings`)
 
 export const KEY_MP_PROFILE_MIGRATED = addPrefix(`mp_profile_migrated`)
 
-/** 图片 hash 缓存上限 */
+/** Max entries in image hash cache */
 export const MAX_IMAGE_MAP_ENTRIES = 500
 
-/** AI 生成图缓存上限 */
+/** Max entries in AI-generated image cache */
 export const MAX_AI_IMAGE_ENTRIES = 50

--- a/apps/web/src/storage/manager.ts
+++ b/apps/web/src/storage/manager.ts
@@ -9,9 +9,7 @@ import { trimCacheValue } from '@/storage/repositories/cache'
 export { IndexedDBEngine, LocalStorageEngine, RestfulStorageEngine }
 export type { StorageEngine }
 
-/**
- * 统一存储管理器
- */
+/** Unified storage manager. */
 class StorageManager {
   private engine: StorageEngine = new LocalStorageEngine()
 
@@ -23,7 +21,7 @@ class StorageManager {
     return this.engine
   }
 
-  /** 同步读取（initStorage 预加载后可用） */
+  /** Sync read (available after initStorage preload). */
   getSync(key: string): string | null {
     if (this.engine.getSync)
       return this.engine.getSync(key)

--- a/apps/web/src/storage/migrate/from-local-storage.ts
+++ b/apps/web/src/storage/migrate/from-local-storage.ts
@@ -58,9 +58,9 @@ export interface MigrationResult {
 }
 
 /**
- * 迁移完成后清理 localStorage 中已迁入 IndexedDB 的应用数据。
- * @param explicitKeys 本次迁移涉及的 key；省略则扫描所有本应用 key
- * @returns 删除的 key 数量
+ * After migration, remove app data from localStorage that was moved to IndexedDB.
+ * @param explicitKeys Keys involved in this migration; omit to scan all app keys
+ * @returns Number of keys deleted
  */
 export function cleanupMigratedLocalStorage(explicitKeys?: string[]): number {
   const candidates = new Set<string>()
@@ -218,7 +218,7 @@ export async function migrateMpProfile(engine: IndexedDBEngine): Promise<void> {
 }
 
 /**
- * 将 localStorage 全量迁入 IndexedDB（首次启动执行一次）。
+ * One-time full migration from localStorage to IndexedDB on first launch.
  */
 export async function migrateFromLocalStorage(engine: IndexedDBEngine): Promise<MigrationResult> {
   const keysToMigrate: string[] = []
@@ -261,7 +261,7 @@ export async function migrateFromLocalStorage(engine: IndexedDBEngine): Promise<
   }
 }
 
-/** 清除 cache store */
+/** Clear the cache object store. */
 export async function clearCacheStore(): Promise<void> {
   const db = await getDatabase()
   await db.clear(STORE_CACHE)

--- a/apps/web/src/storage/quota.ts
+++ b/apps/web/src/storage/quota.ts
@@ -2,7 +2,7 @@ import { t } from '@/i18n/translate'
 
 let lastQuotaWarnAt = 0
 
-/** 本地存储配额不足时提示（5 秒内去重） */
+/** Warn when local storage quota is low (deduped within 5s). */
 export function warnStorageQuota(): void {
   const now = Date.now()
   if (now - lastQuotaWarnAt < 5000)

--- a/apps/web/src/storage/repositories/cache.ts
+++ b/apps/web/src/storage/repositories/cache.ts
@@ -1,6 +1,6 @@
 import { MAX_AI_IMAGE_ENTRIES, MAX_IMAGE_MAP_ENTRIES } from '@/storage/keys'
 
-/** 裁剪 JSON 对象 map，保留最近 maxEntries 条 */
+/** Trim JSON object map to the most recent maxEntries entries. */
 export function trimRecordMap(raw: string, maxEntries: number): string {
   try {
     const map = JSON.parse(raw) as Record<string, string>
@@ -19,7 +19,7 @@ export function trimRecordMap(raw: string, maxEntries: number): string {
   }
 }
 
-/** 裁剪 JSON 数组，保留最近 maxEntries 条 */
+/** Trim JSON array to the most recent maxEntries entries. */
 export function trimArray(raw: string, maxEntries: number): string {
   try {
     const arr = JSON.parse(raw) as unknown[]

--- a/apps/web/src/storage/repositories/documents.ts
+++ b/apps/web/src/storage/repositories/documents.ts
@@ -38,7 +38,7 @@ let cachedPosts: Post[] | null = null
 let useLegacyStorage = false
 let writeQueue: Promise<void> = Promise.resolve()
 
-/** IndexedDB 不可用时，回退到 localStorage 整包存储 */
+/** Fallback to localStorage bundle when IndexedDB is unavailable. */
 export function setUseLegacyDocumentStorage(enabled: boolean): void {
   useLegacyStorage = enabled
 }

--- a/apps/web/src/storage/safe-access.ts
+++ b/apps/web/src/storage/safe-access.ts
@@ -3,7 +3,7 @@ import { isStorageQuotaError, parseStoredValue, warnStorageQuota } from '@/stora
 
 export { isStorageQuotaError, parseStoredValue, warnStorageQuota }
 
-/** 同步读取（initStorage 完成后走 IndexedDB 内存缓存） */
+/** Sync read (uses in-memory cache after initStorage). */
 export function safeGetItem(key: string): string | null {
   try {
     if (store.supportsSyncRead())
@@ -16,7 +16,7 @@ export function safeGetItem(key: string): string | null {
   }
 }
 
-/** 写入存储（异步持久化，同步更新内存缓存） */
+/** Write storage (async persist, sync memory cache update). */
 export function safeSetItem(key: string, value: string): boolean {
   try {
     void store.set(key, value)

--- a/apps/web/src/stores/aiConfig.ts
+++ b/apps/web/src/stores/aiConfig.ts
@@ -7,36 +7,21 @@ import {
 } from '@md/shared/constants'
 import { store } from '@/storage'
 
-/**
- * AI 配置 Store
- * 负责管理 AI 服务的配置，包括服务类型、模型、温度等参数
- */
+/** AI service configuration: provider, model, temperature, API keys. */
 export const useAIConfigStore = defineStore(`AIConfig`, () => {
-  // ==================== 全局配置 ====================
-
-  // 服务类型
   const type = store.reactive<string>(`openai_type`, DEFAULT_SERVICE_TYPE)
 
-  // 温度参数（0-2，控制随机性）
   const temperature = store.reactive<number>(`openai_temperature`, DEFAULT_SERVICE_TEMPERATURE)
 
-  // 最大 token 数
   const maxToken = store.reactive<number>(`openai_max_token`, DEFAULT_SERVICE_MAX_TOKEN)
 
-  // ==================== 服务相关字段 ====================
-
-  // 服务端点（由 watch(type) 自动初始化）
   const endpoint = ref<string>(``)
 
-  // 模型名称（由 watch(type) 自动初始化）
   const model = ref<string>(``)
 
-  // ==================== API Key 管理 ====================
-
-  // API Key（按服务类型分别持久化）
   const apiKey = ref<string>(DEFAULT_SERVICE_KEY)
 
-  // 异步加载初始值（捕获 type 防止竞态覆盖）
+  // Capture type on load to avoid async race overwriting a newer selection
   Promise.resolve().then(async () => {
     const capturedType = type.value
     const value = await store.get(`openai_key_${capturedType}`)
@@ -45,54 +30,39 @@ export const useAIConfigStore = defineStore(`AIConfig`, () => {
     }
   })
 
-  // ==================== 响应式逻辑 ====================
-
-  // 监听服务类型变化，自动同步端点、模型和 API Key
   watch(
     type,
     async (newType) => {
       const svc = serviceOptions.find(s => s.value === newType) ?? serviceOptions[0]
 
-      // 更新服务端点
       endpoint.value = svc.endpoint
 
-      // 读取已保存的模型，如果不存在或不在列表中，则使用默认模型
       const saved = await store.get(`openai_model_${newType}`) || ``
       model.value = svc.models.includes(saved) ? saved : svc.models[0]
 
-      // 保存当前模型
       await store.set(`openai_model_${newType}`, model.value)
 
-      // 加载对应服务的 API Key
       const keyValue = await store.get(`openai_key_${newType}`)
       apiKey.value = keyValue || DEFAULT_SERVICE_KEY
     },
-    { immediate: true }, // 首次加载时也执行
+    { immediate: true },
   )
 
-  // 监听 API Key 变化，持久化存储（仅非默认服务类型）
   watch(apiKey, async (val) => {
     if (type.value !== DEFAULT_SERVICE_TYPE) {
       await store.set(`openai_key_${type.value}`, val)
     }
   })
 
-  // 监听模型变化，持久化存储
   watch(model, async (val) => {
     await store.set(`openai_model_${type.value}`, val)
   })
 
-  // ==================== Actions ====================
-
-  /**
-   * 重置所有配置到默认值
-   */
   const reset = async () => {
     type.value = DEFAULT_SERVICE_TYPE
     temperature.value = DEFAULT_SERVICE_TEMPERATURE
     maxToken.value = DEFAULT_SERVICE_MAX_TOKEN
 
-    // 清理所有服务相关的持久化数据
     await Promise.all(
       serviceOptions.map(async ({ value }) => {
         await store.remove(`openai_key_${value}`)
@@ -102,18 +72,14 @@ export const useAIConfigStore = defineStore(`AIConfig`, () => {
   }
 
   return {
-    // State
     type,
     endpoint,
     model,
     temperature,
     maxToken,
     apiKey,
-
-    // Actions
     reset,
   }
 })
 
-// 默认导出（向后兼容）
 export default useAIConfigStore

--- a/apps/web/src/stores/aiImageConfig.ts
+++ b/apps/web/src/stores/aiImageConfig.ts
@@ -5,31 +5,19 @@ import {
 } from '@md/shared/constants'
 import { store } from '@/storage'
 
-/**
- * AI 图片生成配置 Store
- * 负责管理 AI 图片生成服务的配置，包括服务类型、尺寸、质量等参数
- */
+/** AI image generation configuration: provider, size, quality, API keys. */
 export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
-  // ==================== 全局配置 ====================
-
-  // 服务类型
   const type = store.reactive<string>(`openai_image_type`, DEFAULT_SERVICE_TYPE)
 
-  // 图片尺寸
   const size = store.reactive<string>(`openai_image_size`, `1024x1024`)
 
-  // 图片质量
   const quality = store.reactive<string>(`openai_image_quality`, `standard`)
 
-  // 图片风格
   const style = store.reactive<string>(`openai_image_style`, `natural`)
 
-  // ==================== 服务相关字段 ====================
-
-  // 服务端点（支持自定义服务）
   const endpoint = ref<string>(``)
 
-  // 异步加载初始端点（捕获 type 防止竞态覆盖）
+  // Capture type on load to avoid async race overwriting a newer selection
   Promise.resolve().then(async () => {
     const capturedType = type.value
     if (capturedType === `custom`) {
@@ -46,15 +34,10 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
     }
   })
 
-  // 模型名称（由 watch(type) 自动初始化）
   const model = ref<string>(``)
 
-  // ==================== API Key 管理 ====================
-
-  // API Key（按服务类型分别持久化）
   const apiKey = ref<string>(DEFAULT_SERVICE_KEY)
 
-  // 异步加载初始值（捕获 type 防止竞态覆盖）
   Promise.resolve().then(async () => {
     const capturedType = type.value
     const value = await store.get(`openai_image_key_${capturedType}`)
@@ -63,15 +46,11 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
     }
   })
 
-  // ==================== 响应式逻辑 ====================
-
-  // 监听服务类型变化，自动同步端点、模型和 API Key
   watch(
     type,
     async (newType) => {
       const svc = imageServiceOptions.find(s => s.value === newType) ?? imageServiceOptions[0]
 
-      // 同步端点
       if (newType === `custom`) {
         const endpointValue = await store.get(`openai_image_endpoint_${newType}`)
         endpoint.value = endpointValue || ``
@@ -81,59 +60,46 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
       }
 
       if (newType === `custom`) {
-        // 自定义服务：从存储读取模型
         const savedModel = await store.get(`openai_image_model_${newType}`) || ``
         model.value = savedModel
       }
       else {
-        // 预设服务：读取已保存的模型，如果不存在或不在列表中，则使用默认模型
         const saved = await store.get(`openai_image_model_${newType}`) || ``
         model.value = svc.models.includes(saved) ? saved : svc.models[0]
 
-        // 如果需要回退到默认模型，则保存
         if (!svc.models.includes(saved) && svc.models[0]) {
           await store.set(`openai_image_model_${newType}`, svc.models[0])
         }
       }
 
-      // 加载对应服务的 API Key
       const keyValue = await store.get(`openai_image_key_${newType}`)
       apiKey.value = keyValue || DEFAULT_SERVICE_KEY
     },
-    { immediate: true }, // 首次加载时也执行
+    { immediate: true },
   )
 
-  // 监听模型变化，持久化存储
   watch(model, async (val) => {
     await store.set(`openai_image_model_${type.value}`, val)
   })
 
-  // 监听 API Key 变化，持久化存储（仅非默认服务类型）
   watch(apiKey, async (val) => {
     if (type.value !== DEFAULT_SERVICE_TYPE) {
       await store.set(`openai_image_key_${type.value}`, val)
     }
   })
 
-  // 监听端点变化，持久化存储（仅自定义服务类型）
   watch(endpoint, async (val) => {
     if (type.value === `custom`) {
       await store.set(`openai_image_endpoint_${type.value}`, val)
     }
   })
 
-  // ==================== Actions ====================
-
-  /**
-   * 重置所有配置到默认值
-   */
   const reset = async () => {
     type.value = DEFAULT_SERVICE_TYPE
     size.value = `1024x1024`
     quality.value = `standard`
     style.value = `natural`
 
-    // 清理所有服务相关的持久化数据
     await Promise.all(
       imageServiceOptions.map(async ({ value }) => {
         await store.remove(`openai_image_key_${value}`)
@@ -144,7 +110,6 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
   }
 
   return {
-    // State
     type,
     endpoint,
     model,
@@ -152,11 +117,8 @@ export const useAIImageConfigStore = defineStore(`AIImageConfig`, () => {
     quality,
     style,
     apiKey,
-
-    // Actions
     reset,
   }
 })
 
-// 默认导出（向后兼容）
 export default useAIImageConfigStore

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -12,8 +12,8 @@ import { SyncClient } from '@/services/sync/client'
 import { store } from '@/storage'
 
 /**
- * 全局账户 Store
- * 负责登录态、JWT、用户信息；云同步等云端能力共用同一账户
+ * Global account store: auth token, JWT, user profile.
+ * Cloud sync and other cloud features share this account.
  */
 export const useAuthStore = defineStore(`auth`, () => {
   const token = store.reactive(ACCOUNT_TOKEN_KEY, ``)
@@ -26,7 +26,7 @@ export const useAuthStore = defineStore(`auth`, () => {
   const api = new MdApiClient(() => token.value || null)
   const syncClient = new SyncClient(() => token.value || null)
 
-  /** 启动时捕获 OAuth 回跳并拉取用户信息 */
+  /** On startup: capture OAuth redirect token and fetch user profile. */
   async function bootstrap(): Promise<void> {
     if (!isConfigured.value || bootstrapped)
       return

--- a/apps/web/src/stores/confirm.ts
+++ b/apps/web/src/stores/confirm.ts
@@ -6,11 +6,11 @@ interface ConfirmOptions {
   description?: string
   cancelText?: string
   confirmText?: string
-  /** 确认按钮使用红色 destructive 样式 */
+  /** Use destructive (red) style for the confirm button. */
   destructive?: boolean
-  /** 确认回调 */
+  /** Confirm callback. */
   onConfirm?: () => void | Promise<void>
-  /** 取消回调（可选） */
+  /** Optional cancel callback. */
   onCancel?: () => void
 }
 

--- a/apps/web/src/stores/cssEditor.ts
+++ b/apps/web/src/stores/cssEditor.ts
@@ -10,9 +10,7 @@ import { addPrefix } from '@/storage/prefix'
 
 const DEFAULT_CSS_CONTENT = DEFAULT_CUSTOM_THEME
 
-/**
- * CSS 编辑器配置接口
- */
+/** CSS editor tab configuration. */
 export interface CssContentConfig {
   active: string
   tabs: {
@@ -27,28 +25,22 @@ export interface CssContentConfig {
   isSelectMode?: boolean
 }
 
-/**
- * CSS 编辑器 Store
- * 负责管理自定义 CSS 编辑器及其配置
- */
+/** Manages the custom CSS editor and its tab configuration. */
 export const useCssEditorStore = defineStore(`cssEditor`, () => {
   const isDark = useDark()
 
-  // CSS 编辑器实例
   const cssEditor = ref<EditorView | null>(null)
   const cssEditorThemeCompartment = ref<Compartment | null>(null)
 
-  // CSS 内容配置
   const cssContentConfig = store.reactive<CssContentConfig>(addPrefix(`css_content_config`), {
     active: ``,
     tabs: [],
   })
 
-  // 兼容旧数据：补齐缺失的 id / createDatetime / updateDatetime，并将 active 迁移为 id
+  // Backfill missing id / timestamps; migrate active from name to id
   onBeforeMount(() => {
     const now = new Date()
 
-    // 如果没有任何 tab，初始化默认方案
     if (cssContentConfig.value.tabs.length === 0) {
       const defaultId = crypto.randomUUID()
       cssContentConfig.value.tabs = [{
@@ -70,16 +62,14 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
       updateDatetime: tab.updateDatetime ?? new Date(now.getTime() + index),
     }))
 
-    // 将旧的 active（name）迁移为 id
     const activeById = cssContentConfig.value.tabs.find(t => t.id === cssContentConfig.value.active)
     if (!activeById) {
-      // 旧数据中 active 存的是 name，找到对应 tab 再存 id
+      // Legacy data stored active as tab name; resolve to id
       const activeByName = cssContentConfig.value.tabs.find(t => t.name === cssContentConfig.value.active)
       cssContentConfig.value.active = activeByName?.id ?? cssContentConfig.value.tabs[0].id
     }
   })
 
-  // 获取当前激活的 Tab
   const getCurrentTab = () => {
     const tab = cssContentConfig.value.tabs.find(tab => tab.id === cssContentConfig.value.active)
     if (!tab) {
@@ -104,12 +94,10 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     return tab
   }
 
-  // 获取当前 Tab 的内容
   const getCurrentTabContent = () => {
     return getCurrentTab().content
   }
 
-  // 设置编辑器内容
   const setCssEditorValue = (content: string) => {
     if (cssEditor.value) {
       cssEditor.value.dispatch({
@@ -118,15 +106,13 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     }
   }
 
-  // 切换 Tab 的回调（由外部传入，用于触发渲染刷新）
+  /** External callback to refresh preview when the active CSS tab changes. */
   let onTabChangedCallback: ((content: string) => void) | null = null
 
-  // 设置切换 Tab 的回调
   const setOnTabChangedCallback = (callback: (content: string) => void) => {
     onTabChangedCallback = callback
   }
 
-  // 切换 Tab
   const tabChanged = (id: string) => {
     cssContentConfig.value.active = id
     const tab = cssContentConfig.value.tabs.find(tab => tab.id === id)
@@ -134,21 +120,17 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
       return
     setCssEditorValue(tab.content)
 
-    // 触发回调以刷新渲染
     if (onTabChangedCallback) {
       onTabChangedCallback(tab.content)
     }
   }
 
-  // 重命名 Tab
   const renameTab = (name: string) => {
     const tab = getCurrentTab()
     tab.title = name
     tab.name = name
-    // active 存的是 id，重命名不需要更新 active
   }
 
-  // 添加 CSS 方案
   const addCssContentTab = (name: string, initialContent?: string) => {
     const content = initialContent || DEFAULT_CSS_CONTENT
     const now = new Date()
@@ -164,13 +146,11 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     cssContentConfig.value.active = newTab.id
     setCssEditorValue(content)
 
-    // 触发回调以刷新渲染（使用新方案的 CSS）
     if (onTabChangedCallback) {
       onTabChangedCallback(content)
     }
   }
 
-  // 重置 CSS 配置
   const resetCssConfig = () => {
     const defaultId = crypto.randomUUID()
     cssContentConfig.value = {
@@ -194,7 +174,6 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     }
   }
 
-  // 初始化 CSS 编辑器
   const initCssEditor = (onUpdate: (content: string) => void) => {
     const cssEditorDom = document.querySelector<HTMLTextAreaElement>(`#cssEditor`)
     if (!cssEditorDom)
@@ -202,15 +181,12 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
 
     cssEditorDom.value = getCurrentTab().content
 
-    // 创建 CSS 编辑器的容器
     const cssContainer = document.createElement(`div`)
     cssContainer.className = 'w-full h-full'
     cssEditorDom.parentNode?.replaceChild(cssContainer, cssEditorDom)
 
-    // 创建主题 Compartment 用于动态切换
     cssEditorThemeCompartment.value = new Compartment()
 
-    // 创建 CSS 编辑器
     const state = EditorState.create({
       doc: getCurrentTab().content,
       extensions: [
@@ -234,7 +210,6 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     }))
   }
 
-  // 监听深色模式变化
   watch(isDark, () => {
     if (cssEditor.value && cssEditorThemeCompartment.value) {
       cssEditor.value.dispatch({
@@ -243,7 +218,6 @@ export const useCssEditorStore = defineStore(`cssEditor`, () => {
     }
   })
 
-  // 滚动到指定标题级别的 CSS 区域并选中
   const scrollToHeading = (level: string) => {
     if (!cssEditor.value)
       return

--- a/apps/web/src/stores/customComponent.ts
+++ b/apps/web/src/stores/customComponent.ts
@@ -5,36 +5,27 @@ import { store } from '@/storage'
 import { addPrefix } from '@/storage/prefix'
 
 /**
- * 自定义组件管理 Store
+ * Custom component store.
  *
- * 用户可定义 JSX 风格的组件，在 Markdown 中使用：
- *   <QRCodeBlock url="https://example.com" text="扫码访问" />
+ * Users define JSX-style components for Markdown, e.g.:
+ *   <QRCodeBlock url="https://example.com" text="Scan to visit" />
  *
- * 内置组件随系统提供，用户组件持久化到 localStorage。
- * 合并后的注册表传递给渲染器使用。
+ * Built-in components ship with the app; user components persist to localStorage.
+ * The merged registry is passed to the renderer.
  */
 export const useCustomComponentStore = defineStore(`customComponent`, () => {
-  // ==================== 状态 ====================
-
-  /** 用户自定义组件列表（持久化） */
   const userComponents = store.reactive<CustomComponentDef[]>(addPrefix(`custom_components`), [])
 
-  // ==================== 计算属性 ====================
-
-  /** 内置组件列表（只读） */
   const builtInComponents = computed(() => BUILT_IN_COMPONENTS)
 
-  /** 所有组件（内置 + 用户，用户组件可覆盖内置组件名） */
   const allComponents = computed<CustomComponentDef[]>(() => {
     const builtInMap = new Map(BUILT_IN_COMPONENTS.map(c => [c.name, c]))
-    // 用户组件覆盖同名内置组件
     for (const c of userComponents.value) {
       builtInMap.set(c.name, c)
     }
     return [...builtInMap.values()]
   })
 
-  /** 渲染器使用的注册表 */
   const registry = computed<ComponentRegistry>(() => {
     const base = getBuiltInRegistry()
     for (const c of userComponents.value) {
@@ -43,11 +34,6 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
     return base
   })
 
-  // ==================== 方法 ====================
-
-  /**
-   * 创建新的用户组件
-   */
   function createComponent(params: CreateComponentParams): CustomComponentDef {
     const now = Date.now()
     const def: CustomComponentDef = {
@@ -64,9 +50,6 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
     return def
   }
 
-  /**
-   * 更新用户组件
-   */
   function updateComponent(id: string, params: UpdateComponentParams): boolean {
     const idx = userComponents.value.findIndex(c => c.id === id)
     if (idx === -1) {
@@ -82,9 +65,6 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
     return true
   }
 
-  /**
-   * 删除用户组件（不能删除内置组件）
-   */
   function deleteComponent(id: string): boolean {
     const idx = userComponents.value.findIndex(c => c.id === id)
     if (idx === -1) {
@@ -97,17 +77,11 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
     return true
   }
 
-  /**
-   * 根据 ID 查找用户组件
-   */
   function getComponentById(id: string): CustomComponentDef | undefined {
     return userComponents.value.find(c => c.id === id)
   }
 
-  /**
-   * 生成该组件的 Markdown 使用示例字符串
-   * 优先使用 example 字段；否则自动构造，根据 prop.type 生成合适的占位值
-   */
+  /** Build a Markdown usage snippet; uses `example` when set, otherwise derives placeholders from prop types. */
   function buildSnippet(def: CustomComponentDef): string {
     if (def.example)
       return def.example
@@ -131,13 +105,10 @@ export const useCustomComponentStore = defineStore(`customComponent`, () => {
   }
 
   return {
-    // State
     userComponents,
-    // Computed
     builtInComponents,
     allComponents,
     registry,
-    // Actions
     createComponent,
     updateComponent,
     deleteComponent,

--- a/apps/web/src/stores/editor.ts
+++ b/apps/web/src/stores/editor.ts
@@ -1,12 +1,8 @@
 import type { EditorView } from '@codemirror/view'
 import { t } from '@/i18n/translate'
 
-/**
- * 编辑器 Store
- * 负责管理 CodeMirror 编辑器实例和基础操作
- */
+/** CodeMirror editor instance and basic document operations. */
 export const useEditorStore = defineStore(`editor`, () => {
-  // 内容编辑器实例
   const editor = ref<EditorView | null>(null)
 
   let flushPendingContent: (() => void) | null = null
@@ -19,12 +15,11 @@ export const useEditorStore = defineStore(`editor`, () => {
     flushPendingContent = null
   }
 
-  /** 将编辑器中尚未防抖落盘的内容同步到 post store（刷新前调用） */
+  /** Sync debounced editor content to post store (call before page refresh). */
   function flushContentToPostStore() {
     flushPendingContent?.()
   }
 
-  // 格式化文档
   const formatContent = async () => {
     if (!editor.value)
       return
@@ -37,7 +32,6 @@ export const useEditorStore = defineStore(`editor`, () => {
     return doc
   }
 
-  // 导入默认文档
   const importContent = (content: string) => {
     if (!editor.value)
       return
@@ -47,7 +41,6 @@ export const useEditorStore = defineStore(`editor`, () => {
     })
   }
 
-  // 清空内容
   const clearContent = () => {
     if (!editor.value)
       return
@@ -58,12 +51,10 @@ export const useEditorStore = defineStore(`editor`, () => {
     toast.success(t('store.editor.contentCleared'))
   }
 
-  // 获取当前内容
   const getContent = () => {
     return editor.value?.state.doc.toString() ?? ``
   }
 
-  // 获取选中的文本
   const getSelection = () => {
     if (!editor.value)
       return ``
@@ -72,7 +63,6 @@ export const useEditorStore = defineStore(`editor`, () => {
     return editor.value.state.doc.sliceString(selection.from, selection.to)
   }
 
-  // 替换选中的文本
   const replaceSelection = (text: string) => {
     if (!editor.value)
       return
@@ -112,7 +102,6 @@ export const useEditorStore = defineStore(`editor`, () => {
     return true
   }
 
-  // 在光标位置插入文本
   const insertAtCursor = (text: string) => {
     if (!editor.value)
       return

--- a/apps/web/src/stores/export.ts
+++ b/apps/web/src/stores/export.ts
@@ -9,18 +9,13 @@ import {
 import { usePostStore } from './post'
 import { useUIStore } from './ui'
 
-/**
- * 导出功能 Store
- * 负责处理各种导出功能：HTML、PDF、MD、图片等
- */
+/** Export helpers: HTML, PDF, Markdown, card image, etc. */
 export const useExportStore = defineStore(`export`, () => {
   const postStore = usePostStore()
   const uiStore = useUIStore()
 
-  // 将编辑器内容转换为 HTML
   const editorContent2HTML = () => getHtmlContent()
 
-  // 导出编辑器内容为 HTML，并且下载到本地
   const exportEditorContent2HTML = async () => {
     const currentPost = postStore.currentPost
     if (!currentPost)
@@ -29,7 +24,6 @@ export const useExportStore = defineStore(`export`, () => {
     await exportHTML(currentPost.title)
   }
 
-  // 导出编辑器内容为无样式 HTML
   const exportEditorContent2PureHTML = (content: string) => {
     const currentPost = postStore.currentPost
     if (!currentPost)
@@ -38,7 +32,6 @@ export const useExportStore = defineStore(`export`, () => {
     exportPureHTML(content, currentPost.title)
   }
 
-  // 下载卡片图片
   const downloadAsCardImage = async () => {
     const currentPost = postStore.currentPost
     if (!currentPost)
@@ -49,7 +42,6 @@ export const useExportStore = defineStore(`export`, () => {
     })
   }
 
-  // 导出编辑器内容为 PDF
   const exportEditorContent2PDF = async () => {
     const currentPost = postStore.currentPost
     if (!currentPost)
@@ -58,7 +50,6 @@ export const useExportStore = defineStore(`export`, () => {
     await exportPDF(currentPost.title)
   }
 
-  // 导出编辑器内容到本地（Markdown）
   const exportEditorContent2MD = (content: string) => {
     const currentPost = postStore.currentPost
     if (!currentPost)

--- a/apps/web/src/stores/folderSource.ts
+++ b/apps/web/src/stores/folderSource.ts
@@ -1,6 +1,3 @@
-/**
- * 文件系统节点接口
- */
 import { t } from '@/i18n/translate'
 
 export interface FileSystemNode {
@@ -11,64 +8,47 @@ export interface FileSystemNode {
   handle?: FileSystemFileHandle | FileSystemDirectoryHandle
 }
 
-/**
- * 运行时文件夹信息（包含 handle，仅在内存中）
- */
+/** Runtime folder info (includes handle; kept in memory only). */
 interface RuntimeFolderInfo {
   id: string
   name: string
   handle: FileSystemDirectoryHandle
 }
 
-/**
- * Safely extract a message from an unknown error value.
- */
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error)
     return error.message
   return String(error)
 }
 
-/**
- * Safely extract the error name from an unknown error value.
- */
 function getErrorName(error: unknown): string {
   if (error instanceof Error)
     return error.name
   return `UnknownError`
 }
 
-/**
- * 本地文件夹源 Store
- * 负责管理本地文件夹的访问、文件树结构和文件读写
- */
+/** Local folder source: File System Access API, file tree, read/write. */
 export const useFolderSourceStore = defineStore(`folderSource`, () => {
-  // 内存中的运行时文件夹信息（不持久化）
   const runtimeFolderMap = new Map<string, RuntimeFolderInfo>()
 
-  // 当前激活的文件夹 ID（不持久化）
   const currentFolderId = ref<string | null>(null)
 
-  // 当前文件夹的文件树（不持久化，因为包含不可序列化的 handle）
+  // Not persisted: tree nodes hold non-serializable handles
   const fileTree = ref<FileSystemNode[]>([])
 
-  // 选中的文件路径
   const selectedFilePath = ref<string>(``)
 
-  // 是否正在加载
   const isLoading = ref(false)
 
-  // 加载错误信息
   const loadError = ref<string>(``)
 
-  // 当前运行时文件夹
   const currentRuntimeFolder = computed(() => {
     if (!currentFolderId.value)
       return null
     return runtimeFolderMap.get(currentFolderId.value) || null
   })
 
-  // 兼容旧代码的属性
+  /** @deprecated Legacy shape for older callers */
   const folderHandles = computed(() => {
     return Array.from(runtimeFolderMap.values()).map(folder => ({
       id: folder.id,
@@ -78,6 +58,7 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     }))
   })
 
+  /** @deprecated Legacy shape for older callers */
   const currentFolderHandle = computed(() => {
     if (!currentRuntimeFolder.value)
       return null
@@ -89,17 +70,13 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     }
   })
 
-  // 兼容：savedFolders 返回空数组
+  /** @deprecated Always returns []; folders are not persisted */
   const savedFolders = ref<any[]>([])
 
-  // 检查浏览器是否支持 File System Access API
   const isFileSystemAPISupported = computed(() => {
     return typeof window !== `undefined` && `showDirectoryPicker` in window
   })
 
-  /**
-   * 选择并打开本地文件夹
-   */
   async function selectFolder() {
     if (!isFileSystemAPISupported.value) {
       toast.error(t('store.folder.apiNotSupported'))
@@ -115,24 +92,20 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
         startIn: `documents`,
       })
 
-      // 请求权限
       const permission = await handle.requestPermission({ mode: `readwrite` })
       if (permission !== `granted`) {
         toast.error(t('store.folder.permissionDenied'))
         return
       }
 
-      // 检查是否已经打开过这个文件夹
       let folderId: string
       const existingFolder = Array.from(runtimeFolderMap.values()).find(f => f.name === handle.name)
 
       if (existingFolder) {
         folderId = existingFolder.id
-        // 更新 handle
         existingFolder.handle = handle
       }
       else {
-        // 创建新文件夹信息
         folderId = generateFolderId()
         const folderInfo: RuntimeFolderInfo = {
           id: folderId,
@@ -144,14 +117,12 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
 
       currentFolderId.value = folderId
 
-      // 加载文件树
       await loadFileTree(handle)
 
       toast.success(t('store.folder.opened', { name: handle.name }))
     }
     catch (error: unknown) {
       if (getErrorName(error) === `AbortError`) {
-        // 用户取消了选择
         return
       }
       const msg = getErrorMessage(error)
@@ -163,11 +134,7 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     }
   }
 
-  /**
-   * 关闭当前文件夹，同时释放内存中的句柄引用
-   */
   function closeFolder() {
-    // 释放当前文件夹的句柄引用，避免内存泄漏
     if (currentFolderId.value) {
       runtimeFolderMap.delete(currentFolderId.value)
     }
@@ -176,21 +143,14 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     selectedFilePath.value = ``
   }
 
-  /**
-   * 从列表中移除文件夹
-   */
   function removeFolder(folderId: string) {
     runtimeFolderMap.delete(folderId)
 
-    // 如果关闭的是当前文件夹，清空当前状态
     if (currentFolderId.value === folderId) {
       closeFolder()
     }
   }
 
-  /**
-   * 加载文件树
-   */
   async function loadFileTree(handle: FileSystemDirectoryHandle): Promise<void> {
     try {
       const tree = await buildFileTree(handle, handle.name)
@@ -202,9 +162,6 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     }
   }
 
-  /**
-   * 递归构建文件树
-   */
   async function buildFileTree(
     handle: FileSystemDirectoryHandle,
     path: string,
@@ -221,7 +178,6 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
       for await (const entry of handle.values()) {
         const entryPath = `${path}/${entry.name}`
         if (entry.kind === `file`) {
-          // 只添加 Markdown 文件
           if (entry.name.toLowerCase().endsWith(`.md`)) {
             node.children!.push({
               name: entry.name,
@@ -232,13 +188,12 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
           }
         }
         else if (entry.kind === `directory`) {
-          // 递归处理子目录
           const childNode = await buildFileTree(entry as FileSystemDirectoryHandle, entryPath)
           node.children!.push(childNode)
         }
       }
 
-      // 排序：目录在前，文件在后，按名称排序
+      // Directories first, then files, sorted by name
       node.children!.sort((a, b) => {
         if (a.type !== b.type) {
           return a.type === `directory` ? -1 : 1
@@ -247,22 +202,18 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
       })
     }
     catch (error: unknown) {
-      console.error(`读取目录失败: ${path}`, getErrorMessage(error))
+      console.error(`Failed to read directory: ${path}`, getErrorMessage(error))
     }
 
     return node
   }
 
-  /**
-   * 读取文件内容
-   */
   async function readFile(filePath: string): Promise<string> {
     if (!currentRuntimeFolder.value) {
       throw new Error(t('store.folder.noFolderSelected'))
     }
 
     try {
-      // 直接从文件树中查找节点
       const node = findNodeByPath(fileTree.value, filePath)
       if (!node) {
         throw new Error(t('store.folder.fileNotFound', { path: filePath }))
@@ -272,7 +223,6 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
         throw new Error(t('store.folder.notAFile', { path: filePath }))
       }
 
-      // 使用节点中存储的文件句柄
       const fileHandle = node.handle as FileSystemFileHandle
       const file = await fileHandle.getFile()
       return await file.text()
@@ -283,49 +233,38 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     }
   }
 
-  /**
-   * 写入文件内容
-   */
   async function writeFile(filePath: string, content: string): Promise<void> {
     if (!currentRuntimeFolder.value) {
       throw new Error(t('store.folder.noFolderSelected'))
     }
 
     try {
-      // 解析路径，找到对应的目录句柄
-      const pathParts = filePath.split(`/`).slice(1) // 移除第一部分（文件夹名）
+      const pathParts = filePath.split(`/`).slice(1) // drop root folder segment
       let currentHandle = currentRuntimeFolder.value.handle as FileSystemDirectoryHandle
 
-      // 遍历路径，创建不存在的目录
       for (let i = 0; i < pathParts.length - 1; i++) {
         const dirName = pathParts[i]
         try {
           currentHandle = await currentHandle.getDirectoryHandle(dirName)
         }
         catch {
-          // 目录不存在，创建它
           currentHandle = await currentHandle.getDirectoryHandle(dirName, { create: true })
         }
       }
 
-      // 获取或创建文件句柄
       const fileName = pathParts[pathParts.length - 1]
       const fileHandle = await currentHandle.getFileHandle(fileName, { create: true })
 
-      // 写入内容
       const writable = await fileHandle.createWritable()
       await writable.write(content)
       await writable.close()
     }
     catch (error: unknown) {
-      console.error(`保存文件失败: ${getErrorMessage(error)}`)
+      console.error(`Failed to save file: ${getErrorMessage(error)}`)
       throw error
     }
   }
 
-  /**
-   * 在文件树中查找节点
-   */
   function findNodeByPath(nodes: FileSystemNode[], path: string): FileSystemNode | null {
     for (const node of nodes) {
       if (node.path === path) {
@@ -340,9 +279,6 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     return null
   }
 
-  /**
-   * 获取所有 Markdown 文件列表
-   */
   function getAllMarkdownFiles(nodes: FileSystemNode[] = fileTree.value): FileSystemNode[] {
     const files: FileSystemNode[] = []
     for (const node of nodes) {
@@ -356,27 +292,19 @@ export const useFolderSourceStore = defineStore(`folderSource`, () => {
     return files
   }
 
-  /**
-   * 生成文件夹 ID
-   */
   function generateFolderId(): string {
     return `folder_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
   }
 
   return {
-    // State
-    folderHandles, // 兼容旧代码
-    currentFolderHandle, // 兼容旧代码
+    folderHandles,
+    currentFolderHandle,
     savedFolders,
     fileTree,
     selectedFilePath,
     isLoading,
     loadError,
-
-    // Computed
     isFileSystemAPISupported,
-
-    // Actions
     selectFolder,
     closeFolder,
     removeFolder,

--- a/apps/web/src/stores/locale.ts
+++ b/apps/web/src/stores/locale.ts
@@ -26,7 +26,7 @@ function syncDocumentLocale(locale: AppLocale) {
     description.setAttribute(`content`, meta.description)
 }
 
-/** 供 index.html 启动屏在 IndexedDB 就绪前同步读取 */
+/** Sync locale to localStorage for index.html splash before IndexedDB is ready. */
 function syncLocaleBootCache(locale: AppLocale) {
   try {
     localStorage.setItem(LOCALE_STORAGE_KEY, locale)
@@ -61,7 +61,7 @@ export const useLocaleStore = defineStore(`locale`, () => {
     locale.value = value
   }
 
-  /** 按 SUPPORTED_LOCALES 顺序循环切换到下一语言 */
+  /** Cycle to the next locale in SUPPORTED_LOCALES order. */
   function cycleLocale() {
     locale.value = getNextLocale(locale.value)
   }

--- a/apps/web/src/stores/mpAccounts.ts
+++ b/apps/web/src/stores/mpAccounts.ts
@@ -11,14 +11,14 @@ export interface MpAccount {
   logo: string
   desc: string
   /**
-   * 1: 公众号
-   * 2: 服务号
+   * 1: subscription account
+   * 2: service account
    */
   serviceType: `1` | `2`
   /**
-   * 0: 无标识
-   * 1: 个人认证
-   * 2: 企业认证
+   * 0: unverified
+   * 1: personal verification
+   * 2: enterprise verification
    */
   verify: `0` | `1` | `2`
 }

--- a/apps/web/src/stores/post.ts
+++ b/apps/web/src/stores/post.ts
@@ -38,10 +38,7 @@ function postSignature(post: Post): string {
   return `${post.id}:${post.title}:${post.content.length}:${post.updateDatetime}:${post.parentId ?? ``}:${post.history?.length ?? 0}:${post.collapsed ? 1 : 0}`
 }
 
-/**
- * 文章管理 Store
- * 负责管理文章列表、当前文章、文章 CRUD 操作
- */
+/** Post list, current post, and CRUD operations. */
 export const usePostStore = defineStore(`post`, () => {
   const loaded = getLoadedDocuments()
   const posts = ref<Post[]>(
@@ -61,7 +58,7 @@ export const usePostStore = defineStore(`post`, () => {
     await documentRepo.savePost(post)
   }, 500)
 
-  /** 删除等关键操作立即落盘，避免防抖未完成时刷新导致数据回弹 */
+  /** Flush immediately on delete etc. so a refresh before debounce finishes does not restore stale data. */
   async function persistImmediately(): Promise<void> {
     persistAll.cancel()
     persistOne.cancel()

--- a/apps/web/src/stores/quickCommands.ts
+++ b/apps/web/src/stores/quickCommands.ts
@@ -5,7 +5,7 @@ import { store } from '@/storage'
 export interface QuickCommandPersisted {
   id: string
   label: string
-  template: string // 用 {{sel}} 占位
+  template: string // use {{sel}} as selection placeholder
 }
 
 export interface QuickCommandRuntime extends QuickCommandPersisted {
@@ -14,7 +14,6 @@ export interface QuickCommandRuntime extends QuickCommandPersisted {
 
 const STORAGE_KEY = `quick_commands`
 
-// 把持久化的对象转换为可执行的 buildPrompt
 function hydrate(cmd: QuickCommandPersisted): QuickCommandRuntime {
   return {
     ...cmd,

--- a/apps/web/src/stores/render.ts
+++ b/apps/web/src/stores/render.ts
@@ -11,37 +11,27 @@ export interface RenderOptions {
   force?: boolean
 }
 
-/**
- * 渲染 Store
- * 负责 Markdown 渲染、HTML 输出、标题提取等
- */
+/** Markdown rendering, HTML output, and heading extraction. */
 export const useRenderStore = defineStore(`render`, () => {
-  // 输出的 HTML
   const output = ref(``)
 
-  // 阅读时间统计
   const readingTime = reactive({
     chars: 0,
     words: 0,
     minutes: 0,
   })
 
-  // 文章标题列表（用于生成目录）
   const titleList = ref<{
     url: string
     title: string
     level: number
   }[]>([])
 
-  // 渲染器实例（延迟初始化）
   let renderer: ReturnType<typeof initRenderer> | null = null
   let lastOptionsFingerprint = ``
   let lastContent = ``
 
-  /**
-   * 初始化渲染器（新主题系统）
-   * 主题样式通过 useThemeStore().applyCurrentTheme() 注入到 <style> 标签
-   */
+  /** Init renderer; theme CSS is injected via useThemeStore().applyCurrentTheme(). */
   const initRendererInstance = (options?: {
     isMacCodeBlock?: boolean
     isShowLineNumber?: boolean
@@ -52,7 +42,6 @@ export const useRenderStore = defineStore(`render`, () => {
     return renderer
   }
 
-  // 获取渲染器
   const getRenderer = () => renderer
 
   const buildDiagramMessages = () => ({
@@ -65,7 +54,7 @@ export const useRenderStore = defineStore(`render`, () => {
   })
 
   const buildCountMessages = () => ({
-    // 保留占位符，交由 core 层替换为具体数值。
+    // Keep placeholders; core replaces them with actual counts.
     summary: t(`store.count.summary`, {
       words: `{words}`,
       minutes: `{minutes}`,
@@ -117,7 +106,6 @@ export const useRenderStore = defineStore(`render`, () => {
     ].join(`\u0001`)
   }
 
-  // 提取标题
   const extractTitles = () => {
     const div = document.createElement(`div`)
     div.innerHTML = output.value
@@ -137,7 +125,6 @@ export const useRenderStore = defineStore(`render`, () => {
     output.value = div.innerHTML
   }
 
-  // 渲染内容
   const render = (content: string, options?: RenderOptions) => {
     if (!renderer) {
       throw new Error(`Renderer not initialized. Call initRendererInstance first.`)
@@ -152,8 +139,7 @@ export const useRenderStore = defineStore(`render`, () => {
     if (!options?.force && content === lastContent && optionsFingerprint === lastOptionsFingerprint)
       return output.value
 
-    // 重置渲染器配置
-    // 注意：isUseIndent 和 isUseJustify 通过 CSS 变量处理，不需要传递给渲染器
+    // isUseIndent / isUseJustify are applied via CSS variables, not renderer options
     renderer.reset({
       citeStatus: themeStore.isCiteStatus,
       legend: themeStore.legend,
@@ -167,18 +153,14 @@ export const useRenderStore = defineStore(`render`, () => {
       renderMessages: buildRenderMessages(),
     })
 
-    // 渲染 Markdown
     const { html: baseHtml, readingTime: readingTimeResult } = renderMarkdown(content, renderer)
 
-    // 更新统计信息
     readingTime.chars = content.length
     readingTime.words = readingTimeResult.words
     readingTime.minutes = Math.ceil(readingTimeResult.minutes)
 
-    // 后处理 HTML
     output.value = postProcessHtml(baseHtml, readingTimeResult, renderer)
 
-    // 提取标题
     extractTitles()
     lastContent = content
     lastOptionsFingerprint = optionsFingerprint

--- a/apps/web/src/stores/sync.ts
+++ b/apps/web/src/stores/sync.ts
@@ -32,10 +32,7 @@ function writeSyncedIds(ids: string[]): void {
   safeSetItem(SYNCED_IDS_KEY, JSON.stringify(ids))
 }
 
-/**
- * 云同步 Store
- * 负责同步状态机、手动/自动同步编排、上次同步时间
- */
+/** Cloud sync: state machine, manual/auto sync orchestration, last sync time. */
 export const useSyncStore = defineStore(`sync`, () => {
   const authStore = useAuthStore()
   const postStore = usePostStore()

--- a/apps/web/src/stores/template.ts
+++ b/apps/web/src/stores/template.ts
@@ -3,28 +3,16 @@ import { t } from '@/i18n/translate'
 import { store } from '@/storage'
 import { addPrefix } from '@/storage/prefix'
 
-/**
- * 模板管理 Store
- * 负责管理 Markdown 模板的增删改查
- */
+/** Markdown template CRUD. */
 export const useTemplateStore = defineStore(`template`, () => {
-  // ==================== 状态 ====================
-  // 模板列表 - 使用响应式存储，自动持久化到 localStorage
   const templates = store.reactive<Template[]>(addPrefix(`templates`), [])
 
-  // ==================== 计算属性 ====================
-  // 按创建时间倒序排列的模板列表
   const sortedTemplates = computed(() => {
     return [...templates.value].sort((a, b) => b.createdAt - a.createdAt)
   })
 
-  // 模板总数
   const templateCount = computed(() => templates.value.length)
 
-  // ==================== 方法 ====================
-  /**
-   * 创建新模板
-   */
   function createTemplate(params: CreateTemplateParams): Template {
     const now = Date.now()
     const newTemplate: Template = {
@@ -42,16 +30,10 @@ export const useTemplateStore = defineStore(`template`, () => {
     return newTemplate
   }
 
-  /**
-   * 根据 ID 获取模板
-   */
   function getTemplateById(id: string): Template | undefined {
     return templates.value.find(t => t.id === id)
   }
 
-  /**
-   * 更新模板
-   */
   function updateTemplate(id: string, params: UpdateTemplateParams): boolean {
     const index = templates.value.findIndex(t => t.id === id)
     if (index === -1) {
@@ -69,9 +51,6 @@ export const useTemplateStore = defineStore(`template`, () => {
     return true
   }
 
-  /**
-   * 删除模板
-   */
   function deleteTemplate(id: string): boolean {
     const index = templates.value.findIndex(t => t.id === id)
     if (index === -1) {
@@ -85,9 +64,6 @@ export const useTemplateStore = defineStore(`template`, () => {
     return true
   }
 
-  /**
-   * 根据名称搜索模板
-   */
   function searchTemplates(keyword: string): Template[] {
     if (!keyword.trim()) {
       return sortedTemplates.value
@@ -103,9 +79,6 @@ export const useTemplateStore = defineStore(`template`, () => {
     })
   }
 
-  /**
-   * 批量删除模板
-   */
   function deleteTemplates(ids: string[]): number {
     let deletedCount = 0
     ids.forEach((id) => {
@@ -123,25 +96,16 @@ export const useTemplateStore = defineStore(`template`, () => {
     return deletedCount
   }
 
-  /**
-   * 清空所有模板
-   */
   function clearAllTemplates(): void {
     const count = templates.value.length
     templates.value = []
     toast.success(t('store.template.allCleared', { count }))
   }
 
-  /**
-   * 导出所有模板为 JSON
-   */
   function exportTemplates(): string {
     return JSON.stringify(templates.value, null, 2)
   }
 
-  /**
-   * 从 JSON 导入模板
-   */
   function importTemplates(jsonData: string): boolean {
     try {
       const importedTemplates = JSON.parse(jsonData) as Template[]
@@ -151,7 +115,6 @@ export const useTemplateStore = defineStore(`template`, () => {
         return false
       }
 
-      // 验证每个模板的必需字段
       const validTemplates = importedTemplates.filter((t) => {
         return t.id && t.name && t.content && t.createdAt && t.updatedAt
       })
@@ -161,11 +124,9 @@ export const useTemplateStore = defineStore(`template`, () => {
         return false
       }
 
-      // 合并模板（避免 ID 重复）
       validTemplates.forEach((importedTemplate) => {
         const existingIndex = templates.value.findIndex(t => t.id === importedTemplate.id)
         if (existingIndex !== -1) {
-          // ID 重复，生成新 ID
           templates.value.push({
             ...importedTemplate,
             id: crypto.randomUUID(),
@@ -187,14 +148,9 @@ export const useTemplateStore = defineStore(`template`, () => {
   }
 
   return {
-    // 状态
     templates,
-
-    // 计算属性
     sortedTemplates,
     templateCount,
-
-    // 方法
     createTemplate,
     getTemplateById,
     updateTemplate,

--- a/apps/web/src/stores/theme.ts
+++ b/apps/web/src/stores/theme.ts
@@ -6,11 +6,10 @@ import { addPrefix } from '@/storage/prefix'
 import { useCssEditorStore } from '@/stores/cssEditor'
 
 /**
- * 主题和样式配置 Store
- * 负责管理所有与主题、字体、颜色相关的配置
+ * Theme and style configuration.
  *
- * 每个主题拥有独立的配置（primaryColor、fontFamily、fontSize、codeBlockTheme、
- * headingStyles、isShowLineNumber、isMacCodeBlock），切换主题时自动加载对应配置。
+ * Each theme has its own settings (primaryColor, fontFamily, fontSize, codeBlockTheme,
+ * headingStyles, isShowLineNumber, isMacCodeBlock); switching themes loads the matching config.
  */
 export const useThemeStore = defineStore(`theme`, () => {
   const theme = store.reactive<ThemeName>(addPrefix(`theme`), defaultStyleConfig.theme)

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -1,43 +1,32 @@
 import { store } from '@/storage'
 import { addPrefix } from '@/storage/prefix'
 
-/**
- * UI 状态 Store
- * 负责管理全局 UI 状态，包括深色模式、侧边栏、对话框等
- */
+/** Global UI state: dark mode, sidebars, dialogs, view mode, etc. */
 export const useUIStore = defineStore(`ui`, () => {
-  // ==================== 全局 UI 状态 ====================
-  // 是否开启深色模式
   const isDark = useDark()
   const toggleDark = useToggle(isDark)
 
-  // 是否开启 AI 工具箱
   const showAIToolbox = store.reactive(`showAIToolbox`, true)
   const toggleAIToolbox = useToggle(showAIToolbox)
 
-  // 是否已经显示过 AI 工具箱选中文本提示
   const hasShownAIToolboxHint = store.reactive(`hasShownAIToolboxHint`, false)
 
-  // 是否打开右侧滑块
   const isOpenRightSlider = store.reactive(addPrefix(`is_open_right_slider`), false)
 
-  // 是否打开文章列表滑块
   const isOpenPostSlider = store.reactive(addPrefix(`is_open_post_slider`), false)
 
-  // 是否打开本地文件夹面板
   const isOpenFolderPanel = store.reactive(addPrefix(`is_open_folder_panel`), false)
 
-  // 是否为移动端
   const isMobile = store.reactive(`isMobile`, false)
 
-  // 视图模式：edit（纯编辑）| split（双屏）| preview（纯预览）
+  // viewMode: edit | split | preview
   const viewMode = store.reactive<'edit' | 'split' | 'preview'>(`viewMode`, `split`)
 
   function setViewMode(mode: 'edit' | 'split' | 'preview') {
     viewMode.value = mode
   }
 
-  // 预览设备：desktop（电脑端）| mobile（移动端模拟）
+  // previewDevice: desktop | mobile (simulated)
   const previewDevice = store.reactive<'desktop' | 'mobile'>(`previewDevice`, `mobile`)
 
   function setPreviewDevice(device: 'desktop' | 'mobile') {
@@ -48,31 +37,23 @@ export const useUIStore = defineStore(`ui`, () => {
     previewDevice.value = previewDevice.value === `desktop` ? `mobile` : `desktop`
   }
 
-  // 是否启用图片转存（默认关闭）
   const enableImageReupload = store.reactive(addPrefix(`enableImageReupload`), false)
   const toggleImageReupload = useToggle(enableImageReupload)
 
-  // 是否开启同步滚动（编辑器与预览区联动）
   const enableScrollSync = store.reactive(addPrefix(`enableScrollSync`), true)
   const toggleScrollSync = useToggle(enableScrollSync)
 
-  // 复制到公众号时的格式模式
   const copyMode = store.reactive(addPrefix(`copyMode`), `txt`)
 
-  // ==================== 对话框状态 ====================
-  // 是否展示 CSS 编辑器
   const isShowCssEditor = store.reactive(`isShowCssEditor`, false)
   const toggleShowCssEditor = useToggle(isShowCssEditor)
 
-  // 是否展示插入表格对话框
   const isShowInsertFormDialog = ref(false)
   const toggleShowInsertFormDialog = useToggle(isShowInsertFormDialog)
 
-  // 是否展示上传图片对话框
   const isShowUploadImgDialog = ref(false)
   const toggleShowUploadImgDialog = useToggle(isShowUploadImgDialog)
 
-  // 是否展示公式编辑对话框
   const isShowFormulaEditorDialog = ref(false)
   const formulaEditorValue = ref(``)
   const formulaEditorDisplayMode = ref(true)
@@ -96,16 +77,14 @@ export const useUIStore = defineStore(`ui`, () => {
     formulaEditorSourceRaw.value = null
   }
 
-  // 是否展示导入 Markdown 对话框
   const isShowImportMdDialog = ref(false)
   const toggleShowImportMdDialog = useToggle(isShowImportMdDialog)
-  /** 通过 URL 参数 open 打开时传入的待导入链接，对话框打开后会据此自动执行导入 */
+  /** URL from ?open= query; import dialog auto-imports when opened with this set. */
   const importMdOpenUrl = ref<string | null>(null)
 
-  // 是否展示本地图片上传对话框
   const isShowLocalImageUpload = ref(false)
   const toggleShowLocalImageUpload = useToggle(isShowLocalImageUpload)
-  /** 待处理的本地图片上传数据 */
+  /** Pending local image upload batch data. */
   const localImageUploadData = ref<{
     markdownContent: string
     detectedPaths: string[]
@@ -115,23 +94,18 @@ export const useUIStore = defineStore(`ui`, () => {
     failCount?: number
   } | null>(null)
 
-  // 是否展示模板管理对话框
   const isShowTemplateDialog = ref(false)
   const toggleShowTemplateDialog = useToggle(isShowTemplateDialog)
 
-  // 是否展示组件对话框
   const isShowComponentDialog = ref(false)
   const toggleShowComponentDialog = useToggle(isShowComponentDialog)
 
-  // 是否展示云同步对话框
   const isShowSyncDialog = ref(false)
   const toggleShowSyncDialog = useToggle(isShowSyncDialog)
 
-  // 是否展示账户对话框
   const isShowAccountDialog = ref(false)
   const toggleShowAccountDialog = useToggle(isShowAccountDialog)
 
-  // 是否展示分享对话框
   const isShowShareDialog = ref(false)
   const shareDialogInitialTab = ref<`create` | `manage`>(`create`)
 
@@ -140,7 +114,6 @@ export const useUIStore = defineStore(`ui`, () => {
     isShowShareDialog.value = true
   }
 
-  // 是否展示关于 / 赞赏 / 语法帮助 / 配置导入导出对话框
   const isShowAboutDialog = ref(false)
   const toggleShowAboutDialog = useToggle(isShowAboutDialog)
 
@@ -162,7 +135,7 @@ export const useUIStore = defineStore(`ui`, () => {
   const isShowCommandPalette = ref(false)
   const toggleShowCommandPalette = useToggle(isShowCommandPalette)
 
-  // 组件对话框 — 打开时预展开的组件名（如 'MpProfile'）
+  /** Component name to expand when opening the component dialog (e.g. 'MpProfile'). */
   const componentDialogTarget = ref<string | null>(null)
 
   function openComponentDialogWithTarget(target: string) {
@@ -170,7 +143,6 @@ export const useUIStore = defineStore(`ui`, () => {
     isShowComponentDialog.value = true
   }
 
-  // AI 对话框
   const aiDialogVisible = ref(false)
   const aiImageDialogVisible = ref(false)
 
@@ -182,7 +154,6 @@ export const useUIStore = defineStore(`ui`, () => {
     aiImageDialogVisible.value = value ?? !aiImageDialogVisible.value
   }
 
-  // 搜索面板状态
   const searchTabRequest = ref<{ word: string, showReplace: boolean } | null>(null)
 
   function openSearchTab(searchWord: string = '', showReplace: boolean = false) {
@@ -193,15 +164,13 @@ export const useUIStore = defineStore(`ui`, () => {
     searchTabRequest.value = null
   }
 
-  // 跳转行号（Footer 监听并打开输入框）
+  /** Incremented to request go-to-line from Footer. */
   const goToLineRequest = ref(0)
 
   function requestGoToLine() {
     goToLineRequest.value++
   }
 
-  // ==================== 工具函数 ====================
-  // 处理窗口大小变化
   let splitCollapsedByResize = false
 
   function handleResize() {
@@ -209,12 +178,12 @@ export const useUIStore = defineStore(`ui`, () => {
     isMobile.value = window.innerWidth <= 768
 
     if (!wasMobile && isMobile.value && viewMode.value === `split`) {
-      // 从桌面端变为移动端且当前是双屏：切换为编辑模式并记录
+      // Desktop → mobile while split: collapse to edit and remember for restore
       viewMode.value = `edit`
       splitCollapsedByResize = true
     }
     else if (wasMobile && !isMobile.value && splitCollapsedByResize) {
-      // 从移动端变回桌面端且是由 resize 触发的折叠：还原为双屏
+      // Mobile → desktop after resize collapse: restore split
       viewMode.value = `split`
       splitCollapsedByResize = false
     }
@@ -230,7 +199,6 @@ export const useUIStore = defineStore(`ui`, () => {
   })
 
   return {
-    // ==================== 全局 UI 状态 ====================
     isDark,
     showAIToolbox,
     hasShownAIToolboxHint,
@@ -244,7 +212,6 @@ export const useUIStore = defineStore(`ui`, () => {
     enableScrollSync,
     copyMode,
 
-    // ==================== 对话框状态 ====================
     isShowCssEditor,
     toggleShowCssEditor,
     isShowInsertFormDialog,
@@ -295,14 +262,12 @@ export const useUIStore = defineStore(`ui`, () => {
     aiImageDialogVisible,
     toggleAIImageDialog,
 
-    // ==================== 搜索面板 ====================
     searchTabRequest,
     openSearchTab,
     clearSearchTabRequest,
     goToLineRequest,
     requestGoToLine,
 
-    // ==================== Actions ====================
     toggleDark,
     toggleAIToolbox,
     toggleImageReupload,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -68,7 +68,7 @@ export default defineConfig(({ mode }) => {
     build: {
       rolldownOptions: {
         onwarn(warning, warn) {
-          // @vueuse/core 中的 /* #__PURE__ */ 注释位置不符合 Rolldown 要求，忽略该警告
+          // @vueuse/core /* #__PURE__ */ placement triggers INVALID_ANNOTATION; ignore
           if (warning.code === `INVALID_ANNOTATION` && warning.message?.includes(`@vueuse/core`))
             return
           warn(warning)

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -4,42 +4,32 @@ const MP_HOST = `https://api.weixin.qq.com`
 
 export default class extends WorkerEntrypoint {
   async fetch(request: Request): Promise<Response> {
-    // 1️⃣ 获取原请求 URL 与路径
     const url = new URL(request.url)
 
-    // 拼接转发目标，例如请求 /cgi-bin/stable_token 就会转发到
-    // https://api.weixin.qq.com/cgi-bin/stable_token
+    // e.g. /cgi-bin/stable_token → https://api.weixin.qq.com/cgi-bin/stable_token
     const targetUrl = `${MP_HOST}${url.pathname}${url.search}`
 
-    // 2️⃣ 克隆请求头
     const headers = new Headers(request.headers)
 
-    // 可选：删除或修改一些可能引起冲突的头
     headers.delete(`host`)
     headers.delete(`content-length`)
     headers.delete(`cf-connecting-ip`)
     headers.delete(`x-forwarded-for`)
 
-    // 3️⃣ 构造新的请求
     const init: RequestInit = {
       method: request.method,
       headers,
       redirect: `follow`,
     }
 
-    // ⚙️ 特别处理带 body 的请求（POST/PUT 等）
     if (request.method !== `GET` && request.method !== `HEAD`) {
-      // 对文件上传、JSON、表单都可直接转发
       init.body = request.body
     }
 
     try {
-      // 4️⃣ 发起转发请求
       const resp = await fetch(targetUrl, init)
 
-      // 5️⃣ 克隆返回的响应头
       const respHeaders = new Headers(resp.headers)
-      // 可选：允许跨域访问（如果你需要在网页端调用）
       respHeaders.set(`Access-Control-Allow-Origin`, `*`)
       respHeaders.set(`Access-Control-Allow-Headers`, `*`)
 

--- a/apps/web/wxt.config.ts
+++ b/apps/web/wxt.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       `https://*.githubusercontent.com/*`,
       `https://*.gitee.com/*`,
       `https://*.weixin.qq.com/*`,
-      // 微信公众号图片
+      // WeChat public account images (qpic CDN)
       `https://*.qpic.cn/*`,
       `https://www.plantuml.com/*`,
     ],

--- a/docs/examples/wechat-openapi-worker/worker.js
+++ b/docs/examples/wechat-openapi-worker/worker.js
@@ -23,7 +23,7 @@ export default {
     return proxyResponse
   },
 }
-// 设置 CORS 头部
+
 function setCorsHeaders(headers) {
   headers.set(`Access-Control-Allow-Origin`, `*`)
   headers.set(`Access-Control-Allow-Methods`, `GET, POST, PUT, DELETE`)

--- a/packages/core/src/extensions/alert.ts
+++ b/packages/core/src/extensions/alert.ts
@@ -14,17 +14,14 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
   const resolvedVariants = resolveVariants(variants)
 
   /**
-   * 解析名称对应的变体配置。
-   * 命中内置类型（大小写不敏感）→ 返回该配置；
-   * 未命中（含任意自定义名称、中文等）→ 返回 null，走默认兜底样式。
+   * Resolve variant by name (case-insensitive built-in match).
+   * Unknown/custom names (including CJK) return null → default fallback styles.
    */
   function resolveVariant(name: string): AlertVariantItem | null {
     const lower = name.toLowerCase()
     return resolvedVariants.find(v => v.type.toLowerCase() === lower) ?? null
   }
 
-  // 提取公共的元数据构建逻辑。
-  // name：原始名称；matchedVariant：命中的内置变体（未命中为 null）；customTitle：同行自定义标题
   function buildMeta(name: string, matchedVariant: AlertVariantItem | null, customTitle?: string, fromContainer = false) {
     const variant = matchedVariant ? matchedVariant.type : `custom`
     const defaultTitle = matchedVariant
@@ -43,15 +40,12 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
     }
   }
 
-  // 提取公共的渲染逻辑
   const renderAlert: AlertRendererFn = function (this: AlertRendererThis, token: AlertToken) {
     const { meta, tokens = [] } = token
     const text = this.parser.parse(tokens)
-    // 新主题系统：使用 CSS 选择器而非内联样式
     let tmpl = `<blockquote class="${meta.className} ${meta.className}-${meta.variant}">\n`
     tmpl += `<p class="${meta.titleClassName} alert-title-${meta.variant}">`
     if (!withoutStyle) {
-      // 给 SVG 添加 class，通过 CSS 控制颜色
       tmpl += meta.icon.replace(
         `<svg`,
         `<svg class="alert-icon-${meta.variant}"`,
@@ -70,7 +64,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
       if (token.type !== `blockquote`)
         return
 
-      // 通用匹配任意 [!名称]（含未知/中文名称）及同行可选自定义标题
+      // Match [!name] with optional custom title on the same line (any name, including CJK)
       const headerMatch = /^\[!([^\]\n]+)\][ \t]*([^\n]*)/.exec(token.text)
       if (!headerMatch)
         return
@@ -84,10 +78,10 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
         meta: buildMeta(name, matchedVariant, customTitle),
       })
 
-      // 从正文首段移除「[!名称] 自定义标题」所在的首个物理行。
-      // 标题可能含行内 Markdown（如 *强调*），会被拆成多个 inline token；首行结束于
-      // 硬换行（br token）或软换行（文本 token 内的 \n），需要兼顾两种情况，
-      // 否则会把标题内容泄漏到正文，或误删正文。
+      // Strip the first physical line ([!name] + optional title) from the first paragraph.
+      // Title may contain inline Markdown (*emphasis*) split across tokens; line ends at
+      // a hard break (br token) or soft break (\\n inside a text token). Handle both or
+      // title leaks into body or body gets deleted.
       const firstLine = token.tokens?.[0] as Tokens.Paragraph | undefined
       const inlineTokens = firstLine?.tokens
       if (inlineTokens?.length) {
@@ -95,13 +89,11 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
         for (let i = 0; i < inlineTokens.length; i++) {
           const t = inlineTokens[i]
           if (t.type === `br`) {
-            // 硬换行：删除首行全部 token（含 br）
             inlineTokens.splice(0, i + 1)
             stripped = true
             break
           }
           if (t.type === `text` && t.raw.includes(`\n`)) {
-            // 软换行：该文本 token 跨越行边界，删除其前的 token 并裁掉首行部分
             const textToken = t as Tokens.Text
             const restRaw = textToken.raw.slice(textToken.raw.indexOf(`\n`) + 1)
             const nlInText = textToken.text.indexOf(`\n`)
@@ -115,7 +107,6 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
             break
           }
         }
-        // 未发现换行：整段即首行（仅标记与标题，无正文），整段删除
         if (!stripped || inlineTokens.length === 0)
           token.tokens?.shift()
       }
@@ -133,7 +124,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
           return src.match(/^:::/)?.index
         },
         tokenizer(src, _tokens) {
-          // 名称支持任意非空白字符（含中文）；同行可跟自定义标题
+          // Name: any non-whitespace (incl. CJK); optional custom title on same line
           // eslint-disable-next-line regexp/no-super-linear-backtracking
           const match = /^:::[ \t]*(\S+)[ \t]*([^\n]*)\n([\s\S]*?)\n:::/.exec(src)
 
@@ -156,7 +147,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
   }
 }
 
-// 学术环境（定理、定义等）共用的图标
+// Shared icons for academic environments (theorem, definition, etc.)
 const ICON_THEOREM = `<svg class="octicon octicon-light-bulb" style="margin-right: 0.25em;" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"></path></svg>`
 const ICON_DEFINITION = `<svg class="octicon octicon-book" style="margin-right: 0.25em;" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path></svg>`
 const ICON_PROOF = `<svg class="octicon octicon-check-circle" style="margin-right: 0.25em;" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm3.78-9.72a.751.751 0 0 0-.018-1.042.751.751 0 0 0-1.042-.018L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042l2 2a.75.75 0 0 0 1.06 0Z"></path></svg>`
@@ -281,7 +272,7 @@ const defaultAlertVariant: AlertVariantItem[] = [
     title: `Cite`,
     icon: `<svg class="octicon octicon-quote" style="margin-right: 0.25em;" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25v-8.5C0 2.784.784 2 1.75 2ZM1.5 12.25c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25ZM4 5.25a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5A.75.75 0 0 1 4 5.25Zm0 4a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75Z"></path></svg>`,
   },
-  // ==================== 学术环境（定理、引理、定义等） ====================
+  // Academic environments (theorem, lemma, definition, etc.)
   {
     type: `theorem`,
     title: `Theorem`,

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -2,9 +2,7 @@ import type { ComponentRegistry, CustomComponentDef } from '@md/shared/types'
 import type { MarkedExtension } from 'marked'
 import { escapeHtml, unescapeHtml } from '../utils/basicHelpers'
 
-// ────────────────────────────────────────────────────────────────────────────
-// 内置组件定义
-// ────────────────────────────────────────────────────────────────────────────
+// Built-in components
 
 export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
   {
@@ -125,29 +123,21 @@ export const BUILT_IN_COMPONENTS: CustomComponentDef[] = [
   },
 ]
 
-// ────────────────────────────────────────────────────────────────────────────
-// 属性解析
-// ────────────────────────────────────────────────────────────────────────────
+// Prop parsing
 
-/** 将 prop 字符串解析为 key->value 映射 */
+/** Parse prop string into key→value map */
 function parseProps(propsStr: string): Record<string, string> {
   const result: Record<string, string> = {}
-  // 支持 key="value" 和 key='value'
+  // key="value" and key='value'
   for (const m of propsStr.matchAll(/(\w[\w-]*)=(?:"([^"]*)"|'([^']*)')/g)) {
     result[m[1]] = unescapeHtml(m[2] !== undefined ? m[2] : (m[3] ?? ``))
   }
   return result
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// 特殊渲染器（内置组件专用，处理 JSON 数组等复杂逻辑）
-// ────────────────────────────────────────────────────────────────────────────
+// CSS variables & palette (light fallbacks; dark overridden via injected vars)
 
-// ────────────────────────────────────────────────────────────────────────────
-// CSS 变量与调色板（light 模式回退值，深色通过外部注入覆盖）
-// ────────────────────────────────────────────────────────────────────────────
-
-/** CSS 变量名→light 回退值的简写，注入为模板变量（下划线前缀防止与用户 prop 冲突） */
+/** Palette shorthand → light fallback, injected as template vars (_ prefix avoids prop clash) */
 function injectPaletteVars(props: Record<string, string>): Record<string, string> {
   return {
     _bgPrimary_: `var(--md-comp-bg, #fff)`,
@@ -162,7 +152,7 @@ function injectPaletteVars(props: Record<string, string>): Record<string, string
   }
 }
 
-/** CSS 变量简写对象，供特殊渲染器直接内联 */
+/** Palette shorthand for special renderers */
 const CV = {
   bg: `var(--md-comp-bg, #fff)`,
   bgSec: `var(--md-comp-bg-secondary, #f5f5f5)`,
@@ -174,9 +164,7 @@ const CV = {
   borderL: `var(--md-comp-border-light, #eee)`,
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// 特殊渲染器（内置组件专用，处理 JSON 数组等复杂逻辑）
-// ────────────────────────────────────────────────────────────────────────────
+// Special renderers (JSON arrays etc.)
 
 function renderTableBlock(props: Record<string, string>): string {
   let headers: string[] = []
@@ -249,15 +237,12 @@ function renderInfoGrid(props: Record<string, string>): string {
   return html
 }
 
-/** 特殊渲染器注册表 */
 const SPECIAL_RENDERERS: Record<string, (props: Record<string, string>) => string> = {
   TableBlock: renderTableBlock,
   InfoGrid: renderInfoGrid,
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// TipBlock 类型颜色映射
-// ────────────────────────────────────────────────────────────────────────────
+// TipBlock type colors
 
 const TIP_COLORS: Record<string, { borderColor: string, bgColor: string, textColor: string }> = {
   info: { borderColor: `#1890ff`, bgColor: `#e6f7ff`, textColor: `#0050b3` },
@@ -272,20 +257,13 @@ function injectTipColors(props: Record<string, string>): Record<string, string> 
   return { ...colors, ...props }
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// 模板渲染引擎
-// ────────────────────────────────────────────────────────────────────────────
+// Template engine
 
 /**
- * 递归处理模板字符串，支持：
- *   - `{{#each arrayProp}}...{{item}}...{{item.key}}...{{@index}}...{{/each}}`
- *   - `{{#if prop}}...{{#else}}...{{/if}}`
- *   - `{{#unless prop}}...{{/unless}}`
- *   - `{{propName}}` 基础替换（自动 HTML 转义）
- *   - `{{children}}` 保留原始 HTML 不转义
+ * Recursive template: {{#each}}, {{#if}}/{{#else}}, {{#unless}}, {{prop}} (escaped), {{children}} (raw HTML)
  */
 function processTemplate(html: string, props: Record<string, string>): string {
-  // 1. {{#each}} 循环（非贪婪；循环体内部通过递归支持嵌套的 #if/#unless，但不支持 #each 嵌套）
+  // {{#each}} — non-greedy; nested #if/#unless OK, not nested #each
   html = html.replace(/\{\{#each\s+([\w-]+)\}\}([\s\S]*?)\{\{\/each\}\}/g, (_, propKey, body) => {
     let items: unknown[]
     try { items = JSON.parse(props[propKey] || `[]`) }
@@ -305,12 +283,10 @@ function processTemplate(html: string, props: Record<string, string>): string {
       else {
         itemBody = itemBody.replace(/\{\{item\}\}/g, escapeHtml(String(item ?? ``)))
       }
-      // 递归处理循环体内的 #if/#unless/prop 替换
       return processTemplate(itemBody, props)
     }).join(``)
   })
 
-  // 2. {{#if prop}}...{{#else}}...{{/if}}
   html = html.replace(/\{\{#if\s+([\w-]+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, content) => {
     const elseIdx = content.indexOf(`{{#else}}`)
     if (elseIdx >= 0) {
@@ -319,12 +295,10 @@ function processTemplate(html: string, props: Record<string, string>): string {
     return props[key] ? content : ``
   })
 
-  // 3. {{#unless prop}}...{{/unless}}
   html = html.replace(/\{\{#unless\s+([\w-]+)\}\}([\s\S]*?)\{\{\/unless\}\}/g, (_, key, content) => {
     return !props[key] ? content : ``
   })
 
-  // 4. {{propName}} 替换；{{children}} 不转义
   html = html.replace(/\{\{([\w-]+)\}\}/g, (_, key) => {
     if (key === `children`)
       return props[key] ?? ``
@@ -334,13 +308,8 @@ function processTemplate(html: string, props: Record<string, string>): string {
   return html
 }
 
-/**
- * 将组件定义和 props 渲染为 HTML 字符串。
- * 优先使用 SPECIAL_RENDERERS，否则走 processTemplate 模板引擎。
- * 颜色通过 CSS 自定义属性适配暗色模式，回退值为 light 模式颜色。
- */
+/** Render component def + props to HTML (SPECIAL_RENDERERS or template; CSS vars for dark mode). */
 function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string>): string {
-  // 1. 合并默认值
   const props: Record<string, string> = {}
   for (const propDef of def.props) {
     if (propDef.default !== undefined) {
@@ -349,13 +318,11 @@ function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string
   }
   Object.assign(props, rawProps)
 
-  // 2. 特殊渲染器（TableBlock / InfoGrid）
   const specialRenderer = SPECIAL_RENDERERS[def.name]
   if (specialRenderer) {
     return specialRenderer(props)
   }
 
-  // 3. 注入调色板变量 + TipBlock 颜色
   const propsWithPalette = injectPaletteVars(
     def.name === `TipBlock` ? injectTipColors(props) : props,
   )
@@ -363,9 +330,7 @@ function renderTemplate(def: CustomComponentDef, rawProps: Record<string, string
   return processTemplate(def.template, propsWithPalette)
 }
 
-/**
- * 预览组件渲染结果（供编辑器 UI 实时预览使用）
- */
+/** Preview component HTML for editor UI */
 export function previewComponent(
   def: CustomComponentDef,
   propsOverride?: Record<string, string>,
@@ -373,18 +338,14 @@ export function previewComponent(
   return renderTemplate(def, propsOverride ?? {})
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// 可变注册表（通过 setComponentRegistry 在渲染时更新）
-// ────────────────────────────────────────────────────────────────────────────
+// Mutable registry (updated at render time via setComponentRegistry)
 
 let _registry: ComponentRegistry = {}
 
-/** 更新当前渲染使用的组件注册表 */
 export function setComponentRegistry(registry: ComponentRegistry): void {
   _registry = registry
 }
 
-/** 获取内置组件注册表 */
 export function getBuiltInRegistry(): ComponentRegistry {
   const reg: ComponentRegistry = {}
   for (const c of BUILT_IN_COMPONENTS) {
@@ -393,18 +354,10 @@ export function getBuiltInRegistry(): ComponentRegistry {
   return reg
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Marked 扩展
-// ────────────────────────────────────────────────────────────────────────────
-
 /**
- * marked 扩展：解析 JSX 风格的自定义组件语法
- *
- * 支持：
- *   自闭合：  <ComponentName prop="value" />
- *   开闭合：  <ComponentName prop="value">children</ComponentName>
- *
- * 组件名必须以大写字母开头（PascalCase）以与普通 HTML 标签区分。
+ * marked extension: JSX-style custom components (PascalCase names).
+ * Self-closing: <Component prop="value" />
+ * With children: <Component prop="value">children</Component>
  */
 const DEFAULT_UNKNOWN_COMPONENT = `Unknown component: {name}`
 
@@ -458,13 +411,8 @@ export function markedComponent(
     return undefined
   }
 
-  /**
-   * 简单的非正则标签解析器，避免复杂 regex 的回溯问题。
-   * 返回 raw（完整原始文本）、name（组件名）、propsStr（属性串）。
-   */
+  /** Non-regex tag parser (avoids catastrophic backtracking). Returns raw, name, propsStr. */
   function parseTag(src: string) {
-    // 必须以 <UppercaseLetter 开头
-
     function findClosingTag(src: string, name: string, from: number): number {
       const closeTag = `</${name}>`
       let lineStart = from
@@ -506,14 +454,13 @@ export function markedComponent(
     if (src[0] !== `<` || src[1] < `A` || src[1] > `Z`)
       return null
 
-    // 提取组件名
     let i = 1
     while (i < src.length && /\w/.test(src[i])) i++
     const name = src.slice(1, i)
     if (!name)
       return null
 
-    // 扫描开始标签内容，正确处理引号内的 > 字符
+    // Scan open tag; respect > inside quoted attribute values
     let inQuote = ``
     let j = i
     while (j < src.length) {
@@ -526,7 +473,6 @@ export function markedComponent(
         inQuote = ch
       }
       else if (ch === `/` && src[j + 1] === `>`) {
-        // 自闭合标签结束
         if (!hasOnlyWhitespaceToLineEnd(src, j + 2))
           return null
         return { raw: src.slice(0, j + 2), name, propsStr: src.slice(i, j).trim(), children: `` }
@@ -535,7 +481,7 @@ export function markedComponent(
         const lineEnd = findLineEnd(src, j + 1)
         const closeTag = `</${name}>`
 
-        // 支持同一行内自洽的开闭合标签，但不接受标签后混入其他 Markdown 语法。
+        // Same-line open/close OK; nothing else on the line after close tag
         const inlineCloseIdx = src.indexOf(closeTag, j + 1)
         if (inlineCloseIdx >= 0 && inlineCloseIdx < lineEnd) {
           if (src.slice(inlineCloseIdx + closeTag.length, lineEnd).trim() !== ``)
@@ -548,7 +494,7 @@ export function markedComponent(
         if (!hasOnlyWhitespaceToLineEnd(src, j + 1))
           return null
 
-        // 多行组件要求关闭标签位于独立行，且跳过 fenced code 中的同名文本。
+        // Multiline: close tag on its own line; skip matches inside fenced code
         const closeIdx = findClosingTag(src, name, lineEnd === src.length ? lineEnd : lineEnd + 1)
         if (closeIdx < 0)
           return null
@@ -587,11 +533,10 @@ export function markedComponent(
           const { name, propsStr, children } = token as unknown as { name: string, propsStr: string, children: string }
           const def = resolveRegistry()[name]
           if (!def) {
-            // 未知组件，保留原始文本并给出提示
             return `<p style="color:#f00;font-size:12px;">[${formatUnknownComponent(name)}]</p>\n`
           }
           const props = parseProps(propsStr)
-          // 将内部子内容作为保留的 children prop 传入（原始 HTML，不转义）
+          // Pass inner HTML as children prop (unescaped)
           if (children && props.children === undefined) {
             props.children = children
           }

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -1,4 +1,3 @@
-// Markdown 扩展导出
 export * from './alert'
 export * from './component'
 export * from './diagram-theme'

--- a/packages/core/src/extensions/infographic.ts
+++ b/packages/core/src/extensions/infographic.ts
@@ -21,7 +21,6 @@ interface InfographicOptions {
 
 type InfographicOptionsSource = InfographicOptions | (() => InfographicOptions | undefined)
 
-// key -> svg（LRU 缓存，上限 50 条）
 const svgCache = createSVGCache(50)
 const pendingMeta = new Map<string, { code: string, options?: InfographicOptions }>()
 const inFlight = new Set<string>()
@@ -199,7 +198,7 @@ async function renderInfographic(containerId: string, code: string, cacheKey: st
   }
 }
 
-/** 预览区 DOM 更新后，将缓存 SVG 写入占位节点或重试未完成的渲染 */
+/** After preview DOM updates, write cached SVG into placeholders or retry pending renders. */
 export function hydratePendingInfographicDiagrams(root: ParentNode, options?: InfographicOptions) {
   if (typeof window === `undefined`)
     return

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -63,8 +63,8 @@ function createRenderer(
     const width = svg.style[`min-width`] || svg.getAttribute(`width`)
     svg.removeAttribute(`width`)
 
-    // 行内公式对齐 https://groups.google.com/g/mathjax-users/c/zThKffrrCvE?pli=1
-    // 直接覆盖 style 会覆盖 MathJax 的样式，需要逐个属性设置
+    // Inline math vertical align: https://groups.google.com/g/mathjax-users/c/zThKffrrCvE?pli=1
+    // Set properties individually; assigning style overwrites MathJax defaults
 
     if (withStyle) {
       svg.style.display = `initial`
@@ -74,7 +74,6 @@ function createRenderer(
     }
 
     if (!display) {
-      // 新主题系统：使用 class 而非内联样式
       return `<span class="katex-inline" data-math-display="false" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</span>`
     }
 

--- a/packages/core/src/extensions/markup.ts
+++ b/packages/core/src/extensions/markup.ts
@@ -2,16 +2,10 @@ import type { MarkedExtension } from 'marked'
 import type { MarkupHighlightToken, MarkupUnderlineToken, MarkupWavylineToken } from '../types/marked-tokens'
 import { asTextTokenRenderer } from '../types/marked-tokens'
 
-/**
- * 扩展标记语法：
- * - 高亮: ==文本==
- * - 下划线: ++文本++
- * - 波浪线: ~文本~
- */
+/** Extended markup: ==highlight==, ++underline++, ~wavyline~ */
 export function markedMarkup(): MarkedExtension {
   return {
     extensions: [
-      // 高亮语法 ==文本==
       {
         name: `markup_highlight`,
         level: `inline`,
@@ -34,7 +28,6 @@ export function markedMarkup(): MarkedExtension {
         }),
       },
 
-      // 下划线语法 ++文本++
       {
         name: `markup_underline`,
         level: `inline`,
@@ -57,7 +50,6 @@ export function markedMarkup(): MarkedExtension {
         }),
       },
 
-      // 波浪线语法 ~文本~
       {
         name: `markup_wavyline`,
         level: `inline`,

--- a/packages/core/src/extensions/mermaid.ts
+++ b/packages/core/src/extensions/mermaid.ts
@@ -51,7 +51,6 @@ function buildCacheKey(code: string, themeMode?: DiagramThemeMode): string {
   return simpleHash(`${code}-${diagramCacheThemeSuffix(themeMode)}`)
 }
 
-// key -> svg（LRU 缓存，上限 50 条）
 const svgCache = createSVGCache(50)
 
 async function renderMermaidSvg(code: string, themeMode?: DiagramThemeMode): Promise<string> {

--- a/packages/core/src/extensions/plantuml.ts
+++ b/packages/core/src/extensions/plantuml.ts
@@ -14,46 +14,30 @@ import { simpleHash } from '../utils/basicHelpers'
 import { createSVGCache } from '../utils/svgCache'
 import { diagramCacheThemeSuffix, injectPlantUmlTheme } from './diagram-theme'
 
-// key -> svg（LRU 缓存，上限 50 条）
 const svgCache = createSVGCache(50)
 
 export interface PlantUMLOptions {
-  /**
-   * PlantUML 服务器地址
-   * @default 'https://www.plantuml.com/plantuml'
-   */
+  /** @default 'https://www.plantuml.com/plantuml' */
   serverUrl?: string
-  /**
-   * 渲染格式
-   * @default 'svg'
-   */
+  /** @default 'svg' */
   format?: `svg` | `png`
-  /**
-   * CSS 类名
-   * @default 'plantuml-diagram'
-   */
+  /** @default 'plantuml-diagram' */
   className?: string
-  /**
-   * 是否内嵌SVG内容（用于微信公众号等不支持外链图片的环境）
-   * @default false
-   */
+  /** Inline SVG for WeChat and other environments that block external images. @default false */
   inlineSvg?: boolean
   /**
-   * 自定义样式
+   * Custom styles
    */
   styles?: {
     container?: Record<string, string | number>
   }
-  /** 异步图表文案（Web 端按 locale 注入） */
+  /** Async diagram messages (Web injects per locale) */
   getDiagramMessages?: () => DiagramMessages | undefined
-  /** 图表明暗主题（与 Infographic 一致） */
+  /** Diagram light/dark theme (same as Infographic) */
   getThemeMode?: () => DiagramThemeMode | undefined
 }
 
-/**
- * PlantUML 专用的 6-bit 编码函数
- * 基于官方文档 https://plantuml.com/text-encoding
- */
+/** PlantUML 6-bit encoding per https://plantuml.com/text-encoding */
 function encode6bit(b: number): string {
   if (b < 10) {
     return String.fromCharCode(48 + b)
@@ -76,10 +60,7 @@ function encode6bit(b: number): string {
   return `?`
 }
 
-/**
- * 将 3 个字节附加到编码字符串中
- * 基于官方文档 https://plantuml.com/text-encoding
- */
+/** Append 3 bytes to the encoded string (PlantUML text encoding). */
 function append3bytes(b1: number, b2: number, b3: number): string {
   const c1 = b1 >> 2
   const c2 = ((b1 & 0x3) << 4) | (b2 >> 4)
@@ -93,10 +74,7 @@ function append3bytes(b1: number, b2: number, b3: number): string {
   return r
 }
 
-/**
- * PlantUML 专用的 base64 编码函数
- * 基于官方文档 https://plantuml.com/text-encoding
- */
+/** PlantUML custom base64 encoding per https://plantuml.com/text-encoding */
 function encode64(data: string): string {
   let r = ``
   for (let i = 0; i < data.length; i += 3) {
@@ -113,42 +91,29 @@ function encode64(data: string): string {
   return r
 }
 
-/**
- * 使用 fflate 库进行 Deflate 压缩
- * 按照官方规范进行压缩
- */
+/** Deflate compress per PlantUML spec (fflate, level 9). */
 function performDeflate(input: string): string {
   try {
-    // 将字符串转换为字节数组
     const inputBytes = new TextEncoder().encode(input)
 
-    // 使用 fflate 进行 deflate 压缩（最高压缩级别 9）
     const compressed = deflateSync(inputBytes, { level: 9 })
 
-    // 将压缩后的字节数组转换为二进制字符串
     return String.fromCharCode(...compressed)
   }
   catch (error) {
     console.warn(`Deflate compression failed:`, error)
-    // 如果压缩失败，返回原始输入
     return input
   }
 }
 
-/**
- * 编码 PlantUML 代码为服务器可识别的格式
- * 按照官方规范：UTF-8 编码 -> Deflate 压缩 -> PlantUML Base64 编码
- */
+/** Encode PlantUML: UTF-8 → Deflate → PlantUML base64 */
 function encodePlantUML(plantumlCode: string): string {
   try {
-    // 步骤 1 & 2: UTF-8 编码 + Deflate 压缩
     const deflated = performDeflate(plantumlCode)
 
-    // 步骤 3: PlantUML 专用的 base64 编码
     return encode64(deflated)
   }
   catch (error) {
-    // 如果编码失败，回退到简单方案
     console.warn(`PlantUML encoding failed, using fallback:`, error)
     const utf8Bytes = new TextEncoder().encode(plantumlCode)
     const base64 = btoa(String.fromCharCode(...utf8Bytes))
@@ -158,9 +123,6 @@ function encodePlantUML(plantumlCode: string): string {
 
 type ResolvedPlantUMLOptions = Required<Omit<PlantUMLOptions, 'getDiagramMessages' | 'getThemeMode'>> & Pick<PlantUMLOptions, 'getDiagramMessages' | 'getThemeMode'>
 
-/**
- * 生成 PlantUML 图片 URL
- */
 function generatePlantUMLUrl(code: string, options: Pick<ResolvedPlantUMLOptions, 'serverUrl' | 'format'>): string {
   const encoded = encodePlantUML(code)
   const formatPath = options.format === `svg` ? `svg` : `png`
@@ -168,7 +130,7 @@ function generatePlantUMLUrl(code: string, options: Pick<ResolvedPlantUMLOptions
 }
 
 /**
- * 渲染 PlantUML 图表
+ * Render PlantUML diagram
  */
 function resolvePlantUmlCode(code: string, themeMode?: DiagramThemeMode): string {
   return injectPlantUmlTheme(code, themeMode)
@@ -202,11 +164,9 @@ function renderPlantUMLDiagram(
   const finalCode = resolvePlantUmlCode(code, themeMode)
   const imageUrl = generatePlantUMLUrl(finalCode, options)
 
-  // 如果启用了内嵌SVG且格式是SVG
   if (options.inlineSvg && options.format === `svg`) {
     const placeholder = `plantuml-${cacheKey}`
 
-    // 异步获取SVG内容并替换
     fetchSvgContent(imageUrl, messages.plantumlError).then((svgContent) => {
       const placeholderElement = document.querySelector(`[data-placeholder="${placeholder}"]`) as HTMLElement
       if (placeholderElement) {
@@ -231,9 +191,6 @@ function renderPlantUMLDiagram(
   return createPlantUMLHTML(imageUrl, options)
 }
 
-/**
- * 获取SVG内容
- */
 async function fetchSvgContent(svgUrl: string, errorMessage: string): Promise<string> {
   try {
     const response = await fetch(svgUrl)
@@ -241,12 +198,10 @@ async function fetchSvgContent(svgUrl: string, errorMessage: string): Promise<st
       throw new Error(`HTTP ${response.status}`)
     }
     const svgContent = await response.text()
-    // 移除SVG根元素的固定尺寸，使其响应式
+    // Drop fixed SVG dimensions for responsive layout
     return svgContent
-      // 移除width和height属性
       .replace(/(<svg[^>]*)\swidth="[^"]*"/g, `$1`)
       .replace(/(<svg[^>]*)\sheight="[^"]*"/g, `$1`)
-      // 移除style中的width和height
       .replace(/(<svg[^>]*style="[^"]*?)width:[^;]*;?/g, `$1`)
       .replace(/(<svg[^>]*style="[^"]*?)height:[^;]*;?/g, `$1`)
       // "none" squashes diagrams when only one axis is constrained in preview / WeChat
@@ -258,9 +213,6 @@ async function fetchSvgContent(svgUrl: string, errorMessage: string): Promise<st
   }
 }
 
-/**
- * 创建 PlantUML HTML 元素
- */
 function createPlantUMLHTML(
   imageUrl: string,
   options: ResolvedPlantUMLOptions,
@@ -273,7 +225,6 @@ function createPlantUMLHTML(
         .join(`; `)
     : ``
 
-  // 如果有SVG内容，直接嵌入
   if (svgContent) {
     const state = isError ? MD_DIAGRAM_STATE.error : MD_DIAGRAM_STATE.ready
     return `<div class="${options.className}" style="${containerStyles}" ${diagramStateAttr(state)}>
@@ -281,15 +232,12 @@ function createPlantUMLHTML(
     </div>`
   }
 
-  // 否则使用图片链接
   return `<div class="${options.className}" style="${containerStyles}" ${diagramStateAttr(MD_DIAGRAM_STATE.ready)}>
     <img src="${imageUrl}" alt="PlantUML Diagram" style="max-width: 100%; height: auto;" />
   </div>`
 }
 
-/**
- * PlantUML marked 扩展
- */
+/** PlantUML marked extension */
 export function markedPlantUML(options: PlantUMLOptions = {}): MarkedExtension {
   const resolvedOptions: ResolvedPlantUMLOptions = {
     serverUrl: options.serverUrl || `https://www.plantuml.com/plantuml`,
@@ -313,11 +261,9 @@ export function markedPlantUML(options: PlantUMLOptions = {}): MarkedExtension {
         name: `plantuml`,
         level: `block`,
         start(src: string) {
-          // 匹配 ```plantuml 代码块
           return src.match(/^```plantuml/m)?.index
         },
         tokenizer(src: string) {
-          // 匹配完整的 plantuml 代码块
           const match = /^```plantuml\r?\n([\s\S]*?)\r?\n```/.exec(src)
 
           if (match) {

--- a/packages/core/src/extensions/ruby.ts
+++ b/packages/core/src/extensions/ruby.ts
@@ -3,19 +3,12 @@ import type { RubyToken } from '../types/marked-tokens'
 import { asTextTokenRenderer } from '../types/marked-tokens'
 
 /**
- * 注音/拼音标注扩展
+ * Ruby / pinyin annotation extension
  * https://talk.commonmark.org/t/proper-ruby-text-rb-syntax-support-in-markdown/2279
  * https://www.w3.org/TR/ruby/
  *
- * 支持的格式：
- * 1. [文字]{注音}
- * 2. [文字]^(注音)
- *
- * 分隔符：
- * - `・` (中点)
- * - `．` (全角句点)
- * - `。` (中文句号)
- * - `-` (英文减号)
+ * Syntax: [text]{ruby} or [text]^(ruby)
+ * Separators in ruby part: `・` `．` `。` `-`
  */
 export function markedRuby(): MarkedExtension {
   return {
@@ -24,11 +17,9 @@ export function markedRuby(): MarkedExtension {
         name: `ruby`,
         level: `inline`,
         start(src: string) {
-          // 匹配以 [ 开头的格式
           return src.match(/\[/)?.index
         },
         tokenizer(src: string) {
-          // 1. [文字]{注音}
           const rule1 = /^\[([^\]]+)\]\{([^}]+)\}/
           let match = rule1.exec(src)
           if (match) {
@@ -41,7 +32,6 @@ export function markedRuby(): MarkedExtension {
             }
           }
 
-          // 2. [文字]^(注音)
           const rule2 = /^\[([^\]]+)\]\^\(([^)]+)\)/
           match = rule2.exec(src)
           if (match) {
@@ -59,20 +49,16 @@ export function markedRuby(): MarkedExtension {
         renderer: asTextTokenRenderer((token: RubyToken) => {
           const { text, ruby, format } = token
 
-          // 检查是否有分隔符
           const separatorRegex = /[・．。-]/g
           const hasSeparators = separatorRegex.test(ruby)
 
           if (hasSeparators) {
-            // 分割注音部分
             const rubyParts = ruby.split(separatorRegex).filter((part: string) => part.trim() !== ``)
 
             const textChars = text.split(``)
             const result = []
 
             if (textChars.length >= rubyParts.length) {
-              // 文字字符数量 >= 注音部分数量
-              // 按注音部分数量分割文字
               let currentIndex = 0
 
               for (let i = 0; i < rubyParts.length; i++) {
@@ -80,14 +66,11 @@ export function markedRuby(): MarkedExtension {
                 const remainingChars = textChars.length - currentIndex
                 const remainingParts = rubyParts.length - i
 
-                // 计算当前部分应该包含多少个字符，默认为 1
                 let charCount = 1
                 if (remainingParts === 1) {
-                  // 最后一个部分，包含所有剩余字符
                   charCount = remainingChars
                 }
 
-                // 提取当前部分的文字
                 const currentText = textChars.slice(currentIndex, currentIndex + charCount).join(``)
 
                 result.push(`<ruby data-text="${currentText}" data-ruby="${rubyPart}" data-format="${format}">${currentText}<rp>(</rp><rt>${rubyPart}</rt><rp>)</rp></ruby>`)
@@ -95,14 +78,11 @@ export function markedRuby(): MarkedExtension {
                 currentIndex += charCount
               }
 
-              // 处理剩余的字符
               if (currentIndex < textChars.length) {
                 result.push(textChars.slice(currentIndex).join(``))
               }
             }
             else {
-              // 文字字符数量 < 注音部分数量
-              // 每个字符对应一个注音部分，多余的注音被忽略
               for (let i = 0; i < textChars.length; i++) {
                 const char = textChars[i]
                 const rubyPart = rubyParts[i] || ``

--- a/packages/core/src/extensions/slider.ts
+++ b/packages/core/src/extensions/slider.ts
@@ -39,20 +39,17 @@ export function markedSlider(): MarkedExtension {
             const alt = altMatch[1] || ``
             const src = srcMatch[1] || ``
 
-            // 新主题系统：不再需要内联样式
             return { src, alt }
           })
 
-          // 使用微信公众号兼容的滑动容器布局
-          // 使用微信支持的section标签和特殊样式组合
-
+          // WeChat-compatible horizontal scroll: section tags + overflow-x scroll
           return `
             <section style="box-sizing: border-box; font-size: 16px;">
               <section data-role="outer" style="font-family: 微软雅黑; font-size: 16px;">
                 <section data-role="paragraph" style="margin: 0px auto; box-sizing: border-box; width: 100%;">
                   <section style="margin: 0px auto; text-align: center;">
                     <section style="display: inline-block; width: 100%;">
-                      <!-- 微信公众号支持的滑动图片容器 -->
+                      <!-- WeChat-compatible horizontal scroll image container -->
                       <section style="overflow-x: scroll; -webkit-overflow-scrolling: touch; white-space: nowrap; width: 100%; text-align: center;">
                         ${images.map((img: { src: string, alt: string }, _index: number) => `<section style="display: inline-block; width: 100%; margin-right: 0; vertical-align: top;">
                           <img src="${img.src}" alt="${img.alt}" title="${img.alt}" style="width: 100%; height: auto; border-radius: 4px; vertical-align: top;"/>

--- a/packages/core/src/extensions/toc.ts
+++ b/packages/core/src/extensions/toc.ts
@@ -1,8 +1,6 @@
 import type { MarkedExtension } from 'marked'
 
-/**
- * marked 插件：支持 [TOC] 语法，自动生成嵌套目录
- */
+/** marked extension: [TOC] syntax for nested table of contents */
 export function markedToc(): MarkedExtension {
   let headings: { text: string, depth: number, index: number }[] = []
 
@@ -26,7 +24,7 @@ export function markedToc(): MarkedExtension {
         name: `toc`,
         level: `block`,
         start(src) {
-          // 只匹配独立一行的 [TOC]，避免误伤
+          // Match [TOC] on its own line only
           const match = src.match(/^\s*\[TOC\]\s*$/m)
           return match ? match.index : undefined
         },

--- a/packages/core/src/mathjax.d.ts
+++ b/packages/core/src/mathjax.d.ts
@@ -1,6 +1,5 @@
 /**
- * 类型声明：MathJax 全局变量
- * MathJax 通过 <script> 标签加载到 window 上，无官方 TypeScript 声明
+ * MathJax global on window (loaded via <script>; no official TypeScript types).
  */
 
 interface MathJaxDocument {

--- a/packages/core/src/renderer/index.ts
+++ b/packages/core/src/renderer/index.ts
@@ -1,3 +1,2 @@
-// 主渲染器导出
 export * from './renderer-impl'
 export type { RendererAPI } from '@md/shared/types'

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -67,11 +67,8 @@ function buildFootnoteArray(footnotes: [number, string, string][]): string {
 
 function extractFileName(href: string): string {
   try {
-    // 移除查询参数和哈希
     const urlPath = href.split('?')[0].split('#')[0]
-    // 获取最后一个 / 之后的部分
     const fileName = urlPath.split('/').pop() || ''
-    // 移除文件扩展名
     const nameWithoutExt = fileName.replace(/\.[^.]*$/, '')
     return nameWithoutExt
   }
@@ -108,9 +105,8 @@ const macCodeSvg = `
 `.trim()
 
 /**
- * 渲染 diff-{lang} 代码块。
- * 以 `+` 开头的行显示绿色底色（新增），`-` 开头的行显示红色底色（删除），
- * 其余行正常高亮显示。
+ * Render diff-{lang} code blocks: + lines green (added), - lines red (deleted),
+ * other lines highlighted normally.
  */
 function renderDiffCode(text: string, baseLang: string): string {
   const isLangRegistered = hljs.getLanguage(baseLang)
@@ -118,7 +114,7 @@ function renderDiffCode(text: string, baseLang: string): string {
 
   const lines = text.split(`\n`)
   const prefixes = lines.map(line => line[0])
-  // 将每行去掉前缀（+/-/ ）后拼接，整体高亮一次以避免逐行调用 hljs
+  // Strip +/- prefixes and highlight once to avoid per-line hljs calls
   const strippedLines = lines.map((line, i) => {
     const p = prefixes[i]
     return (p === `+` || p === `-`) ? line.slice(1) : line
@@ -152,7 +148,7 @@ function renderDiffCode(text: string, baseLang: string): string {
     .join(``)
 
   const span = `<span class="mac-sign" style="padding: 10px 14px 0;">${macCodeSvg}</span>`
-  // 与普通代码块一致：用单个块级容器包裹，避免 code 上的 -webkit-box 把多行 span 横向摆放导致错位
+  // Same -webkit-box wrapper as normal code blocks (see highlightAndFormatCode)
   return `<pre class="hljs code__pre">${span}<code class="language-diff-${baseLang}"><span class="code-block__inner" style="display:block">${rendered}</span></code></pre>`
 }
 
@@ -201,13 +197,6 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     return opts
   }
 
-  /**
-   * 生成带 CSS 类的内容（新主题系统）
-   * @param styleLabel CSS 类名标识
-   * @param content 内容
-   * @param tagName HTML 标签名（可选）
-   * @param style 内联样式（可选）
-   */
   function styledContent(styleLabel: string, content: string, tagName?: string, style?: string): string {
     const tag = tagName ?? styleLabel
     const className = `${styleLabel.replace(UNDERSCORE_REGEX, `-`)}`
@@ -217,13 +206,11 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   }
 
   function addFootnote(title: string, link: string): number {
-    // 检查是否已经存在相同的链接
     const existingFootnote = footnotes.find(([, , existingLink]) => existingLink === link)
     if (existingFootnote) {
-      return existingFootnote[0] // 返回已存在的脚注索引
+      return existingFootnote[0]
     }
 
-    // 如果不存在，创建新的脚注
     footnotes.push([++footnoteIndex, title, link])
     return footnoteIndex
   }
@@ -296,14 +283,13 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
     blockquote({ tokens }: Tokens.Blockquote): string {
       const text = this.parser.parse(tokens)
-      // 新主题系统：blockquote 内的 p 标签由 CSS 选择器 `blockquote p` 控制
+      // Theme CSS targets blockquote p via `blockquote p`
       return styledContent(`blockquote`, text)
     },
 
     code({ text, lang = `` }: Tokens.Code): string {
       const langText = lang.split(` `)[0]
 
-      // diff-{lang} 语法：将代码渲染为 diff 对比视图（+/- 行着色）
       if (langText.startsWith(`diff-`)) {
         return renderDiffCode(text, langText.slice(5))
       }
@@ -314,7 +300,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       const highlighted = highlightAndFormatCode(text, language, hljs, !!opts.isShowLineNumber)
 
       const span = `<span class="mac-sign" style="padding: 10px 14px 0;">${macCodeSvg}</span>`
-      // 如果语言未注册，添加 data-language-pending 属性和原始代码文本用于后续动态加载
+      // Defer highlighting until grammar loads from CDN
       let pendingAttr = ``
       if (!isLanguageRegistered && langText !== `plaintext`) {
         const escapedText = text.replace(DOUBLE_QUOTE_REGEX, `&quot;`)
@@ -347,19 +333,16 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       )
     },
 
-    // 2. listitem：从栈顶取 ordered + counter，计算 prefix 并自增
     listitem(token: Tokens.ListItem) {
       const ordered = listOrderedStack[listOrderedStack.length - 1]
       const idx = listCounters[listCounters.length - 1]!
 
-      // 准备下一个
       listCounters[listCounters.length - 1] = idx + 1
 
       const prefix = ordered
         ? `${idx}. `
         : `• `
 
-      // 渲染内容：优先 inline，fallback 去掉 <p> 包裹
       let content: string
       try {
         content = this.parser.parseInline(token.tokens)
@@ -462,8 +445,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   }
 
   markdownParser.use({ renderer })
-  // 新主题系统：扩展不再需要 styles 参数
-  // 通过闭包传入注册表 getter，避免直接依赖全局状态
+  // Registry getter via closure avoids global state
   markdownParser.use(markedComponent(
     () => opts.components ?? getBuiltInRegistry(),
     () => opts.renderMessages,
@@ -482,7 +464,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     diagramMessages: opts.diagramMessages,
   })))
   markdownParser.use(markedPlantUML({
-    inlineSvg: true, // 启用SVG内嵌，适用于微信公众号
+    inlineSvg: true, // Inline SVG for WeChat (no external images)
     getDiagramMessages: () => opts.diagramMessages,
     getThemeMode: () => opts.themeMode,
   }))

--- a/packages/core/src/theme/componentDarkVars.ts
+++ b/packages/core/src/theme/componentDarkVars.ts
@@ -1,15 +1,14 @@
 /**
- * 组件暗色模式 CSS 变量注入
+ * Dark-mode CSS variables for built-in components.
  *
- * 使用独立样式元素（id="md-comp-dark"），不会被 getThemeStyles() 读取，
- * 因此不会污染复制到微信公众号的 HTML 剪贴板内容。
+ * Injected as <style id="md-comp-dark">; not read by getThemeStyles(), so clipboard
+ * HTML copied to WeChat stays unpolluted.
  *
- * 暗色变量通过 .dark 选择器激活（Tailwind 暗色模式将 .dark 挂载在 <html> 上），
- * 自动覆盖 #output 预览区和组件对话框预览区，无需分别处理。
+ * Vars activate under .dark (Tailwind on <html>), covering #output and component preview.
  *
- * 组件内联样式使用 var(--md-comp-xxx, lightFallback) 格式：
- *   - 编辑器暗色模式：.dark 选择器激活深色变量 → 深色显示 ✓
- *   - 复制到微信（不含此样式元素）：变量未定义 → 使用浅色回退值 ✓
+ * Inline styles use var(--md-comp-xxx, lightFallback):
+ *   - Editor dark: .dark sets dark vars
+ *   - WeChat paste (no style tag): undefined vars → light fallbacks
  */
 
 const COMP_DARK_VARS_CSS = `.dark {
@@ -23,10 +22,7 @@ const COMP_DARK_VARS_CSS = `.dark {
   --md-comp-border-light: #333;
 }`
 
-/**
- * 初始化组件暗色模式 CSS 变量（页面加载时调用一次）。
- * 注入 <style id="md-comp-dark"> 到 <head>，通过 .dark 选择器在暗色模式自动激活。
- */
+/** Inject component dark vars once on page load (<style id="md-comp-dark">). */
 export function initComponentDarkVars(): void {
   if (typeof document === `undefined`)
     return

--- a/packages/core/src/theme/cssProcessor.ts
+++ b/packages/core/src/theme/cssProcessor.ts
@@ -1,11 +1,8 @@
 /**
- * CSS 运行时处理工具（浏览器原生实现）
- * 不依赖 PostCSS，直接在浏览器中解析 CSS 自定义属性（var()）
+ * Runtime CSS processing in the browser (no PostCSS).
+ * Resolves var() and nested custom properties.
  */
 
-/**
- * 从 CSS 字符串中提取所有 CSS 自定义属性定义
- */
 function extractCSSVariables(css: string): Map<string, string> {
   const vars = new Map<string, string>()
   const regex = /--([\w-]+)\s*:\s*([^;}\n]+)/g
@@ -15,21 +12,11 @@ function extractCSSVariables(css: string): Map<string, string> {
   return vars
 }
 
-/**
- * 使用浏览器原生方式处理 CSS 字符串
- * 将所有 var(--xxx) 替换为实际值（支持 fallback 和嵌套变量）
- *
- * @param css - 原始 CSS 字符串
- * @returns 处理后的 CSS 字符串
- */
+/** Replace var(--xxx) with values from the CSS string (fallbacks & nesting supported) */
 export function processCSS(css: string): string {
-  // 1. 从 CSS 字符串本身提取变量定义
   const vars = extractCSSVariables(css)
 
-  // 注意：不从 DOM 计算值覆盖 CSS 字符串中已定义的变量。
-  // 若用 getComputedStyle 覆盖，会读取到上一次注入的旧值，导致主题色更新滞后一次点击。
-
-  // 2. 迭代替换 var() 引用，直到没有可解析的为止（处理嵌套变量）
+  // Do not override from getComputedStyle — stale injected theme would lag one click behind
   const varRegex = /var\(\s*(--[\w-]+)\s*(?:,([^()]*(?:\([^()]*\)[^()]*)*))?\)/g
   let result = css
   let prev = ``
@@ -45,7 +32,6 @@ export function processCSS(css: string): string {
     iterations++
   }
 
-  // 3. 化简 calc() 表达式（由内而外，迭代处理嵌套）
   const calcRegex = /calc\(([^()]+)\)/g
   prev = ``
   iterations = 0
@@ -62,16 +48,11 @@ const UNITS = `px|em|rem|vw|vh|vmin|vmax|%|pt|pc|cm|mm|in|ex|ch`
 const NUM = `(-?[\\d.]+)`
 const UNIT_VAL = `(-?[\\d.]+)(${UNITS})?`
 
-/**
- * 对 calc() 内部表达式求值（不含外层 calc()）
- * 支持：加减（同单位）、乘除（一个操作数无单位）
- */
+/** Evaluate calc() inner expression (same-unit +/-, scale with unitless operand) */
 function evaluateCalcInner(expr: string): string {
-  // 乘法：Xunit * N 或 N * Xunit
   const mul = expr.match(new RegExp(`^${UNIT_VAL}\\s*\\*\\s*${UNIT_VAL}$`))
   if (mul) {
     const [, a, ua, b, ub] = mul
-    // 有且仅有一侧有单位
     if (!ua !== !ub) {
       const unit = ua || ub
       const result = round(Number.parseFloat(a) * Number.parseFloat(b))
@@ -79,7 +60,6 @@ function evaluateCalcInner(expr: string): string {
     }
   }
 
-  // 除法：Xunit / N
   const div = expr.match(new RegExp(`^${UNIT_VAL}\\s*/\\s*${NUM}$`))
   if (div) {
     const [, a, unit,, b] = div
@@ -87,7 +67,6 @@ function evaluateCalcInner(expr: string): string {
     return `${result}${unit ?? ``}`
   }
 
-  // 加减：同单位
   const addSub = expr.match(new RegExp(`^${UNIT_VAL}\\s*([+-])\\s*${UNIT_VAL}$`))
   if (addSub) {
     const [, a, ua, op, b, ub] = addSub
@@ -97,7 +76,6 @@ function evaluateCalcInner(expr: string): string {
     }
   }
 
-  // 无法化简，保留 calc()
   return `calc(${expr})`
 }
 

--- a/packages/core/src/theme/cssScopeWrapper.ts
+++ b/packages/core/src/theme/cssScopeWrapper.ts
@@ -1,62 +1,46 @@
 /**
- * CSS 作用域包装器
- * 给 CSS 选择器添加作用域前缀，限制样式只在预览区域生效
+ * Scope CSS selectors to a prefix so styles apply only in the preview area.
  */
 
 import { SELECTOR_MAPPING } from './selectorMapping'
 
-/**
- * 给 CSS 添加作用域前缀，并使用映射表转换旧选择器
- * @param css - 原始 CSS 字符串
- * @param scope - 作用域选择器，默认为 #output
- * @returns 添加作用域后的 CSS
- */
+/** Add scope prefix and map legacy selectors via SELECTOR_MAPPING */
 export function wrapCSSWithScope(css: string, scope: string = `#output`): string {
-  // 处理每个 CSS 规则
   return css.replace(
     /([^{}]+)\{([^}]*)\}/g,
     (match, selectors, properties) => {
-      // 跳过 @规则（如 @keyframes, @media）和 :root
       const trimmedSelectors = selectors.trim()
       if (trimmedSelectors.startsWith(`@`) || trimmedSelectors.startsWith(`:root`)) {
         return match
       }
 
-      // 分割多个选择器（用逗号分隔）
       const wrappedSelectors = selectors
         .split(`,`)
         .map((selector: string) => {
           let trimmed = selector.trim()
 
-          // 跳过已经有作用域前缀的
           if (trimmed.startsWith(scope)) {
             return trimmed
           }
 
-          // 跳过空选择器
           if (!trimmed) {
             return trimmed
           }
 
-          // 旧根容器类名兼容
           trimmed = trimmed.replace(/\.md-container\b/g, `.container`)
 
-          // 获取选择器的第一部分（基础选择器）
           const baseSelector = trimmed.split(/[\s>+~:[]/, 1)[0].trim()
 
-          // 使用映射表转换旧选择器到新类名
           if (baseSelector && SELECTOR_MAPPING[baseSelector]) {
-            // 替换基础选择器为新类名
             trimmed = trimmed.replace(baseSelector, `.${SELECTOR_MAPPING[baseSelector]}`)
           }
 
-          // 对 h1-h6 标题选择器添加 section 以匹配预设标题样式的选择器优先级
+          // Prefix h1–h6 with section to match preset heading selector specificity
           const headingMatch = trimmed.match(/^(h[1-6])(\s|$|::|[:[])/)
           if (headingMatch) {
             return `${scope} section ${trimmed}`
           }
 
-          // 添加作用域前缀
           return `${scope} ${trimmed}`
         })
         .filter(Boolean)

--- a/packages/core/src/theme/cssVariables.ts
+++ b/packages/core/src/theme/cssVariables.ts
@@ -1,7 +1,4 @@
-/**
- * CSS 变量生成工具
- * 根据配置动态生成 CSS 变量样式
- */
+/** Dynamic CSS variable generation from editor config */
 
 import type { HeadingLevel, HeadingStyles, HeadingStyleType } from '@md/shared/configs'
 
@@ -14,21 +11,16 @@ export interface CSSVariableConfig {
   headingStyles?: HeadingStyles
 }
 
-/**
- * 生成 CSS 变量样式
- * @param config - 配置对象
- * @returns CSS 变量字符串
- */
 export function generateCSSVariables(config: CSSVariableConfig): string {
   return `
 :root {
-  /* 动态配置变量 */
+  /* Theme config */
   --md-primary-color: ${config.primaryColor};
   --md-font-family: ${config.fontFamily};
   --md-font-size: ${config.fontSize};
 }
 
-/* 段落缩进和对齐 */
+/* Paragraph indent & justify */
 #output p {
   ${config.isUseIndent ? 'text-indent: 2em;' : ''}
   ${config.isUseJustify ? 'text-align: justify;' : ''}
@@ -36,16 +28,11 @@ export function generateCSSVariables(config: CSSVariableConfig): string {
   `.trim()
 }
 
-/**
- * 生成标题样式 CSS（单独导出，用于在主题 CSS 之后应用）
- */
+/** Heading preset CSS (apply after theme CSS) */
 export function generateHeadingStyles(config: CSSVariableConfig): string {
   return generateHeadingStylesCSS(config.headingStyles)
 }
 
-/**
- * 生成标题样式 CSS
- */
 function generateHeadingStylesCSS(headingStyles?: HeadingStyles): string {
   if (!headingStyles)
     return ``
@@ -55,7 +42,7 @@ function generateHeadingStylesCSS(headingStyles?: HeadingStyles): string {
 
   for (const level of levels) {
     const style = headingStyles[level]
-    // 自定义样式由用户在 CSS 编辑器中直接编辑，这里只处理预设样式
+    // Custom styles are edited in CSS editor; only preset types here
     if (style && style !== `default` && style !== `custom`) {
       cssRules.push(generateHeadingCSS(level, style))
     }
@@ -64,9 +51,6 @@ function generateHeadingStylesCSS(headingStyles?: HeadingStyles): string {
   return cssRules.join(`\n\n`)
 }
 
-/**
- * 生成单个标题级别的样式 CSS
- */
 function generateHeadingCSS(level: HeadingLevel, style: HeadingStyleType): string {
   const baseStyles = `
   display: block;

--- a/packages/core/src/theme/selectorMapping.ts
+++ b/packages/core/src/theme/selectorMapping.ts
@@ -1,15 +1,9 @@
 /**
- * CSS 选择器映射表
- * 将旧的自定义选择器映射到新的规范类名（kebab-case）
- * 实现向后兼容
+ * Legacy selector → kebab-case class mapping for backward compatibility
  */
 
-/**
- * 选择器映射表
- * 旧选择器 → 新类名
- */
 export const SELECTOR_MAPPING: Record<string, string> = {
-  // GFM Alert 相关
+  // GFM alerts
   blockquote_note: `markdown-alert-note`,
   blockquote_tip: `markdown-alert-tip`,
   blockquote_info: `markdown-alert-info`,
@@ -93,15 +87,15 @@ export const SELECTOR_MAPPING: Record<string, string> = {
   blockquote_p_quote: `alert-content-quote`,
   blockquote_p_cite: `alert-content-cite`,
 
-  // 代码相关
+  // Code blocks
   code_pre: `code-block`,
   codespan: `code-inline`,
 
-  // KaTeX 公式
+  // KaTeX
   inline_katex: `katex-inline`,
   block_katex: `katex-block`,
 
-  // Markup 标记
+  // Markup extensions
   markup_highlight: `markup-highlight`,
   markup_underline: `markup-underline`,
   markup_wavyline: `markup-wavyline`,

--- a/packages/core/src/theme/themeApplicator.ts
+++ b/packages/core/src/theme/themeApplicator.ts
@@ -1,7 +1,4 @@
-/**
- * 主题应用工具
- * 负责将主题样式应用到页面
- */
+/** Apply merged theme styles to the page */
 
 import type { ThemeName } from '@md/shared/configs'
 import type { CSSVariableConfig } from './cssVariables'
@@ -12,23 +9,16 @@ import { generateCSSVariables, generateHeadingStyles } from './cssVariables'
 import { getThemeInjector } from './themeInjector'
 
 export interface ThemeConfig {
-  themeName: string // 主题名称
-  customCSS?: string // 用户自定义 CSS
+  themeName: string
+  customCSS?: string
   variables: CSSVariableConfig
 }
 
-/**
- * 应用主题
- * @param config - 主题配置
- */
 export async function applyTheme(config: ThemeConfig): Promise<void> {
-  // 1. 生成 CSS 变量
   const variablesCSS = generateCSSVariables(config.variables)
 
-  // 2. 构建主题 CSS（模拟旧系统的合并行为）
-  let themeCSS = themeMap.default // 默认主题作为基础
+  let themeCSS = themeMap.default
 
-  // 3. 如果不是 default 主题，叠加主题特定样式
   if (config.themeName !== `default`) {
     const specificThemeCSS = themeMap[config.themeName as ThemeName]
     if (specificThemeCSS) {
@@ -36,30 +26,24 @@ export async function applyTheme(config: ThemeConfig): Promise<void> {
     }
   }
 
-  // 4. 给主题 CSS 添加作用域（只影响 #output 预览区域）
   const scopedThemeCSS = wrapCSSWithScope(themeCSS, `#output`)
 
-  // 5. 生成标题样式 CSS（在主题 CSS 之后应用，确保覆盖主题默认样式）
   const headingStylesCSS = generateHeadingStyles(config.variables)
 
-  // 6. 处理用户自定义 CSS（添加作用域）
   const scopedCustomCSS = config.customCSS
     ? wrapCSSWithScope(config.customCSS, `#output`)
     : ``
 
-  // 7. 拼接完整 CSS（用户自定义 CSS 在最后，优先级最高）
   let mergedCSS = [
-    variablesCSS, // CSS 变量（全局）
-    baseCSSContent, // 基础样式（全局）
-    scopedThemeCSS, // 主题样式（限制在 #output）
-    headingStylesCSS, // 标题样式
-    scopedCustomCSS, // 用户自定义 CSS（最后应用，可覆盖预设样式）
+    variablesCSS,
+    baseCSSContent,
+    scopedThemeCSS,
+    headingStylesCSS,
+    scopedCustomCSS,
   ].filter(Boolean).join(`\n\n`)
 
-  // 8. 解析 CSS 变量（将 var(--xxx) 替换为实际值，供导出/复制内联样式使用）
   mergedCSS = processCSS(mergedCSS)
 
-  // 9. 注入到页面
   const injector = getThemeInjector()
   injector.inject(mergedCSS)
 }

--- a/packages/core/src/theme/themeExporter.ts
+++ b/packages/core/src/theme/themeExporter.ts
@@ -1,29 +1,17 @@
-/**
- * 主题导出工具
- * 导出合并后的主题CSS
- */
+/** Export merged theme CSS to a downloadable file */
 
 import type { CSSVariableConfig } from './cssVariables'
 import { downloadFile } from '@md/shared/utils'
 import { generateCSSVariables } from './cssVariables'
 
-/**
- * 导出合并后的主题CSS
- * @param customCSS - 用户自定义的CSS内容
- * @param baseThemeCSS - 基础主题CSS
- * @param config - 配置项
- * @param fileName - 导出文件名
- */
 export function exportMergedTheme(
   customCSS: string,
   baseThemeCSS: string,
   config: CSSVariableConfig,
   fileName: string,
 ) {
-  // 1. 生成 CSS 变量
   const variablesCSS = generateCSSVariables(config)
 
-  // 2. 拼接完整 CSS
   const mergedCSS = [
     `/**`,
     ` * MD 主题导出`,

--- a/packages/core/src/theme/themeInjector.ts
+++ b/packages/core/src/theme/themeInjector.ts
@@ -1,19 +1,9 @@
-/**
- * 主题样式注入器
- * 负责管理动态注入的 <style> 标签
- */
+/** Manages the injected theme <style> element */
 
-/**
- * 主题样式注入器类
- */
 export class ThemeInjector {
   private styleElement: HTMLStyleElement | null = null
   private readonly styleId = `md-theme`
 
-  /**
-   * 注入或更新主题样式
-   * @param cssContent - CSS 内容
-   */
   inject(cssContent: string): void {
     if (!this.styleElement) {
       this.styleElement = document.createElement(`style`)
@@ -23,9 +13,6 @@ export class ThemeInjector {
     this.styleElement.textContent = cssContent
   }
 
-  /**
-   * 移除主题样式
-   */
   remove(): void {
     if (this.styleElement) {
       this.styleElement.remove()
@@ -33,20 +20,13 @@ export class ThemeInjector {
     }
   }
 
-  /**
-   * 检查是否已注入
-   */
   isInjected(): boolean {
     return this.styleElement !== null
   }
 }
 
-// 单例模式
 let injectorInstance: ThemeInjector | null = null
 
-/**
- * 获取主题注入器单例
- */
 export function getThemeInjector(): ThemeInjector {
   if (!injectorInstance) {
     injectorInstance = new ThemeInjector()

--- a/packages/core/src/utils/asyncDiagramState.ts
+++ b/packages/core/src/utils/asyncDiagramState.ts
@@ -36,7 +36,7 @@ export function isSvgMarkup(content: string): boolean {
   return content.trimStart().startsWith(`<svg`)
 }
 
-/** 异步图表占位是否仍在等待渲染（与文案语言无关） */
+/** Whether an async diagram placeholder is still awaiting render (locale-independent). */
 export function isAsyncDiagramPending(el: Element): boolean {
   if (!(el instanceof HTMLElement))
     return false

--- a/packages/core/src/utils/basicHelpers.ts
+++ b/packages/core/src/utils/basicHelpers.ts
@@ -1,6 +1,3 @@
-/**
- * 首字母大写
- */
 export function ucfirst(str: string) {
   return str.slice(0, 1).toUpperCase() + str.slice(1).toLowerCase()
 }

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -27,38 +27,26 @@ export const COMMON_LANGUAGES: Record<string, LanguageFn> = {
   xml,
 }
 
-// highlight.js CDN 配置
 const HLJS_VERSION = `11.11.1`
 const HLJS_CDN_BASE = `https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/npm/highlightjs/${HLJS_VERSION}`
 
-// 缓存正在加载的语言
 const loadingLanguages = new Map<string, Promise<void>>()
 
-/**
- * 生成语言包的 CDN URL
- */
 function grammarUrlFor(language: string): string {
   return `${HLJS_CDN_BASE}/es/languages/${language}.min.js`
 }
 
-/**
- * 动态加载并注册语言
- * @param language 语言名称
- * @param hljs highlight.js 实例
- */
+/** Dynamically load and register a highlight.js language grammar from CDN. */
 export async function loadAndRegisterLanguage(language: string, hljs: HLJSApi): Promise<void> {
-  // 如果已经注册，直接返回
   if (hljs.getLanguage(language)) {
     return
   }
 
-  // 如果正在加载，等待加载完成
   if (loadingLanguages.has(language)) {
     await loadingLanguages.get(language)
     return
   }
 
-  // 开始加载
   const loadPromise = (async () => {
     try {
       const module = await import(/* webpackIgnore: true */ /* @vite-ignore */ grammarUrlFor(language))
@@ -77,23 +65,17 @@ export async function loadAndRegisterLanguage(language: string, hljs: HLJSApi): 
   await loadPromise
 }
 
-/**
- * 格式化高亮后的代码，处理空格和制表符
- */
 function formatHighlightedCode(html: string, preserveNewlines = false): string {
   let formatted = html
-  // 将 span 之间的空格移到 span 内部
+  // Move whitespace between adjacent spans inside the preceding span
   formatted = formatted.replace(/(<span[^>]*>[^<]*<\/span>)(\s+)(<span[^>]*>[^<]*<\/span>)/g, (_: string, span1: string, spaces: string, span2: string) => span1 + span2.replace(/^(<span[^>]*>)/, `$1${spaces}`))
   formatted = formatted.replace(/(\s+)(<span[^>]*>)/g, (_: string, spaces: string, span: string) => span.replace(/^(<span[^>]*>)/, `$1${spaces}`))
-  // 替换制表符为4个空格
   formatted = formatted.replace(/\t/g, `    `)
 
   if (preserveNewlines) {
-    // 替换换行符为 <br/>，并将空格转换为 &nbsp;
     formatted = formatted.replace(/\r\n/g, `<br/>`).replace(/\n/g, `<br/>`).replace(/(>[^<]+)|(^[^<]+)/g, (str: string) => str.replace(/\s/g, `&nbsp;`))
   }
   else {
-    // 只将空格转换为 &nbsp;
     formatted = formatted.replace(/(>[^<]+)|(^[^<]+)/g, (str: string) => str.replace(/\s/g, `&nbsp;`))
   }
 
@@ -101,19 +83,17 @@ function formatHighlightedCode(html: string, preserveNewlines = false): string {
 }
 
 /**
- * 分割高亮后的 HTML 为多行，保持 span 上下文
- * highlight.js 输出的 HTML 中，span 标签不会跨行，但换行符可能在 span 内部
- * 此函数将 HTML 按换行符分割，并在每行前后添加必要的开闭标签
+ * Split highlighted HTML into lines while preserving open <span> context.
+ * highlight.js never splits a span across lines, but newlines may appear inside a span.
  */
 function splitHighlightedHtmlByLines(html: string): string[] {
   const lines: string[] = []
   let currentLine = ``
-  const openTags: string[] = [] // 记录打开的标签，如 '<span class="...">'
+  const openTags: string[] = []
 
   let i = 0
   while (i < html.length) {
     if (html[i] === `<`) {
-      // 读取完整标签
       let tag = `<`
       i++
       while (i < html.length && html[i] !== `>`) {
@@ -127,21 +107,16 @@ function splitHighlightedHtmlByLines(html: string): string[] {
 
       currentLine += tag
 
-      // 只跟踪 highlight.js 产出的 <span> 标签
       if (tag.startsWith(`</span`)) {
-        // 关闭 span，从栈中移除
         openTags.pop()
       }
       else if (tag.startsWith(`<span`)) {
-        // 打开 span，加入栈
         openTags.push(tag)
       }
     }
     else if (html[i] === `\n`) {
-      // 为当前行补齐所有闭合标签
       const closingTags = `</span>`.repeat(openTags.length)
       lines.push(currentLine + closingTags)
-      // 下一行重新打开这些标签
       currentLine = openTags.join(``)
       i++
     }
@@ -151,29 +126,18 @@ function splitHighlightedHtmlByLines(html: string): string[] {
     }
   }
 
-  // 最后一行
   lines.push(currentLine)
   return lines
 }
 
-/**
- * 高亮代码并格式化（支持行号）
- * @param text 原始代码文本
- * @param language 语言名称
- * @param hljs highlight.js 实例
- * @param showLineNumber 是否显示行号
- * @returns 格式化后的 HTML
- */
+/** Highlight code and format for display, optionally with line numbers. */
 export function highlightAndFormatCode(text: string, language: string, hljs: HLJSApi, showLineNumber: boolean): string {
   let highlighted = ``
 
   if (showLineNumber) {
-    // 先归一化换行符，确保分割逻辑一致
     const normalizedText = text.replace(/\r\n/g, `\n`)
-    // 对整个代码块进行高亮，保持跨行上下文
     const fullHighlighted = hljs.highlight(normalizedText, { language }).value
 
-    // 分割为多行，保持 span 上下文
     const highlightedLines = splitHighlightedHtmlByLines(fullHighlighted).map((lineHtml) => {
       const formatted = formatHighlightedCode(lineHtml, false)
       return formatted === `` ? `&nbsp;` : formatted
@@ -194,9 +158,9 @@ export function highlightAndFormatCode(text: string, language: string, hljs: HLJ
   else {
     const rawHighlighted = hljs.highlight(text, { language }).value
     const formatted = formatHighlightedCode(rawHighlighted, true)
-    // 用单个块级容器包裹高亮内容：code 上的 display:-webkit-box 是老式弹性盒，
-    // 若直接平铺多个 span/<br>，不同 Chromium 版本（如部分 Edge）会把子节点按横向盒重排导致代码行错位。
-    // 只保留一个 flex 子项即可让内部 <br> 正常换行，同时保留 -webkit-box 以维持微信端横向滚动。
+    // Wrap in one block child: code uses legacy -webkit-box flex; without a single flex item,
+    // some Chromium builds (e.g. Edge) lay out span/<br> siblings horizontally and break line order.
+    // One child keeps <br> line breaks while preserving -webkit-box for WeChat horizontal scroll.
     highlighted = `<span class="code-block__inner" style="display:block">${formatted}</span>`
   }
 
@@ -220,12 +184,7 @@ export function highlightCodeBlock(codeBlock: Element, language: string, hljs: H
   codeBlock.removeAttribute(`data-show-line-number`)
 }
 
-/**
- * 高亮 DOM 中待处理的代码块
- * 查找带有 data-language-pending 属性的代码块，动态加载语言后重新高亮
- * @param hljs highlight.js 实例
- * @param container 容器元素（可选，默认为 document）
- */
+/** Highlight code blocks marked with data-language-pending after loading their grammar. */
 export function highlightPendingBlocks(hljs: HLJSApi, container: Document | Element = document): void {
   const pendingBlocks = container.querySelectorAll(`code[data-language-pending]`)
 
@@ -235,15 +194,12 @@ export function highlightPendingBlocks(hljs: HLJSApi, container: Document | Elem
       return
 
     if (hljs.getLanguage(language)) {
-      // 语言已加载，直接高亮
       highlightCodeBlock(codeBlock, language, hljs)
     }
     else {
-      // 动态加载语言后重新高亮
       loadAndRegisterLanguage(language, hljs).then(() => {
         highlightCodeBlock(codeBlock, language, hljs)
       }).catch(() => {
-        // 加载失败，移除标记
         codeBlock.removeAttribute(`data-language-pending`)
         codeBlock.removeAttribute(`data-raw-code`)
         codeBlock.removeAttribute(`data-show-line-number`)

--- a/packages/core/src/utils/markdownHelpers.ts
+++ b/packages/core/src/utils/markdownHelpers.ts
@@ -8,16 +8,16 @@ const MERMAID_PLACEHOLDER_REGEX = /<!--mermaid-start-->[\s\S]*?<!--mermaid-end--
 const PROTECTED_SPAN_REGEX = /<span data-md-protected="(\d+)"><\/span>/g
 
 /**
- * DOMPurify v3.1.7+ 会强制移除 foreignObject 内容
+ * DOMPurify v3.1.7+ strips foreignObject content.
  * https://github.com/kkomelin/isomorphic-dompurify/pull/290
  * https://github.com/cure53/DOMPurify/issues/1152
- * 使用占位符方案：在 sanitize 前保护特定内容，sanitize 后还原
- * 注意：HTML 注释会被 DOMPurify 移除，所以使用 span 元素作为占位符
+ * Use placeholders: protect before sanitize, restore after.
+ * HTML comments are removed by DOMPurify, so span placeholders are used instead.
  */
 export function sanitizeHtml(html: string): string {
   const protectedContents: string[] = []
 
-  // 保护 infographic-diagram（使用注释标记定界，避免嵌套 div 问题）
+  // Protect infographic blocks (comment delimiters avoid nested-div issues)
   html = html.replace(
     INFOGRAPHIC_PLACEHOLDER_REGEX,
     (match) => {
@@ -26,7 +26,7 @@ export function sanitizeHtml(html: string): string {
     },
   )
 
-  // 保护 mermaid-diagram（使用注释标记定界，避免嵌套 div 问题）
+  // Protect mermaid blocks (comment delimiters avoid nested-div issues)
   html = html.replace(
     MERMAID_PLACEHOLDER_REGEX,
     (match) => {
@@ -35,10 +35,8 @@ export function sanitizeHtml(html: string): string {
     },
   )
 
-  // XSS 处理
   html = DOMPurify.sanitize(html, { ADD_TAGS: [`mp-common-profile`] })
 
-  // 还原被保护的内容
   html = html.replace(
     PROTECTED_SPAN_REGEX,
     (_, i) => protectedContents[Number(i)],
@@ -47,14 +45,7 @@ export function sanitizeHtml(html: string): string {
   return html
 }
 
-/**
- * 渲染 Markdown 内容
- * @param raw - 原始 markdown 字符串
- * @param renderer - 渲染器 API
- * @returns 渲染结果，包含 HTML 和阅读时间
- */
 export function renderMarkdown(raw: string, renderer: RendererAPI) {
-  // 解析 front-matter 和正文
   const { markdownContent, readingTime }
     = renderer.parseFrontMatterAndContent(raw)
 
@@ -65,20 +56,10 @@ export function renderMarkdown(raw: string, renderer: RendererAPI) {
   return { html, readingTime }
 }
 
-/**
- * 后处理 HTML 内容
- * @param baseHtml - 基础 HTML 字符串
- * @param reading - 阅读时间结果
- * @param renderer - 渲染器 API
- * @returns 处理后的 HTML 字符串
- */
 export function postProcessHtml(baseHtml: string, reading: ReadTimeResults, renderer: RendererAPI): string {
-  // 阅读时间及字数统计
   let html = baseHtml
   html = renderer.buildReadingTime(reading) + html
-  // 引用脚注
   html += renderer.buildFootnotes()
-  // 附加的一些 style
   html += renderer.buildAddition()
   html += `
     <style>
@@ -94,16 +75,9 @@ export function postProcessHtml(baseHtml: string, reading: ReadTimeResults, rend
       }
     </style>
   `
-  // 包裹 HTML
   return renderer.createContainer(html)
 }
 
-/**
- * 修改 HTML 内容
- * @param content - 原始内容
- * @param renderer - 渲染器 API
- * @returns 修改后的 HTML 字符串
- */
 export function modifyHtmlContent(content: string, renderer: RendererAPI): string {
   const {
     markdownContent,

--- a/packages/core/src/utils/mathDetection.ts
+++ b/packages/core/src/utils/mathDetection.ts
@@ -1,15 +1,15 @@
 export const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:？！。，：]|$)/
 export const inlineRuleNonStandard = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1/
-/** 块级公式：换行写法 `$$\n...\n$$` */
+/** Block math: multiline `$$\n...\n$$` */
 export const blockRuleMultiline = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
-/** 块级公式：单行写法 `$$...$$`（独占一行，仅双美元符） */
+/** Block math: single-line `$$...$$` (line-only, double dollars) */
 export const blockRuleSingleLine = /^\s{0,3}(\$\$)([^\n]+)\1[ \t]*(?:\n|$)/
 
 export function matchBlockKatex(src: string): RegExpMatchArray | null {
   return src.match(blockRuleMultiline) ?? src.match(blockRuleSingleLine)
 }
 
-/** @deprecated 使用 matchBlockKatex；保留导出以兼容旧引用 */
+/** @deprecated Use matchBlockKatex; kept for backward compatibility */
 export const blockRule = blockRuleMultiline
 
 function contentHasBlockKatex(content: string): boolean {
@@ -64,10 +64,7 @@ export function findInlineKatexStart(src: string, nonStandard: boolean, ruleReg:
   }
 }
 
-/**
- * 检测 Markdown 是否包含会被 MDKatex 识别的公式。
- * 默认 nonStandard=true，与 renderer-impl 配置一致。
- */
+/** Whether content contains math recognized by MDKatex (default nonStandard=true, same as renderer-impl). */
 export function contentHasMath(content: string, nonStandard = true): boolean {
   if (contentHasBlockKatex(content))
     return true
@@ -80,7 +77,7 @@ export function contentHasMath(content: string, nonStandard = true): boolean {
   return findInlineKatexStart(content, nonStandard, ruleReg) !== undefined
 }
 
-/** 移除 inline 公式前因 breaks 产生的多余换行 */
+/** Strip extra <br> before inline katex caused by marked breaks */
 export function stripBreakBeforeInlineKatex(html: string): string {
   return html.replace(/<br\s*\/?>\s*(?=<span class="katex-inline)/gi, ``)
 }

--- a/packages/core/src/utils/mathjax.ts
+++ b/packages/core/src/utils/mathjax.ts
@@ -54,7 +54,7 @@ export function loadMathJax(): Promise<void> {
       MathJax: {
         tex: { tags: `ams` },
         svg: { fontCache: `none` },
-        // 仅通过 tex2svg 在预览区渲染；禁止扫描整页 DOM，否则会改写 CodeMirror 编辑区内的 $$...$$
+        // Render via tex2svg in preview only; disable page scan or CodeMirror $$...$$ gets rewritten
         startup: {
           typeset: false,
         },

--- a/packages/core/src/utils/pureHtml.ts
+++ b/packages/core/src/utils/pureHtml.ts
@@ -1,7 +1,7 @@
 import { Marked } from 'marked'
 import { markedAlert, MDKatex } from '../extensions'
 
-/** 生成无主题样式的纯 HTML（导出 / 预览用） */
+/** Generate themeless pure HTML (for export / preview). */
 export async function generatePureHTML(raw: string): Promise<string> {
   const markedInstance = new Marked()
   markedInstance.use(markedAlert({ withoutStyle: true }))

--- a/packages/core/src/utils/svgCache.ts
+++ b/packages/core/src/utils/svgCache.ts
@@ -1,43 +1,33 @@
 /**
- * 轻量 LRU 缓存，基于 Map 的插入顺序特性实现。
+ * Lightweight LRU cache using Map insertion order.
  *
- * - 命中时将条目移至末尾（最近使用）
- * - 超限时淘汰最久未使用的条目（头部）
- *
- * @template V 缓存值类型
+ * - On hit, move entry to the end (most recently used)
+ * - On overflow, evict the oldest entry (head)
  */
 export class LRUMap<V> {
   private readonly map = new Map<string, V>()
 
-  /**
-   * @param maxSize 缓存最大条目数，必须 >= 1
-   */
   constructor(private readonly maxSize: number = 50) {
     if (maxSize < 1) {
       throw new RangeError(`LRUMap maxSize must be >= 1, got ${maxSize}`)
     }
   }
 
-  /** 读取缓存，命中时刷新为最近使用 */
   get(key: string): V | undefined {
     if (!this.map.has(key)) {
       return undefined
     }
     const value = this.map.get(key)!
-    // 移至末尾（最近使用）
     this.map.delete(key)
     this.map.set(key, value)
     return value
   }
 
-  /** 写入缓存，超限时淘汰最久未使用的条目 */
   set(key: string, value: V): void {
-    // 已存在则先删除，保证末尾是最新
     if (this.map.has(key)) {
       this.map.delete(key)
     }
     else if (this.map.size >= this.maxSize) {
-      // 淘汰头部（最久未使用）
       const oldestKey = this.map.keys().next().value
       if (oldestKey !== undefined) {
         this.map.delete(oldestKey)
@@ -46,26 +36,16 @@ export class LRUMap<V> {
     this.map.set(key, value)
   }
 
-  /** 当前缓存条目数 */
   get size(): number {
     return this.map.size
   }
 
-  /** 清空缓存 */
   clear(): void {
     this.map.clear()
   }
 }
 
-/**
- * 为异步图表渲染器创建一个带 LRU 缓存的包装器。
- *
- * 返回的 `cache` 对象可直接在 marked 扩展的 renderer 中使用：
- * - `cache.get(key)` 命中则直接返回缓存的 HTML
- * - `cache.set(key, value)` 在异步渲染完成后写入缓存
- *
- * @param maxSize 缓存最大条目数，默认 50
- */
+/** LRU cache for async diagram SVG (default max 50 entries). */
 export function createSVGCache(maxSize: number = 50): LRUMap<string> {
   return new LRUMap<string>(maxSize)
 }

--- a/packages/md-cli/server.js
+++ b/packages/md-cli/server.js
@@ -15,27 +15,22 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const arg = parseArgv()
 
-// unicloud 服务空间配置
+// uniCloud service space credentials
 const spaceInfo = {
   spaceId: ``,
   clientSecret: ``,
   ...arg,
 }
 
-/**
- * 创建 Express 服务器
- * @param {number} port - 服务器端口
- */
+/** Create the Express app listening on the given port. */
 export function createServer(port = 8800) {
   const app = express()
 
-  // 确保上传目录存在
   const uploadDir = path.join(__dirname, 'public/upload')
   if (!fs.existsSync(uploadDir)) {
     fs.mkdirSync(uploadDir, { recursive: true })
   }
 
-  // 配置 multer 用于文件上传
   const storage = multer.diskStorage({
     destination: (req, file, cb) => {
       cb(null, uploadDir)
@@ -47,13 +42,11 @@ export function createServer(port = 8800) {
 
   const upload = multer({ storage })
 
-  // 中间件
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
 
   app.use('/public', express.static(path.join(__dirname, 'public')))
 
-  // 文件上传 API
   app.post('/upload', upload.single('file'), async (req, res) => {
     try {
       if (!req.file) {
@@ -70,14 +63,13 @@ export function createServer(port = 8800) {
             file: fs.createReadStream(file.path)
           })
 
-          // 上传成功后删除本地临时文件
           fs.unlinkSync(file.path)
           console.log('文件已上传到云端:', url)
         } else {
           console.log(`${colors.yellow('未配置云存储，降级到本地存储')}`)
         }
       } catch (err) {
-        // 云上传失败，降级到本地存储
+        // Cloud upload failed — fall back to local file URL
         console.log('云存储上传失败，降级到本地存储:', err.message)
       }
 

--- a/packages/md-cli/util.js
+++ b/packages/md-cli/util.js
@@ -1,3 +1,8 @@
+import FormData from 'form-data'
+import process from 'node:process'
+import util from 'node:util'
+import crypto from 'node:crypto'
+
 /**
  * Custom console colors.
  * https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color

--- a/packages/md-cli/util.js
+++ b/packages/md-cli/util.js
@@ -1,12 +1,7 @@
-import FormData from 'form-data'
-import process from 'node:process'
-import util from 'node:util'
-import crypto from 'node:crypto'
-
 /**
- * 自定义控制台颜色
+ * Custom console colors.
  * https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
- * nodejs 内置颜色: https://nodejs.org/api/util.html#util_foreground_colors
+ * Node built-in colors: https://nodejs.org/api/util.html#util_foreground_colors
  */
 function colors() {
   function colorize(color, text) {
@@ -21,34 +16,30 @@ function colors() {
 
   const colorTable = new Proxy(returnValue, {
     get(obj, prop) {
-      // 在没有对应的具名颜色函数时, 返回空函数作为兼容处理
+      // No named color helper: return identity for compatibility
       const res = obj[prop] ? obj[prop] : arg => arg
       return res
     },
   })
 
-  // 取消下行注释, 查看所有的颜色和名字:
+  // Uncomment to list all color names:
   // Object.keys(returnValue).forEach((color) => console.log(returnValue[color](color)))
   return colorTable
 }
 
-/**
- * 解析命令行参数
- * @param {*} arr
- * @returns {Record<string, string | boolean>}
- */
+/** Parse CLI args into key/value (boolean flags, numbers, strings). */
 function parseArgv(arr) {
   return (arr || process.argv.slice(2)).reduce((acc, arg) => {
     let [k, ...v] = arg.split(`=`)
-    v = v.join(`=`) // 把带有 = 的值合并为字符串
-    acc[k] = v === `` // 没有值时, 则表示为 true
+    v = v.join(`=`) // rejoin values that contain =
+    acc[k] = v === `` // bare flag → true
       ? true
       : (
-        /^(true|false)$/.test(v) // 转换指明的 true/false
+        /^(true|false)$/.test(v) // explicit boolean
           ? v === `true`
           : (
             /[\d|.]+/.test(v)
-              ? (Number.isNaN(Number(v)) ? v : Number(v)) // 如果转换为数字失败, 则使用原始字符
+              ? (Number.isNaN(Number(v)) ? v : Number(v)) // keep string if not numeric
               : v
           )
       )
@@ -63,7 +54,7 @@ function dcloud(spaceInfo) {
 
   function sign(data, secret) {
     const hmac = crypto.createHmac(`md5`, secret)
-    // 排序 obj 再转换为 key=val&key=val 的格式
+    // Sort keys, serialize as key=val&key=val
     const str = Object.keys(data).sort().reduce((acc, cur) => `${acc}&${cur}=${data[cur]}`, ``).slice(1)
     hmac.update(str)
     return hmac.digest(`hex`)

--- a/packages/shared/src/assets/index.ts
+++ b/packages/shared/src/assets/index.ts
@@ -1,6 +1,1 @@
-/**
- * 共享资源导出
- */
-
-// 默认自定义主题模板
 export { default as DEFAULT_CUSTOM_THEME } from './default-custom-theme.txt?raw'

--- a/packages/shared/src/configs/ai-service-options.ts
+++ b/packages/shared/src/configs/ai-service-options.ts
@@ -364,7 +364,7 @@ export const serviceOptions: ServiceOption[] = [
   },
 ]
 
-// 图片模型
+// Image generation models
 export const imageServiceOptions: ImageServiceOption[] = [
   {
     value: `default`,

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -1,9 +1,9 @@
 /**
- * MD 基础主题样式
- * 包含所有元素的基础样式和 CSS 变量定义
+ * MD base theme styles
+ * Base element styles and CSS variable definitions
  */
 
-/* ==================== 容器样式 ==================== */
+/* ==================== Container ==================== */
 section,
 #output .container {
   font-family: var(--md-font-family);
@@ -12,7 +12,6 @@ section,
   text-align: left;
 }
 
-/* 确保 #output 容器应用基础样式 */
 #output {
   font-family: var(--md-font-family);
   font-size: var(--md-font-size);
@@ -20,18 +19,16 @@ section,
   text-align: left;
 }
 
-/* 去除第一个元素的 margin-top */
 #output section > :first-child {
   margin-top: 0 !important;
 }
 
 /*
- * 兜底重置：导出 HTML / 分享页 / VSCode 预览等脱离 Web App 的场景
- * 没有 Tailwind preflight，浏览器 UA 默认样式会冒出来（如
- * blockquote 默认左右各 40px margin、table 默认 border-collapse: separate）。
- * 这里统一重置左右（及顶部）外边距，保证导出结果与预览一致。
- * 垂直间距由主题 blockquote { margin-bottom } 控制，勿在此处 margin: 0 覆盖。
- * section 选择器用于 VSCode 预览（无 #output 容器，内容在 section.container 内）。
+ * Reset for exported HTML / share pages / VSCode preview (no Tailwind preflight).
+ * Browser defaults leak in (e.g. blockquote 40px side margins, table border-collapse: separate).
+ * Reset horizontal (and top) margins so export matches in-app preview.
+ * Vertical spacing comes from theme blockquote { margin-bottom }; do not zero all margins here.
+ * section selector covers VSCode preview (no #output; content in section.container).
  */
 #output blockquote,
 section blockquote {
@@ -43,10 +40,11 @@ section blockquote {
 #output table,
 section table {
   border-collapse: collapse;
-  min-width: 100%;
 }
 
-.mermaid-diagram .nodeLabel p {
-  color: unset !important;
-  letter-spacing: unset !important;
+#output th,
+#output td,
+section th,
+section td {
+  border: 1px solid var(--md-border-color, #e0e0e0);
 }

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -40,11 +40,10 @@ section blockquote {
 #output table,
 section table {
   border-collapse: collapse;
+  min-width: 100%;
 }
 
-#output th,
-#output td,
-section th,
-section td {
-  border: 1px solid var(--md-border-color, #e0e0e0);
+.mermaid-diagram .nodeLabel p {
+  color: unset !important;
+  letter-spacing: unset !important;
 }

--- a/packages/shared/src/configs/theme-css/default.css
+++ b/packages/shared/src/configs/theme-css/default.css
@@ -1,10 +1,10 @@
 /**
- * MD 默认主题（经典主题）
- * 按 Alt/Option + Shift + F 可格式化
- * 如需使用主题色，请使用 var(--md-primary-color) 代替颜色值
+ * MD default theme (classic).
+ * Format with Alt/Option + Shift + F.
+ * Use var(--md-primary-color) for theme color instead of hard-coded values.
  */
 
-/* ==================== 一级标题 ==================== */
+/* ==================== H1 ==================== */
 h1 {
   display: table;
   padding: 0 1em;
@@ -16,7 +16,7 @@ h1 {
   text-align: center;
 }
 
-/* ==================== 二级标题 ==================== */
+/* ==================== H2 ==================== */
 h2 {
   display: table;
   padding: 0 0.2em;
@@ -28,7 +28,7 @@ h2 {
   text-align: center;
 }
 
-/* ==================== 三级标题 ==================== */
+/* ==================== H3 ==================== */
 h3 {
   padding-left: 8px;
   border-left: 3px solid var(--md-primary-color);
@@ -39,7 +39,7 @@ h3 {
   line-height: 1.2;
 }
 
-/* ==================== 四级标题 ==================== */
+/* ==================== H4 ==================== */
 h4 {
   margin: 2em 8px 0.5em;
   color: var(--md-primary-color);
@@ -47,7 +47,7 @@ h4 {
   font-weight: bold;
 }
 
-/* ==================== 五级标题 ==================== */
+/* ==================== H5 ==================== */
 h5 {
   margin: 1.5em 8px 0.5em;
   color: var(--md-primary-color);
@@ -55,21 +55,21 @@ h5 {
   font-weight: bold;
 }
 
-/* ==================== 六级标题 ==================== */
+/* ==================== H6 ==================== */
 h6 {
   margin: 1.5em 8px 0.5em;
   font-size: calc(var(--md-font-size) * 1);
   color: var(--md-primary-color);
 }
 
-/* ==================== 段落 ==================== */
+/* ==================== Paragraph ==================== */
 p {
   margin: 1.5em 8px;
   letter-spacing: 0.1em;
   color: hsl(var(--foreground));
 }
 
-/* ==================== 引用块 ==================== */
+/* ==================== Blockquote ==================== */
 blockquote {
   font-style: normal;
   padding: 1em;
@@ -88,7 +88,7 @@ blockquote > p {
   margin: 0;
 }
 
-/* ==================== GFM 警告块 ==================== */
+/* ==================== GFM alerts ==================== */
 .alert-title-note,
 .alert-title-tip,
 .alert-title-info,
@@ -200,7 +200,7 @@ blockquote > p {
   color: #9ca3af;
 }
 
-/* GFM Alert SVG 图标颜色 */
+/* GFM alert SVG icon colors */
 .alert-icon-note {
   fill: #478be6;
 }
@@ -271,8 +271,8 @@ blockquote > p {
   fill: #9ca3af;
 }
 
-/* ==================== 学术环境（定理、引理、定义等） ==================== */
-/* 标题颜色 */
+/* ==================== Academic environments (theorem, lemma, definition, …) ==================== */
+/* Title colors */
 .alert-title-theorem,
 .alert-title-lemma,
 .alert-title-corollary,
@@ -298,7 +298,7 @@ blockquote > p {
   color: #c69026;
 }
 
-/* 图标颜色 */
+/* Icon colors */
 .alert-icon-theorem,
 .alert-icon-lemma,
 .alert-icon-corollary,
@@ -324,7 +324,7 @@ blockquote > p {
   fill: #c69026;
 }
 
-/* 盒子描边：学术环境使用完整边框，更接近定理环境的视觉效果 */
+/* Full border on academic boxes (theorem-style appearance) */
 .markdown-alert-theorem,
 .markdown-alert-lemma,
 .markdown-alert-corollary,
@@ -355,7 +355,7 @@ blockquote > p {
   border-left: 4px solid #c69026;
 }
 
-/* 自定义/未知名称的兜底样式：无图标，使用主题主色 */
+/* Fallback for custom/unknown names: no icon, theme primary color */
 .alert-title-custom {
   color: var(--md-primary-color);
 }
@@ -364,7 +364,7 @@ blockquote > p {
   border-left: 4px solid var(--md-primary-color);
 }
 
-/* 学术环境正文使用斜体，符合数学写作惯例 */
+/* Italic body text in academic environments (math convention) */
 .markdown-alert-theorem > :not(.markdown-alert-title),
 .markdown-alert-lemma > :not(.markdown-alert-title),
 .markdown-alert-corollary > :not(.markdown-alert-title),
@@ -376,7 +376,7 @@ blockquote > p {
   font-style: italic;
 }
 
-/* ==================== 代码块 ==================== */
+/* ==================== Code blocks ==================== */
 pre.code__pre,
 .hljs.code__pre {
   font-size: 90%;
@@ -387,7 +387,7 @@ pre.code__pre,
   margin: 10px 8px;
 }
 
-/* ==================== 图片 ==================== */
+/* ==================== Images ==================== */
 img {
   display: block;
   max-width: 100%;
@@ -395,7 +395,7 @@ img {
   border-radius: 4px;
 }
 
-/* ==================== 列表 ==================== */
+/* ==================== Lists ==================== */
 ol {
   padding-left: 1em;
   margin-left: 0;
@@ -415,15 +415,15 @@ li {
   color: hsl(var(--foreground));
 }
 
-/* ==================== 脚注 ==================== */
-/* footnotes 在 buildFootnotes() 中渲染为 <p> 标签 */
+/* Footnotes */
+/* footnotes rendered as <p> in buildFootnotes() */
 p.footnotes {
   margin: 0.5em 8px;
   font-size: 80%;
   color: hsl(var(--foreground));
 }
 
-/* ==================== 图表 ==================== */
+/* Diagrams */
 figure {
   margin: 1.5em 8px;
   color: hsl(var(--foreground));
@@ -436,7 +436,7 @@ figcaption,
   font-size: 0.8em;
 }
 
-/* ==================== 分隔线 ==================== */
+/* ==================== Horizontal rules ==================== */
 hr {
   border-style: solid;
   border-width: 2px 0 0;
@@ -449,7 +449,7 @@ hr {
   margin: 1.5em 0;
 }
 
-/* ==================== 行内代码 ==================== */
+/* Inline code */
 .codespan {
   font-size: 90%;
   color: var(--md-primary-color);
@@ -459,7 +459,7 @@ hr {
   border: 1px solid color-mix(in srgb, var(--md-primary-color) 20%, transparent);
 }
 
-/* 代码块内的 code 标签需要特殊处理（覆盖行内 code 样式） */
+/* code inside pre (override inline code) */
 pre.code__pre > code,
 .hljs.code__pre > code {
   display: -webkit-box;
@@ -472,26 +472,26 @@ pre.code__pre > code,
   margin: 0;
 }
 
-/* ==================== 强调 ==================== */
+/* Emphasis */
 em {
   font-style: italic;
   font-size: inherit;
 }
 
-/* ==================== 链接 ==================== */
+/* ==================== Links ==================== */
 a {
   color: #576b95;
   text-decoration: none;
 }
 
-/* ==================== 粗体 ==================== */
+/* ==================== Bold ==================== */
 strong {
   color: var(--md-primary-color);
   font-weight: bold;
   font-size: inherit;
 }
 
-/* ==================== 表格 ==================== */
+/* ==================== Tables ==================== */
 table {
   color: hsl(var(--foreground));
 }
@@ -516,7 +516,7 @@ td {
   word-break: keep-all;
 }
 
-/* ==================== KaTeX 公式 ==================== */
+/* ==================== KaTeX ==================== */
 .katex-inline {
   max-width: 100%;
   overflow-x: auto;
@@ -545,7 +545,7 @@ td {
   opacity: 0.75;
 }
 
-/* ==================== 标记高亮 ==================== */
+/* ==================== Markup highlight ==================== */
 .markup-highlight {
   background-color: var(--md-primary-color);
   padding: 2px 4px;

--- a/packages/shared/src/configs/theme-css/grace.css
+++ b/packages/shared/src/configs/theme-css/grace.css
@@ -1,9 +1,8 @@
 /**
- * MD 优雅主题 (@brzhang)
- * 在默认主题基础上添加优雅的视觉效果
+ * MD grace theme (@brzhang) — refinements on default
  */
 
-/* ==================== 标题样式 ==================== */
+/* Headings */
 h1 {
   padding: 0.5em 1em;
   border-bottom: 2px solid var(--md-primary-color);
@@ -37,7 +36,7 @@ h6 {
   font-size: var(--md-font-size);
 }
 
-/* ==================== 引用块 ==================== */
+/* Blockquote */
 blockquote {
   font-style: italic;
   padding: 1em 1em 1em 2em;
@@ -52,13 +51,13 @@ blockquote {
   font-style: italic;
 }
 
-/* ==================== 行内代码 ==================== */
+/* Inline code */
 .codespan {
   font-family: 'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
-/* ==================== 代码块 ==================== */
+/* Code blocks */
 pre.code__pre,
 .hljs.code__pre {
   box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
@@ -69,7 +68,7 @@ pre.code__pre > code,
   font-family: 'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace;
 }
 
-/* ==================== 图片 ==================== */
+/* Images */
 img {
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -82,7 +81,7 @@ figcaption,
   font-size: 0.8em;
 }
 
-/* ==================== 列表 ==================== */
+/* Lists */
 ol {
   padding-left: 1.5em;
 }
@@ -96,7 +95,7 @@ li {
   margin: 0.5em 8px;
 }
 
-/* ==================== 分隔线 ==================== */
+/* Horizontal rules */
 hr {
   height: 1px;
   border: none;
@@ -104,7 +103,7 @@ hr {
   background: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
 }
 
-/* ==================== 表格 ==================== */
+/* Tables */
 table {
   border-collapse: separate;
   border-spacing: 0;
@@ -123,13 +122,13 @@ td {
   padding: 0.5em 1em;
 }
 
-/* ==================== 强调 ==================== */
+/* Emphasis */
 em {
   font-style: italic;
   font-size: inherit;
 }
 
-/* ==================== 链接 ==================== */
+/* Links */
 a {
   color: #576b95;
   text-decoration: none;

--- a/packages/shared/src/configs/theme-css/index.ts
+++ b/packages/shared/src/configs/theme-css/index.ts
@@ -1,21 +1,12 @@
-/**
- * CSS 主题导出
- * 将 CSS 文件作为字符串导出供 JavaScript 使用
- */
+/** CSS theme strings for JavaScript consumers */
 
 import baseCSS from './base.css?raw'
 import defaultCSS from './default.css?raw'
 import graceCSS from './grace.css?raw'
 import simpleCSS from './simple.css?raw'
 
-/**
- * 基础样式 CSS
- */
 export const baseCSSContent = baseCSS
 
-/**
- * CSS 主题映射表
- */
 export const themeMap = {
   default: defaultCSS,
   grace: graceCSS,

--- a/packages/shared/src/configs/theme-css/simple.css
+++ b/packages/shared/src/configs/theme-css/simple.css
@@ -1,9 +1,8 @@
 /**
- * MD 简洁主题 (@okooo5km)
- * 简洁现代的设计风格
+ * MD simple theme (@okooo5km) — minimal modern layout
  */
 
-/* ==================== 标题样式 ==================== */
+/* Headings */
 h1 {
   padding: 0.5em 1em;
   font-size: calc(var(--md-font-size) * 1.4);
@@ -44,7 +43,7 @@ h6 {
   border-radius: 6px;
 }
 
-/* ==================== 引用块 ==================== */
+/* Blockquote */
 blockquote {
   font-style: italic;
   padding: 1em 1em 1em 2em;
@@ -54,7 +53,7 @@ blockquote {
   border-right: 0.2px solid rgba(0, 0, 0, 0.04);
 }
 
-/* GFM Alert 样式覆盖 */
+/* GFM alert overrides */
 .markdown-alert-note,
 .markdown-alert-tip,
 .markdown-alert-info,
@@ -64,14 +63,14 @@ blockquote {
   font-style: italic;
 }
 
-/* ==================== 行内代码 ==================== */
+/* Inline code */
 .codespan {
   font-family: 'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace;
   border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--md-primary-color) 15%, transparent);
 }
 
-/* ==================== 代码块 ==================== */
+/* Code blocks */
 pre.code__pre,
 .hljs.code__pre {
   border: 1px solid rgba(0, 0, 0, 0.04);
@@ -82,7 +81,7 @@ pre.code__pre > code,
   font-family: 'Fira Code', Menlo, Operator Mono, Consolas, Monaco, monospace;
 }
 
-/* ==================== 图片 ==================== */
+/* Images */
 img {
   border-radius: 8px;
   border: 1px solid rgba(0, 0, 0, 0.04);
@@ -95,7 +94,7 @@ figcaption,
   font-size: 0.8em;
 }
 
-/* ==================== 列表 ==================== */
+/* Lists */
 ol {
   padding-left: 1.5em;
 }
@@ -109,7 +108,7 @@ li {
   margin: 0.5em 8px;
 }
 
-/* ==================== 分隔线 ==================== */
+/* Horizontal rules */
 hr {
   height: 1px;
   border: none;
@@ -117,13 +116,13 @@ hr {
   background: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
 }
 
-/* ==================== 强调 ==================== */
+/* Emphasis */
 em {
   font-style: italic;
   font-size: inherit;
 }
 
-/* ==================== 链接 ==================== */
+/* Links */
 a {
   color: #576b95;
   text-decoration: none;

--- a/packages/shared/src/configs/theme.ts
+++ b/packages/shared/src/configs/theme.ts
@@ -1,7 +1,6 @@
 import type { IConfigOption } from '../types'
 import type { ThemeName } from './theme-css'
 
-// 导出 CSS 主题（新主题系统）
 export { baseCSSContent, themeMap, type ThemeName } from './theme-css'
 
 export const themeOptionsMap = {

--- a/packages/shared/src/editor/basicSetup.ts
+++ b/packages/shared/src/editor/basicSetup.ts
@@ -63,7 +63,7 @@ export const basicSetup: Extension = (() => [
   crosshairCursor(),
   highlightActiveLine(),
   highlightSelectionMatches(),
-  indentationMarkers(), // 添加缩进标记
+  indentationMarkers(),
   keymap.of([
     ...closeBracketsKeymap,
     ...defaultKeymap,

--- a/packages/shared/src/editor/css.ts
+++ b/packages/shared/src/editor/css.ts
@@ -2,9 +2,6 @@ import { css } from '@codemirror/lang-css'
 import { EditorView, keymap } from '@codemirror/view'
 import { basicSetup } from './basicSetup'
 
-/**
- * CSS 格式化处理函数
- */
 async function formatCSS(view: EditorView) {
   const content = view.state.doc.toString()
   const { formatDoc } = await import('../utils/formatDoc')
@@ -14,26 +11,12 @@ async function formatCSS(view: EditorView) {
   })
 }
 
-/**
- * CSS 编辑器的基础扩展集合
- *
- * 包含：
- * - basicSetup（无行号、代码折叠、自动补全、括号匹配等完整功能）
- * - 自动换行（无横向滚动）
- * - CSS 语言支持
- * - 格式化功能（Shift-Alt-f）
- *
- * basicSetup 包含的功能详见 ./basicSetup.ts
- *
- * 主题请使用统一的 theme() 函数，从 './themes' 导入
- */
+/** CSS editor extensions. Import theme() from './themes' for theming. See basicSetup.ts for included features. */
 export function cssSetup() {
   return [
     basicSetup,
     css(),
-    // 自动换行，禁用横向滚动
     EditorView.lineWrapping,
-    // 格式化快捷键
     keymap.of([
       { key: `Shift-Alt-f`, run: (view: EditorView) => { formatCSS(view); return true } },
     ]),

--- a/packages/shared/src/editor/format.ts
+++ b/packages/shared/src/editor/format.ts
@@ -8,9 +8,6 @@ interface ToggleFormatOptions {
   afterInsertCursorOffset?: number
 }
 
-/**
- * 切换格式（加粗、斜体、删除线等）
- */
 export function toggleFormat(
   view: EditorView,
   {
@@ -45,9 +42,6 @@ export function toggleFormat(
   }
 }
 
-/**
- * 应用标题级别
- */
 export function applyHeading(view: EditorView, level: number) {
   const ranges = view.state.selection.ranges
   const changes: Array<{ from: number, to: number, insert: string }> = []
@@ -60,7 +54,6 @@ export function applyHeading(view: EditorView, level: number) {
     for (let lineNum = fromLine.number; lineNum <= toLine.number; lineNum++) {
       const line = view.state.doc.line(lineNum)
       const text = view.state.doc.sliceString(line.from, line.to)
-      // 去掉已有的 # 前缀（1~6 个）+ 空格
       const cleaned = text.replace(/^#{1,6}\s+/, ``).trimStart()
       const heading = headingPrefix + cleaned
 
@@ -74,7 +67,6 @@ export function applyHeading(view: EditorView, level: number) {
 
   if (changes.length > 0) {
     const firstLine = view.state.doc.lineAt(ranges[0].from)
-    // 计算光标应该在的位置：行首 + 标题前缀长度（如 "# " = 2）
     const newCursorPos = firstLine.from + headingPrefix.length
 
     view.dispatch({
@@ -84,9 +76,6 @@ export function applyHeading(view: EditorView, level: number) {
   }
 }
 
-/**
- * 便捷格式化函数
- */
 export function formatBold(view: EditorView) {
   toggleFormat(view, {
     prefix: `**`,
@@ -132,9 +121,6 @@ export function formatCode(view: EditorView) {
   })
 }
 
-/**
- * 设置文字颜色
- */
 export function formatColor(view: EditorView, color: string) {
   const selection = view.state.selection.main
   const selected = view.state.doc.sliceString(selection.from, selection.to)
@@ -181,9 +167,6 @@ export function formatOrderedList(view: EditorView) {
   view.dispatch(view.state.replaceSelection(updated))
 }
 
-/**
- * 撤销/重做
- */
 export function undoAction(view: EditorView): boolean {
   return undo(view)
 }

--- a/packages/shared/src/editor/javascript.ts
+++ b/packages/shared/src/editor/javascript.ts
@@ -3,9 +3,6 @@ import { javascript } from '@codemirror/lang-javascript'
 import { keymap } from '@codemirror/view'
 import { basicSetup } from './basicSetup'
 
-/**
- * JavaScript 格式化处理函数
- */
 async function formatJavaScript(view: EditorView) {
   const content = view.state.doc.toString()
   const { formatDoc } = await import('../utils/formatDoc')
@@ -15,23 +12,11 @@ async function formatJavaScript(view: EditorView) {
   })
 }
 
-/**
- * JavaScript 编辑器的基础扩展集合
- *
- * 包含：
- * - basicSetup（行号、代码折叠、自动补全、括号匹配等完整功能）
- * - JavaScript 语言支持
- * - 格式化功能（Shift-Alt-f）
- *
- * basicSetup 包含的功能详见 ./basicSetup.ts
- *
- * 主题请使用统一的 theme() 函数，从 './themes' 导入
- */
+/** JavaScript editor extensions. Import theme() from './themes' for theming. See basicSetup.ts for included features. */
 export function javascriptSetup() {
   return [
     basicSetup,
     javascript(),
-    // 格式化快捷键
     keymap.of([
       { key: `Shift-Alt-f`, run: (view: EditorView) => { formatJavaScript(view); return true } },
     ]),

--- a/packages/shared/src/editor/markdown.ts
+++ b/packages/shared/src/editor/markdown.ts
@@ -9,9 +9,6 @@ import { indentationMarkers } from '@replit/codemirror-indentation-markers'
 import { codeLanguages } from './codeLanguages'
 import { applyHeading, formatBold, formatCode, formatItalic, formatLink, formatOrderedList, formatStrikethrough, formatUnorderedList, redoAction, undoAction } from './format'
 
-/**
- * Markdown 格式化处理函数
- */
 async function formatMarkdown(view: EditorView) {
   const content = view.state.doc.toString()
   const { formatDoc } = await import('../utils/formatDoc')
@@ -21,11 +18,8 @@ async function formatMarkdown(view: EditorView) {
   })
 }
 
-/**
- * 在光标位置插入缩进（空格）
- */
 function insertTabAtCursor(view: EditorView): boolean {
-  const spaces = `  ` // 2 个空格作为缩进
+  const spaces = `  `
   const changes = view.state.changeByRange(range => ({
     changes: { from: range.from, to: range.to, insert: spaces },
     range: EditorSelection.range(range.from + spaces.length, range.from + spaces.length),
@@ -39,35 +33,25 @@ interface MarkdownKeymapOptions {
   onReplace?: (view: EditorView) => void
   onGoToLine?: (view: EditorView) => void
   placeholder?: string
-  /** 为 true 时不注入 history()，由调用方通过 Compartment 管理（便于切换文档时清空撤销栈） */
+  /** When true, omit history(); caller manages undo via Compartment (e.g. clear stack on doc switch) */
   withoutHistory?: boolean
 }
 
-/**
- * Markdown 编辑器的快捷键映射
- *
- * @param options - 配置选项
- * @param options.onSearch - 搜索回调（可选）
- */
 export function markdownKeymap(options?: MarkdownKeymapOptions) {
   const { onSearch, onReplace, onGoToLine } = options || {}
 
   return keymap.of([
-    // Tab 键在光标位置插入缩进
     { key: `Tab`, run: insertTabAtCursor },
 
-    // 撤销/重做
     { key: `Mod-z`, run: undoAction },
     { key: `Mod-y`, run: redoAction },
 
-    // 文本格式
     { key: `Mod-b`, run: (view) => { formatBold(view); return true } },
     { key: `Mod-i`, run: (view) => { formatItalic(view); return true } },
     { key: `Mod-d`, run: (view) => { formatStrikethrough(view); return true } },
     { key: `Mod-k`, run: (view) => { formatLink(view); return true } },
     { key: `Mod-e`, run: (view) => { formatCode(view); return true } },
 
-    // 标题（使用 Mod-1 到 Mod-6）
     { key: `Mod-1`, run: (view) => { applyHeading(view, 1); return true } },
     { key: `Mod-2`, run: (view) => { applyHeading(view, 2); return true } },
     { key: `Mod-3`, run: (view) => { applyHeading(view, 3); return true } },
@@ -75,15 +59,12 @@ export function markdownKeymap(options?: MarkdownKeymapOptions) {
     { key: `Mod-5`, run: (view) => { applyHeading(view, 5); return true } },
     { key: `Mod-6`, run: (view) => { applyHeading(view, 6); return true } },
 
-    // 列表
     { key: `Mod-u`, run: (view) => { formatUnorderedList(view); return true } },
     { key: `Mod-o`, run: (view) => { formatOrderedList(view); return true } },
 
-    // 搜索和替换（可选）
     ...(onSearch ? [{ key: `Mod-f`, run: (view: EditorView) => { onSearch(view); return true } }] : []),
     ...(onReplace ? [{ key: `Mod-h`, run: (view: EditorView) => { onReplace(view); return true } }] : []),
 
-    // 格式化
     { key: `Shift-Alt-f`, run: (view: EditorView) => { formatMarkdown(view); return true } },
 
     ...(onGoToLine
@@ -92,42 +73,28 @@ export function markdownKeymap(options?: MarkdownKeymapOptions) {
   ])
 }
 
-/**
- * Markdown 编辑器的基础扩展集合
- * 包含语言支持、历史记录、括号匹配等基础功能
- *
- * 主题请使用统一的 theme() 函数，从 './themes' 导入
- *
- * @param options - 配置选项（可选）
- * @param options.onSearch - 搜索回调，触发快捷键 Mod-f
- *
- */
+/** Markdown editor extensions. Import theme() from './themes' for theming. */
 export function markdownSetup(options?: MarkdownKeymapOptions) {
   const { placeholder: placeholderText, withoutHistory } = options || {}
 
   return [
-    // 基础功能
     ...(withoutHistory ? [] : [history()]),
     highlightSelectionMatches(),
     closeBrackets(),
 
-    // 缩进标记
     indentationMarkers(),
 
-    // 语言支持
     markdown({
       base: markdownLanguage,
       codeLanguages,
       addKeymap: true,
     }),
 
-    // Markdown 快捷键（高优先级，优先于默认快捷键）
+    // Higher priority than default keymap
     Prec.high(markdownKeymap(options)),
 
-    // 折叠功能
     foldGutter(),
 
-    // 默认快捷键
     keymap.of([
       ...defaultKeymap,
       ...historyKeymap,
@@ -135,7 +102,6 @@ export function markdownSetup(options?: MarkdownKeymapOptions) {
       ...foldKeymap,
     ]),
 
-    // 编辑器配置
     EditorView.lineWrapping,
     EditorState.allowMultipleSelections.of(true),
 

--- a/packages/shared/src/editor/themes.ts
+++ b/packages/shared/src/editor/themes.ts
@@ -3,7 +3,6 @@ import { vsCodeDark } from '@fsegurai/codemirror-theme-vscode-dark'
 import { vsCodeLight } from '@fsegurai/codemirror-theme-vscode-light'
 
 const customStyles = EditorView.theme({
-  // 装订线：垂直居中、无背景无边框无内边距
   '.cm-gutterElement': {
     display: `flex`,
     justifyContent: `right`,
@@ -15,7 +14,6 @@ const customStyles = EditorView.theme({
     padding: `0 !important`,
   },
 
-  // 折叠装订线：固定宽度，无内边距
   '.cm-foldGutter': {
     width: `10px !important`,
     overflow: `hidden`,
@@ -26,7 +24,6 @@ const customStyles = EditorView.theme({
     minWidth: `unset !important`,
   },
 
-  // 折叠图标：默认隐藏，hover 装订线时显示
   '.cm-foldGutter .cm-gutterElement span': {
     opacity: `0`,
     transition: `opacity 0.15s ease`,
@@ -44,7 +41,6 @@ export function darkTheme() {
   return [vsCodeDark, customStyles]
 }
 
-// 根据主题模式获取主题扩展
 export function theme(isDark: boolean) {
   return isDark ? darkTheme() : lightTheme()
 }

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -2,18 +2,17 @@ import type { Token } from 'marked'
 import type { ComponentRegistry } from './component'
 
 /**
- * 渲染器选项（新主题系统）
- * 主题样式通过 CSS 注入，不再通过 JS 对象传递
- * 注意：isUseIndent 和 isUseJustify 现在通过 CSS 变量系统处理，不需要传递给渲染器
+ * Renderer options (CSS-injected theme system).
+ * isUseIndent / isUseJustify are handled via CSS variables, not passed to the renderer.
  */
 export interface DiagramMessages {
   mermaidLoading: string
-  /** 支持 `{detail}` 占位符 */
+  /** Supports `{detail}` placeholder */
   mermaidError: string
   plantumlLoading: string
   plantumlError: string
   infographicLoading: string
-  /** 支持 `{detail}` 占位符 */
+  /** Supports `{detail}` placeholder */
   infographicError: string
 }
 
@@ -21,13 +20,13 @@ export interface CountMessages {
   summary: string
 }
 
-/** 渲染管线中的通用 UI 文案（Web 端按 locale 注入） */
+/** Render-pipeline UI copy (injected by locale on Web) */
 export interface RenderMessages {
-  /** 文末引用链接标题 */
+  /** Footnote reference link title */
   footnoteTitle: string
-  /** 未知自定义组件提示，支持 `{name}` 占位符 */
+  /** Unknown custom component message; supports `{name}` placeholder */
   unknownComponent: string
-  /** 块级公式加载中占位 */
+  /** Block math loading placeholder */
   katexLoading: string
 }
 
@@ -38,13 +37,13 @@ export interface IOpts {
   isMacCodeBlock?: boolean
   isShowLineNumber?: boolean
   themeMode?: 'light' | 'dark'
-  /** 自定义组件注册表 */
+  /** Custom component registry */
   components?: ComponentRegistry
-  /** 异步图表加载/失败文案（Web 端按 locale 注入） */
+  /** Async diagram load/error copy (injected by locale on Web) */
   diagramMessages?: DiagramMessages
-  /** 阅读时长统计文案（Web 端按 locale 注入） */
+  /** Reading-time summary copy (injected by locale on Web) */
   countMessages?: CountMessages
-  /** 脚注 / 未知组件 / 公式加载等文案（Web 端按 locale 注入） */
+  /** Footnotes, unknown components, math loading, etc. (injected by locale on Web) */
   renderMessages?: RenderMessages
 }
 

--- a/packages/shared/src/types/component.ts
+++ b/packages/shared/src/types/component.ts
@@ -1,56 +1,42 @@
 /**
- * 自定义组件系统类型定义
+ * Custom component system types.
  *
- * 允许用户在 Markdown 中使用 JSX 风格的自定义组件：
- *   <QRCodeBlock url="https://example.com" text="扫码访问" />
+ * Users can embed JSX-style components in Markdown, e.g.:
+ *   <QRCodeBlock url="https://example.com" text="Scan to visit" />
  */
 
-/** 组件 Prop 类型 */
 export type ComponentPropType = 'string' | 'number' | 'boolean' | 'array'
 
-/** 组件 Prop 定义 */
 export interface ComponentPropDef {
-  /** Prop 名称 */
   name: string
-  /** Prop 描述（用于编辑器提示） */
+  /** Shown in editor hints */
   description?: string
-  /** 默认值 */
   default?: string
-  /** 是否必填 */
   required?: boolean
-  /** Prop 类型（默认 string） */
   type?: ComponentPropType
 }
 
-/** 组件定义 */
 export interface CustomComponentDef {
-  /** 唯一 ID */
   id: string
-  /** 组件名称，必须为 PascalCase，如 QRCodeBlock */
+  /** PascalCase component name, e.g. QRCodeBlock */
   name: string
-  /** 组件描述 */
   description?: string
   /**
-   * HTML 模板，使用 {{propName}} 作为 prop 占位符
+   * HTML template with {{propName}} placeholders
    * @example `<img src="https://api.qrserver.com/v1/create-qr-code/?data={{url}}" />`
    */
   template: string
-  /** Prop 列表 */
   props: ComponentPropDef[]
-  /** 是否为内置组件（内置组件不可删除，但可覆盖） */
+  /** Built-in components cannot be deleted but may be overridden */
   builtIn?: boolean
-  /** 使用示例（用于 UI 展示，优先于自动生成的 snippet） */
+  /** UI example; preferred over auto-generated snippet */
   example?: string
-  /** 创建时间戳 */
   createdAt?: number
-  /** 最后更新时间戳 */
   updatedAt?: number
 }
 
-/** 组件注册表：组件名 -> 组件定义 */
 export type ComponentRegistry = Record<string, CustomComponentDef>
 
-/** 创建组件的参数 */
 export interface CreateComponentParams {
   name: string
   description?: string
@@ -58,7 +44,6 @@ export interface CreateComponentParams {
   props: ComponentPropDef[]
 }
 
-/** 更新组件的参数 */
 export interface UpdateComponentParams {
   name?: string
   description?: string

--- a/packages/shared/src/types/prettier.d.ts
+++ b/packages/shared/src/types/prettier.d.ts
@@ -1,7 +1,4 @@
-/**
- * 类型声明：prettier v2.8.8 缺少 TypeScript 声明
- * 为 prettier/standalone 和各 parser 子路径提供模块声明
- */
+/** Type declarations for prettier v2.8.8 (no bundled @types) */
 
 declare module 'prettier/standalone' {
   import type { Plugin } from 'prettier'

--- a/packages/shared/src/types/raw-imports.d.ts
+++ b/packages/shared/src/types/raw-imports.d.ts
@@ -1,6 +1,4 @@
-/**
- * 类型声明：支持 ?raw 后缀的文件导入
- */
+/** Module declarations for ?raw file imports */
 
 declare module '*.css?raw' {
   const content: string

--- a/packages/shared/src/types/renderer-types.ts
+++ b/packages/shared/src/types/renderer-types.ts
@@ -3,12 +3,12 @@ import type { IOpts } from './common'
 import type { FrontMatterData } from './front-matter'
 
 export interface RendererAPI {
-  /* —— 生命周期 —— */
+  /* Lifecycle */
   reset: (newOpts: Partial<IOpts>) => void
   setOptions: (newOpts: Partial<IOpts>) => void
   getOpts: () => IOpts
 
-  /* —— Markdown 处理 —— */
+  /* Markdown */
   parseFrontMatterAndContent: (markdown: string) => {
     yamlData: FrontMatterData
     markdownContent: string
@@ -16,7 +16,7 @@ export interface RendererAPI {
   }
   renderMarkdownToHtml: (markdown: string) => string
 
-  /* —— HTML 拼装 —— */
+  /* HTML assembly */
   buildReadingTime: (reading: ReadTimeResults) => string
   buildFootnotes: () => string
   buildAddition: () => string

--- a/packages/shared/src/types/template.ts
+++ b/packages/shared/src/types/template.ts
@@ -1,51 +1,23 @@
-/**
- * 模板管理相关类型定义
- */
-
-/**
- * 模板接口
- */
 export interface Template {
-  /** 模板唯一标识符 (UUID) */
   id: string
-  /** 模板名称 */
   name: string
-  /** 模板内容 (Markdown) */
   content: string
-  /** 模板描述（可选） */
   description?: string
-  /** 创建时间戳 */
   createdAt: number
-  /** 最后修改时间戳 */
   updatedAt: number
-  /** 模板标签（可选） */
   tags?: string[]
 }
 
-/**
- * 创建模板的参数
- */
 export interface CreateTemplateParams {
-  /** 模板名称 */
   name: string
-  /** 模板内容 */
   content: string
-  /** 模板描述（可选） */
   description?: string
-  /** 模板标签（可选） */
   tags?: string[]
 }
 
-/**
- * 更新模板的参数
- */
 export interface UpdateTemplateParams {
-  /** 模板名称（可选） */
   name?: string
-  /** 模板内容（可选） */
   content?: string
-  /** 模板描述（可选） */
   description?: string
-  /** 模板标签（可选） */
   tags?: string[]
 }

--- a/packages/shared/src/utils/basicHelpers.ts
+++ b/packages/shared/src/utils/basicHelpers.ts
@@ -1,12 +1,8 @@
-/**
- * 清理文件标题，移除非法字符
- * @param title - 原始标题
- * @returns 清理后的安全标题
- */
+/** Sanitize a title for use as a filename (strip illegal characters). */
 export function sanitizeTitle(title: string) {
   const MAX_FILENAME_LENGTH = 100
 
-  // Windows 禁止字符，包含所有平台非法字符合集
+  // Windows-forbidden chars; superset of illegal chars on other platforms
   const INVALID_CHARS = /[\\/:*?"<>|]/g
 
   if (!INVALID_CHARS.test(title) && title.length <= MAX_FILENAME_LENGTH) {
@@ -21,29 +17,18 @@ export function sanitizeTitle(title: string) {
   return safe || `untitled`
 }
 
-/**
- * 移除左边多余空格
- * @param str - 要处理的字符串
- * @returns 处理后的字符串
- */
+/** Remove common leading indentation from every line. */
 export function removeLeft(str: string) {
   const lines = str.split(`\n`)
-  // 获取应该删除的空白符数量
   const minSpaceNum = lines
     .filter(item => item.trim())
     .map(item => (item.match(/(^\s+)?/)!)[0].length)
     .sort((a, b) => a - b)[0]
-  // 删除空白符
   return lines.map(item => item.slice(minSpaceNum)).join(`\n`)
 }
 
-/**
- * 检查图片文件是否符合要求
- * @param file - 要检查的文件
- * @returns 检查结果
- */
+/** Validate image file type and size for WeChat upload limits. */
 export function checkImage(file: File) {
-  // 检查文件名后缀
   const isValidSuffix = /\.(?:gif|pjp|jfif|jpe|pjpeg|jpe?g|png|webp)$/i.test(file.name)
   if (!isValidSuffix) {
     return {
@@ -52,7 +37,6 @@ export function checkImage(file: File) {
     }
   }
 
-  // 检查文件大小
   const maxSizeMB = 10
   if (file.size > maxSizeMB * 1024 * 1024) {
     return {

--- a/packages/shared/src/utils/fileHelpers.ts
+++ b/packages/shared/src/utils/fileHelpers.ts
@@ -1,9 +1,4 @@
-/**
- * 通用文件下载函数
- * @param content - 文件内容
- * @param filename - 文件名
- * @param mimeType - MIME 类型，默认为 text/plain
- */
+/** Trigger a browser download for the given content. */
 export function downloadFile(content: string, filename: string, mimeType: string = `text/plain`) {
   if (typeof document === `undefined`) {
     throw new TypeError(`downloadFile can only be used in browser environment`)
@@ -14,7 +9,6 @@ export function downloadFile(content: string, filename: string, mimeType: string
   downLink.style.display = `none`
   let objectUrl: string | null = null
 
-  // 检查是否是 base64 data URL
   if (content.startsWith(`data:`) || content.startsWith(`blob:`)) {
     downLink.href = content
   }
@@ -31,17 +25,12 @@ export function downloadFile(content: string, filename: string, mimeType: string
   downLink.click()
   document.body.removeChild(downLink)
 
-  // 如果是 blob URL，释放内存
   if (objectUrl) {
     URL.revokeObjectURL(objectUrl)
   }
 }
 
-/**
- * 将文件转换为 Base64 格式
- * @param file - 要转换的文件
- * @returns Base64 字符串的 Promise
- */
+/** Read a Blob as a Base64 string (data URL payload only). */
 export function toBase64(file: Blob): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
@@ -51,14 +40,7 @@ export function toBase64(file: Blob): Promise<string> {
   })
 }
 
-/**
- * 根据数据生成 Markdown 表格
- * @param options - 表格选项
- * @param options.data - 表格数据对象
- * @param options.rows - 表格行数
- * @param options.cols - 表格列数
- * @returns 生成的 Markdown 表格字符串
- */
+/** Build a Markdown table from keyed cell data. */
 export function createTable({ data, rows, cols }: {
   data: { [k: string]: string }
   rows: number

--- a/packages/shared/src/utils/formatDoc.ts
+++ b/packages/shared/src/utils/formatDoc.ts
@@ -44,12 +44,7 @@ function resolveParserPlugin(module: ParserBabelModule | ParserMarkdownModule | 
   return (module as { default?: unknown }).default ?? module
 }
 
-/**
- * 格式化文档内容
- * @param content - 要格式化的内容
- * @param type - 内容类型，决定使用的解析器，默认为 'markdown'
- * @returns 格式化后的内容
- */
+/** Format content with Prettier (markdown, css, or javascript). */
 export async function formatDoc(content: string, type: FormatDocType = `markdown`): Promise<string> {
   const { prettier, parserBabel, parserMarkdown, parserPostcss } = await loadPrettier(type)
   const parser = type === `css` ? `css` : type === `javascript` ? `babel` : `markdown`

--- a/scripts/build-multiarch.sh
+++ b/scripts/build-multiarch.sh
@@ -30,7 +30,6 @@ for app_ver in "$RELEASE_DIR"/*; do
     echo "    VER_GOLANG: $VER_GOLANG"
     echo "    VER_ALPINE: $VER_ALPINE"
 
-    # 构建 base 镜像
     if [ -f "$app_ver/Dockerfile.base" ]; then
         echo "📦 Building base image: $REPO_NAME:${VER_APP}-assets"
         docker buildx build \
@@ -42,7 +41,6 @@ for app_ver in "$RELEASE_DIR"/*; do
             "$app_ver"
     fi
 
-    # 构建 nginx 镜像
     if [ -f "$app_ver/Dockerfile.nginx" ]; then
         echo "📦 Building nginx image: $REPO_NAME:${VER_APP}-nginx"
         docker buildx build \
@@ -55,7 +53,6 @@ for app_ver in "$RELEASE_DIR"/*; do
             "$app_ver"
     fi
 
-    # 构建 standalone 镜像
     if [ -f "$app_ver/Dockerfile.standalone" ]; then
         echo "📦 Building standalone image: $REPO_NAME:${VER_APP}"
         docker buildx build \
@@ -68,7 +65,6 @@ for app_ver in "$RELEASE_DIR"/*; do
             "$app_ver"
     fi
 
-    # 构建 static 镜像
     if [ -f "$app_ver/Dockerfile.static" ]; then
         echo "📦 Building static image: $REPO_NAME:${VER_APP}-static"
         docker buildx build \

--- a/scripts/push-images.sh
+++ b/scripts/push-images.sh
@@ -8,22 +8,22 @@ for app_ver in $RELEASE_DIR/*; do
     tag=$(echo $app_ver | cut -b 10-);
 
     if [ -f "$app_ver/Dockerfile.base" ]; then
-        # 推送构建产物，方便其他的用户和爱好者进行二次封装
+        # Push build assets for downstream re-packaging
         docker push $REPO_NAME:$tag-assets
     fi
 
     if [ -f "$app_ver/Dockerfile.standalone" ]; then
-        # 推送单个二进制的镜像
+        # Push standalone binary image
         docker push $REPO_NAME:$tag
     fi
 
     if [ -f "$app_ver/Dockerfile.nginx" ]; then
-        # 推送使用 Nginx 的镜像
+        # Push Nginx-based image
         docker push $REPO_NAME:$tag-nginx
     fi
 
     if [ -f "$app_ver/Dockerfile.static" ]; then
-        # 推送使用 lipanski/docker-static-website 的镜像
+        # Push lipanski/docker-static-website image
         docker push $REPO_NAME:$tag-static
     fi
 


### PR DESCRIPTION
﻿## Summary

- Unify code comments across the monorepo to English; translate non-obvious why/constraint notes and remove noise that only restates the next line of code.
- Document the English-comment convention in `AGENTS.md` and `CONTRIBUTING.md`.
- Leave i18n message files and other user-facing Chinese strings unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [x] Confirmed no Chinese developer comments remain in `apps/`, `packages/`, `scripts/`, and `docs/examples/` source (excluding `i18n/` and string literals)
- [x] Pre-commit `eslint --fix` passed on the commit
- [ ] Spot-check a few edited modules in the editor if desired (comment-only change; no runtime behavior intended)

## Pre-flight Checklist

- [x] Commit message follows Conventional Commits (English)
- [x] Branch is not `main`
- [x] CI will run on this PR
