### PR TITLE
fix(i18n): keep editor fonts stable when switching locale

### DIFF
--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -18,6 +18,7 @@ import { validateImageFile } from '@/lib/upload/validate-image'
 import { fileUpload } from '@/services/upload'
 import { store } from '@/storage'
 import { useEditorStore } from '@/stores/editor'
+import { useLocaleStore } from '@/stores/locale'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
 import { useThemeStore } from '@/stores/theme'
@@ -28,6 +29,7 @@ const SidebarAIToolbar = defineAsyncComponent(() => import('@/components/ai/Side
 const { t, locale } = useI18n()
 const uploadHostOptions = useLocalizedUploadHostOptions()
 const editorStore = useEditorStore()
+const localeStore = useLocaleStore()
 const postStore = usePostStore()
 const renderStore = useRenderStore()
 const themeStore = useThemeStore()
@@ -685,6 +687,7 @@ defineExpose({
         id="editor"
         ref="editorRef"
         class="codemirror-container mathjax-ignore"
+        :lang="localeStore.contentFontLang"
       />
     </EditorContextMenu>
   </div>

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -11,6 +11,7 @@ import { useImageUploader } from '@/composables/useImageUploader'
 import { completeInitialPreviewBoot } from '@/composables/useInitialPreviewBoot'
 import { useLocalizedUploadHostOptions } from '@/composables/useLocalizedUploadHosts'
 import { useSlashCommand } from '@/composables/useSlashCommand'
+import { CONTENT_FONT_LANG } from '@/i18n/constants'
 import { formatLocalDateTime } from '@/i18n/translate'
 import { jumpToAdjacentHeading } from '@/lib/markdown/headingNavigation'
 import { contentHasMath, loadMathJax, MATHJAX_READY_EVENT } from '@/lib/preview/mathjax'
@@ -18,7 +19,6 @@ import { validateImageFile } from '@/lib/upload/validate-image'
 import { fileUpload } from '@/services/upload'
 import { store } from '@/storage'
 import { useEditorStore } from '@/stores/editor'
-import { useLocaleStore } from '@/stores/locale'
 import { usePostStore } from '@/stores/post'
 import { useRenderStore } from '@/stores/render'
 import { useThemeStore } from '@/stores/theme'
@@ -29,7 +29,6 @@ const SidebarAIToolbar = defineAsyncComponent(() => import('@/components/ai/Side
 const { t, locale } = useI18n()
 const uploadHostOptions = useLocalizedUploadHostOptions()
 const editorStore = useEditorStore()
-const localeStore = useLocaleStore()
 const postStore = usePostStore()
 const renderStore = useRenderStore()
 const themeStore = useThemeStore()
@@ -687,7 +686,7 @@ defineExpose({
         id="editor"
         ref="editorRef"
         class="codemirror-container mathjax-ignore"
-        :lang="localeStore.contentFontLang"
+        :lang="CONTENT_FONT_LANG"
       />
     </EditorContextMenu>
   </div>

--- a/apps/web/src/components/editor/PreviewPanel.vue
+++ b/apps/web/src/components/editor/PreviewPanel.vue
@@ -2,6 +2,7 @@
 import type { DiagramDownloadOverlay } from '@/lib/preview/diagram-download'
 import { highlightPendingBlocks, hljs, hydratePendingInfographicDiagrams } from '@md/core'
 import { setupDiagramDownloadOverlay } from '@/lib/preview/diagram-download'
+import { useLocaleStore } from '@/stores/locale'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
 
@@ -12,6 +13,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const localeStore = useLocaleStore()
 const renderStore = useRenderStore()
 const uiStore = useUIStore()
 
@@ -99,7 +101,13 @@ defineExpose({
             effectivePreviewWidth === 'w-[375px]' ? 'max-w-full' : '',
           ]"
         >
-          <section id="output" class="w-full" @click="onContentClick" v-html="output" />
+          <section
+            id="output"
+            class="w-full"
+            :lang="localeStore.contentFontLang"
+            @click="onContentClick"
+            v-html="output"
+          />
           <div v-if="isCoping" class="loading-mask">
             <div class="loading-mask-box">
               <div class="loading__img" />

--- a/apps/web/src/components/editor/PreviewPanel.vue
+++ b/apps/web/src/components/editor/PreviewPanel.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { DiagramDownloadOverlay } from '@/lib/preview/diagram-download'
 import { highlightPendingBlocks, hljs, hydratePendingInfographicDiagrams } from '@md/core'
+import { CONTENT_FONT_LANG } from '@/i18n/constants'
 import { setupDiagramDownloadOverlay } from '@/lib/preview/diagram-download'
-import { useLocaleStore } from '@/stores/locale'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
 
@@ -13,7 +13,6 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const localeStore = useLocaleStore()
 const renderStore = useRenderStore()
 const uiStore = useUIStore()
 
@@ -104,7 +103,7 @@ defineExpose({
           <section
             id="output"
             class="w-full"
-            :lang="localeStore.contentFontLang"
+            :lang="CONTENT_FONT_LANG"
             @click="onContentClick"
             v-html="output"
           />

--- a/apps/web/src/i18n/constants.ts
+++ b/apps/web/src/i18n/constants.ts
@@ -4,6 +4,13 @@ export const LOCALE_STORAGE_KEY = `locale`
 
 export const DEFAULT_LOCALE: AppLocale = `zh-CN`
 
+/**
+ * Fixed BCP 47 tag on editor/preview so system-font fallback stays stable when
+ * `html[lang]` follows the UI locale. Use `und` (undetermined) instead of a
+ * concrete locale so assistive tech is not told the wrong content language.
+ */
+export const CONTENT_FONT_LANG = `und` as const
+
 export const SUPPORTED_LOCALES: AppLocale[] = [`zh-CN`, `zh-TW`, `en-US`, `ja-JP`]
 
 export const LOCALE_OPTIONS: LocaleOption[] = [

--- a/apps/web/src/stores/locale.ts
+++ b/apps/web/src/stores/locale.ts
@@ -1,5 +1,5 @@
 import type { AppLocale } from '@/i18n/types'
-import { getNextLocale, LOCALE_STORAGE_KEY } from '@/i18n/constants'
+import { DEFAULT_LOCALE, getNextLocale, LOCALE_STORAGE_KEY } from '@/i18n/constants'
 import { detectInitialLocale } from '@/i18n/detect'
 import { getAppI18n } from '@/i18n/index'
 import enUS from '@/i18n/messages/en-US'
@@ -47,6 +47,15 @@ function setI18nLocale(value: AppLocale) {
 export const useLocaleStore = defineStore(`locale`, () => {
   const locale = store.reactive<AppLocale>(LOCALE_STORAGE_KEY, detectInitialLocale())
 
+  /**
+   * Fixed lang for editor/preview font matching.
+   * `html[lang]` follows the UI locale for a11y, but system fonts
+   * (`-apple-system`, `BlinkMacSystemFont`, generic `monospace`) resolve
+   * differently per lang — keep content lang constant so UI language
+   * never changes markdown editor/preview typefaces.
+   */
+  const contentFontLang = DEFAULT_LOCALE
+
   watch(
     locale,
     (value) => {
@@ -68,6 +77,7 @@ export const useLocaleStore = defineStore(`locale`, () => {
 
   return {
     locale,
+    contentFontLang,
     setLocale,
     cycleLocale,
   }

--- a/apps/web/src/stores/locale.ts
+++ b/apps/web/src/stores/locale.ts
@@ -1,5 +1,5 @@
 import type { AppLocale } from '@/i18n/types'
-import { DEFAULT_LOCALE, getNextLocale, LOCALE_STORAGE_KEY } from '@/i18n/constants'
+import { getNextLocale, LOCALE_STORAGE_KEY } from '@/i18n/constants'
 import { detectInitialLocale } from '@/i18n/detect'
 import { getAppI18n } from '@/i18n/index'
 import enUS from '@/i18n/messages/en-US'
@@ -47,15 +47,6 @@ function setI18nLocale(value: AppLocale) {
 export const useLocaleStore = defineStore(`locale`, () => {
   const locale = store.reactive<AppLocale>(LOCALE_STORAGE_KEY, detectInitialLocale())
 
-  /**
-   * Fixed lang for editor/preview font matching.
-   * `html[lang]` follows the UI locale for a11y, but system fonts
-   * (`-apple-system`, `BlinkMacSystemFont`, generic `monospace`) resolve
-   * differently per lang — keep content lang constant so UI language
-   * never changes markdown editor/preview typefaces.
-   */
-  const contentFontLang = DEFAULT_LOCALE
-
   watch(
     locale,
     (value) => {
@@ -77,7 +68,6 @@ export const useLocaleStore = defineStore(`locale`, () => {
 
   return {
     locale,
-    contentFontLang,
     setLocale,
     cycleLocale,
   }


### PR DESCRIPTION
﻿## Summary
- Pin editor/preview `lang` to `DEFAULT_LOCALE` (`zh-CN`) via `contentFontLang`
- Keep `html[lang]` following the UI locale for a11y/title/meta
- Prevent system fonts (`-apple-system`, `BlinkMacSystemFont`, generic `monospace`) from re-resolving when switching UI language

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure
- [ ] Open the editor with Chinese content in both edit and preview panes
- [ ] Switch UI language (zh-CN → en-US → ja-JP → zh-TW) via preferences or footer
- [ ] Confirm markdown editor and preview typefaces do not change
- [ ] Confirm UI chrome strings still update correctly with locale

## Pre-flight Checklist
- [x] Change is focused on a single concern
- [x] Commit follows Conventional Commits
- [x] No secrets or unrelated files included
