### PR TITLE
fix(web): clear style panel selection on drag collapse

### DIFF
--- a/apps/web/src/components/editor/CodemirrorEditor.vue
+++ b/apps/web/src/components/editor/CodemirrorEditor.vue
@@ -266,6 +266,7 @@ const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading
                 :max-size="!isMobile && isOpenRightSlider ? 60 : 0"
                 collapsible
                 :collapsed-size="0"
+                @collapse="isOpenRightSlider = false"
               >
                 <RightSlider v-if="!isMobile && isOpenRightSlider" />
               </ResizablePanel>


### PR DESCRIPTION
﻿## Summary
- Sync `isOpenRightSlider` when the desktop style panel is drag-collapsed via the resizable handle
- Clears the header Style button selected state after the panel disappears

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure
- [x] Desktop: open Style panel → drag the right resize handle until fully collapsed → header Style button is no longer highlighted
- [x] Click Style again → panel reopens normally
- [x] Click Style to close → still works as before

## Pre-flight Checklist
- [x] Change is focused on a single fix
- [x] Lint passes via pre-commit hook
- [ ] Docs updated (N/A)
