### PR TITLE
feat(web): add configurable PDF export options panel

### DIFF
--- a/apps/web/src/components/editor/EditorContextMenu.vue
+++ b/apps/web/src/components/editor/EditorContextMenu.vue
@@ -110,7 +110,7 @@ function exportEditorContent2HTML() {
 }
 
 function exportEditorContent2PDF() {
-  exportStore.exportEditorContent2PDF()
+  uiStore.openPdfExportDialog()
 }
 
 function exportEditorContent2MD() {

--- a/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
@@ -4,6 +4,7 @@ import { FileText, Loader2, Printer } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed, ref } from 'vue'
 import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
+import PanelSegmented from '@/components/shared/panel-dialog/PanelSegmented.vue'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -33,32 +34,32 @@ const dialogOpen = computed({
 const isExporting = ref(false)
 
 const pageNumberFormatOptions = computed(() => [
-  { value: `nOfM` as const, label: t(`pdfExport.pageNumberFormat.nOfM`) },
-  { value: `n` as const, label: t(`pdfExport.pageNumberFormat.n`) },
+  { value: `nOfM`, label: t(`pdfExport.pageNumberFormat.nOfM`) },
+  { value: `n`, label: t(`pdfExport.pageNumberFormat.n`) },
 ])
 
 const pageNumberPositionOptions = computed(() => [
-  { value: `bottomLeft` as const, label: t(`pdfExport.pageNumberPosition.bottomLeft`) },
-  { value: `bottomCenter` as const, label: t(`pdfExport.pageNumberPosition.bottomCenter`) },
-  { value: `bottomRight` as const, label: t(`pdfExport.pageNumberPosition.bottomRight`) },
+  { value: `bottomLeft`, label: t(`pdfExport.pageNumberPosition.bottomLeft`) },
+  { value: `bottomCenter`, label: t(`pdfExport.pageNumberPosition.bottomCenter`) },
+  { value: `bottomRight`, label: t(`pdfExport.pageNumberPosition.bottomRight`) },
 ])
 
 const marginsOptions = computed(() => [
-  { value: `compact` as const, label: t(`pdfExport.margins.compact`) },
-  { value: `default` as const, label: t(`pdfExport.margins.default`) },
-  { value: `comfortable` as const, label: t(`pdfExport.margins.comfortable`) },
+  { value: `compact`, label: t(`pdfExport.margins.compact`) },
+  { value: `default`, label: t(`pdfExport.margins.default`) },
+  { value: `comfortable`, label: t(`pdfExport.margins.comfortable`) },
 ])
 
-function setPageNumberFormat(value: PdfPageNumberFormat) {
-  pdfExportOptions.value.pageNumberFormat = value
+function setPageNumberFormat(value: string) {
+  pdfExportOptions.value.pageNumberFormat = value as PdfPageNumberFormat
 }
 
-function setPageNumberPosition(value: PdfPageNumberPosition) {
-  pdfExportOptions.value.pageNumberPosition = value
+function setPageNumberPosition(value: string) {
+  pdfExportOptions.value.pageNumberPosition = value as PdfPageNumberPosition
 }
 
-function setMargins(value: PdfMargins) {
-  pdfExportOptions.value.margins = value
+function setMargins(value: string) {
+  pdfExportOptions.value.margins = value as PdfMargins
 }
 
 async function handleExport() {
@@ -105,38 +106,22 @@ async function handleExport() {
       <template v-if="pdfExportOptions.showPageNumbers">
         <div class="space-y-2 border-b py-3">
           <Label class="text-sm">{{ t('pdfExport.pageNumberFormat.label') }}</Label>
-          <div class="flex flex-wrap gap-2">
-            <button
-              v-for="option in pageNumberFormatOptions"
-              :key="option.value"
-              type="button"
-              class="rounded-md border px-3 py-1.5 text-sm transition-colors"
-              :class="pdfExportOptions.pageNumberFormat === option.value
-                ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
-                : 'text-muted-foreground hover:bg-muted/50'"
-              @click="setPageNumberFormat(option.value)"
-            >
-              {{ option.label }}
-            </button>
-          </div>
+          <PanelSegmented
+            class="flex h-auto min-h-10 w-full flex-wrap"
+            :model-value="pdfExportOptions.pageNumberFormat"
+            :options="pageNumberFormatOptions"
+            @update:model-value="setPageNumberFormat"
+          />
         </div>
 
         <div class="space-y-2 border-b py-3">
           <Label class="text-sm">{{ t('pdfExport.pageNumberPosition.label') }}</Label>
-          <div class="flex flex-wrap gap-2">
-            <button
-              v-for="option in pageNumberPositionOptions"
-              :key="option.value"
-              type="button"
-              class="rounded-md border px-3 py-1.5 text-sm transition-colors"
-              :class="pdfExportOptions.pageNumberPosition === option.value
-                ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
-                : 'text-muted-foreground hover:bg-muted/50'"
-              @click="setPageNumberPosition(option.value)"
-            >
-              {{ option.label }}
-            </button>
-          </div>
+          <PanelSegmented
+            class="flex w-full"
+            :model-value="pdfExportOptions.pageNumberPosition"
+            :options="pageNumberPositionOptions"
+            @update:model-value="setPageNumberPosition"
+          />
         </div>
       </template>
 
@@ -172,20 +157,12 @@ async function handleExport() {
 
       <div class="space-y-2 py-3">
         <Label class="text-sm">{{ t('pdfExport.margins.label') }}</Label>
-        <div class="flex flex-wrap gap-2">
-          <button
-            v-for="option in marginsOptions"
-            :key="option.value"
-            type="button"
-            class="rounded-md border px-3 py-1.5 text-sm transition-colors"
-            :class="pdfExportOptions.margins === option.value
-              ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
-              : 'text-muted-foreground hover:bg-muted/50'"
-            @click="setMargins(option.value)"
-          >
-            {{ option.label }}
-          </button>
-        </div>
+        <PanelSegmented
+          class="flex w-full"
+          :model-value="pdfExportOptions.margins"
+          :options="marginsOptions"
+          @update:model-value="setMargins"
+        />
       </div>
     </div>
 

--- a/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
@@ -7,7 +7,7 @@ import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { normalizePdfExportOptions } from '@/services/export'
+import { normalizePdfExportOptions, resolvePdfSiteFooterUrl } from '@/services/export'
 import { useExportStore } from '@/stores/export'
 import { useUIStore } from '@/stores/ui'
 
@@ -31,6 +31,8 @@ const dialogOpen = computed({
 })
 
 const isExporting = ref(false)
+
+const siteFooterUrl = computed(() => resolvePdfSiteFooterUrl())
 
 const pageNumberFormatOptions = computed(() => [
   { value: `nOfM` as const, label: t(`pdfExport.pageNumberFormat.nOfM`) },
@@ -176,8 +178,8 @@ async function handleExport() {
       <div class="flex items-center justify-between gap-4 border-b py-3">
         <div class="min-w-0 space-y-0.5">
           <Label for="pdf-site-footer">{{ t('pdfExport.siteFooter.label') }}</Label>
-          <p class="text-xs text-muted-foreground">
-            {{ t('pdfExport.siteFooter.hint') }}
+          <p class="truncate text-xs text-muted-foreground" :title="siteFooterUrl">
+            {{ t('pdfExport.siteFooter.hint', { url: siteFooterUrl }) }}
           </p>
         </div>
         <Switch

--- a/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
@@ -4,7 +4,6 @@ import { FileText, Loader2, Printer } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 import { computed, ref } from 'vue'
 import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
-import PanelSegmented from '@/components/shared/panel-dialog/PanelSegmented.vue'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -34,32 +33,38 @@ const dialogOpen = computed({
 const isExporting = ref(false)
 
 const pageNumberFormatOptions = computed(() => [
-  { value: `nOfM`, label: t(`pdfExport.pageNumberFormat.nOfM`) },
-  { value: `n`, label: t(`pdfExport.pageNumberFormat.n`) },
+  { value: `nOfM` as const, label: t(`pdfExport.pageNumberFormat.nOfM`) },
+  { value: `n` as const, label: t(`pdfExport.pageNumberFormat.n`) },
 ])
 
 const pageNumberPositionOptions = computed(() => [
-  { value: `bottomLeft`, label: t(`pdfExport.pageNumberPosition.bottomLeft`) },
-  { value: `bottomCenter`, label: t(`pdfExport.pageNumberPosition.bottomCenter`) },
-  { value: `bottomRight`, label: t(`pdfExport.pageNumberPosition.bottomRight`) },
+  { value: `bottomLeft` as const, label: t(`pdfExport.pageNumberPosition.bottomLeft`) },
+  { value: `bottomCenter` as const, label: t(`pdfExport.pageNumberPosition.bottomCenter`) },
+  { value: `bottomRight` as const, label: t(`pdfExport.pageNumberPosition.bottomRight`) },
 ])
 
 const marginsOptions = computed(() => [
-  { value: `compact`, label: t(`pdfExport.margins.compact`) },
-  { value: `default`, label: t(`pdfExport.margins.default`) },
-  { value: `comfortable`, label: t(`pdfExport.margins.comfortable`) },
+  { value: `compact` as const, label: t(`pdfExport.margins.compact`) },
+  { value: `default` as const, label: t(`pdfExport.margins.default`) },
+  { value: `comfortable` as const, label: t(`pdfExport.margins.comfortable`) },
 ])
 
-function setPageNumberFormat(value: string) {
-  pdfExportOptions.value.pageNumberFormat = value as PdfPageNumberFormat
+function optionButtonClass(active: boolean) {
+  return active
+    ? `border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20`
+    : `text-muted-foreground hover:bg-muted/50`
 }
 
-function setPageNumberPosition(value: string) {
-  pdfExportOptions.value.pageNumberPosition = value as PdfPageNumberPosition
+function setPageNumberFormat(value: PdfPageNumberFormat) {
+  pdfExportOptions.value.pageNumberFormat = value
 }
 
-function setMargins(value: string) {
-  pdfExportOptions.value.margins = value as PdfMargins
+function setPageNumberPosition(value: PdfPageNumberPosition) {
+  pdfExportOptions.value.pageNumberPosition = value
+}
+
+function setMargins(value: PdfMargins) {
+  pdfExportOptions.value.margins = value
 }
 
 async function handleExport() {
@@ -105,23 +110,51 @@ async function handleExport() {
 
       <template v-if="pdfExportOptions.showPageNumbers">
         <div class="space-y-2 border-b py-3">
-          <Label class="text-sm">{{ t('pdfExport.pageNumberFormat.label') }}</Label>
-          <PanelSegmented
-            class="flex h-auto min-h-10 w-full flex-wrap"
-            :model-value="pdfExportOptions.pageNumberFormat"
-            :options="pageNumberFormatOptions"
-            @update:model-value="setPageNumberFormat"
-          />
+          <Label id="pdf-page-number-format-label" class="text-sm">
+            {{ t('pdfExport.pageNumberFormat.label') }}
+          </Label>
+          <div
+            role="radiogroup"
+            aria-labelledby="pdf-page-number-format-label"
+            class="flex flex-wrap gap-2"
+          >
+            <button
+              v-for="option in pageNumberFormatOptions"
+              :key="option.value"
+              type="button"
+              role="radio"
+              :aria-checked="pdfExportOptions.pageNumberFormat === option.value"
+              class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+              :class="optionButtonClass(pdfExportOptions.pageNumberFormat === option.value)"
+              @click="setPageNumberFormat(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
         </div>
 
         <div class="space-y-2 border-b py-3">
-          <Label class="text-sm">{{ t('pdfExport.pageNumberPosition.label') }}</Label>
-          <PanelSegmented
-            class="flex w-full"
-            :model-value="pdfExportOptions.pageNumberPosition"
-            :options="pageNumberPositionOptions"
-            @update:model-value="setPageNumberPosition"
-          />
+          <Label id="pdf-page-number-position-label" class="text-sm">
+            {{ t('pdfExport.pageNumberPosition.label') }}
+          </Label>
+          <div
+            role="radiogroup"
+            aria-labelledby="pdf-page-number-position-label"
+            class="flex flex-wrap gap-2"
+          >
+            <button
+              v-for="option in pageNumberPositionOptions"
+              :key="option.value"
+              type="button"
+              role="radio"
+              :aria-checked="pdfExportOptions.pageNumberPosition === option.value"
+              class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+              :class="optionButtonClass(pdfExportOptions.pageNumberPosition === option.value)"
+              @click="setPageNumberPosition(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
         </div>
       </template>
 
@@ -156,13 +189,25 @@ async function handleExport() {
       </div>
 
       <div class="space-y-2 py-3">
-        <Label class="text-sm">{{ t('pdfExport.margins.label') }}</Label>
-        <PanelSegmented
-          class="flex w-full"
-          :model-value="pdfExportOptions.margins"
-          :options="marginsOptions"
-          @update:model-value="setMargins"
-        />
+        <Label id="pdf-margins-label" class="text-sm">{{ t('pdfExport.margins.label') }}</Label>
+        <div
+          role="radiogroup"
+          aria-labelledby="pdf-margins-label"
+          class="flex flex-wrap gap-2"
+        >
+          <button
+            v-for="option in marginsOptions"
+            :key="option.value"
+            type="button"
+            role="radio"
+            :aria-checked="pdfExportOptions.margins === option.value"
+            class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+            :class="optionButtonClass(pdfExportOptions.margins === option.value)"
+            @click="setMargins(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
       </div>
     </div>
 

--- a/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PdfExportDialog.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import type { PdfMargins, PdfPageNumberFormat, PdfPageNumberPosition } from '@/services/export'
+import { FileText, Loader2, Printer } from '@lucide/vue'
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { normalizePdfExportOptions } from '@/services/export'
+import { useExportStore } from '@/stores/export'
+import { useUIStore } from '@/stores/ui'
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const { t } = useI18n()
+const uiStore = useUIStore()
+const exportStore = useExportStore()
+
+const { pdfExportOptions } = storeToRefs(uiStore)
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (value: boolean) => emit(`update:open`, value),
+})
+
+const isExporting = ref(false)
+
+const pageNumberFormatOptions = computed(() => [
+  { value: `nOfM` as const, label: t(`pdfExport.pageNumberFormat.nOfM`) },
+  { value: `n` as const, label: t(`pdfExport.pageNumberFormat.n`) },
+])
+
+const pageNumberPositionOptions = computed(() => [
+  { value: `bottomLeft` as const, label: t(`pdfExport.pageNumberPosition.bottomLeft`) },
+  { value: `bottomCenter` as const, label: t(`pdfExport.pageNumberPosition.bottomCenter`) },
+  { value: `bottomRight` as const, label: t(`pdfExport.pageNumberPosition.bottomRight`) },
+])
+
+const marginsOptions = computed(() => [
+  { value: `compact` as const, label: t(`pdfExport.margins.compact`) },
+  { value: `default` as const, label: t(`pdfExport.margins.default`) },
+  { value: `comfortable` as const, label: t(`pdfExport.margins.comfortable`) },
+])
+
+function setPageNumberFormat(value: PdfPageNumberFormat) {
+  pdfExportOptions.value.pageNumberFormat = value
+}
+
+function setPageNumberPosition(value: PdfPageNumberPosition) {
+  pdfExportOptions.value.pageNumberPosition = value
+}
+
+function setMargins(value: PdfMargins) {
+  pdfExportOptions.value.margins = value
+}
+
+async function handleExport() {
+  if (isExporting.value)
+    return
+
+  isExporting.value = true
+  try {
+    const options = normalizePdfExportOptions(pdfExportOptions.value)
+    pdfExportOptions.value = options
+    await exportStore.exportEditorContent2PDF(options)
+    dialogOpen.value = false
+  }
+  finally {
+    isExporting.value = false
+  }
+}
+</script>
+
+<template>
+  <PanelDialog
+    v-model:open="dialogOpen"
+    :title="t('pdfExport.title')"
+    :description="t('pdfExport.description')"
+    :icon="FileText"
+    size="md"
+  >
+    <div class="space-y-1 px-4 py-4 sm:px-6">
+      <div class="flex items-center justify-between gap-4 border-b py-3">
+        <div class="min-w-0 space-y-0.5">
+          <Label for="pdf-page-numbers">{{ t('pdfExport.pageNumbers.label') }}</Label>
+          <p class="text-xs text-muted-foreground">
+            {{ t('pdfExport.pageNumbers.hint') }}
+          </p>
+        </div>
+        <Switch
+          id="pdf-page-numbers"
+          class="shrink-0"
+          :model-value="pdfExportOptions.showPageNumbers"
+          @update:model-value="pdfExportOptions.showPageNumbers = $event"
+        />
+      </div>
+
+      <template v-if="pdfExportOptions.showPageNumbers">
+        <div class="space-y-2 border-b py-3">
+          <Label class="text-sm">{{ t('pdfExport.pageNumberFormat.label') }}</Label>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="option in pageNumberFormatOptions"
+              :key="option.value"
+              type="button"
+              class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+              :class="pdfExportOptions.pageNumberFormat === option.value
+                ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
+                : 'text-muted-foreground hover:bg-muted/50'"
+              @click="setPageNumberFormat(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+
+        <div class="space-y-2 border-b py-3">
+          <Label class="text-sm">{{ t('pdfExport.pageNumberPosition.label') }}</Label>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="option in pageNumberPositionOptions"
+              :key="option.value"
+              type="button"
+              class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+              :class="pdfExportOptions.pageNumberPosition === option.value
+                ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
+                : 'text-muted-foreground hover:bg-muted/50'"
+              @click="setPageNumberPosition(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <div class="flex items-center justify-between gap-4 border-b py-3">
+        <div class="min-w-0 space-y-0.5">
+          <Label for="pdf-title-header">{{ t('pdfExport.titleHeader.label') }}</Label>
+          <p class="text-xs text-muted-foreground">
+            {{ t('pdfExport.titleHeader.hint') }}
+          </p>
+        </div>
+        <Switch
+          id="pdf-title-header"
+          class="shrink-0"
+          :model-value="pdfExportOptions.showTitleHeader"
+          @update:model-value="pdfExportOptions.showTitleHeader = $event"
+        />
+      </div>
+
+      <div class="flex items-center justify-between gap-4 border-b py-3">
+        <div class="min-w-0 space-y-0.5">
+          <Label for="pdf-site-footer">{{ t('pdfExport.siteFooter.label') }}</Label>
+          <p class="text-xs text-muted-foreground">
+            {{ t('pdfExport.siteFooter.hint') }}
+          </p>
+        </div>
+        <Switch
+          id="pdf-site-footer"
+          class="shrink-0"
+          :model-value="pdfExportOptions.showSiteFooter"
+          @update:model-value="pdfExportOptions.showSiteFooter = $event"
+        />
+      </div>
+
+      <div class="space-y-2 py-3">
+        <Label class="text-sm">{{ t('pdfExport.margins.label') }}</Label>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="option in marginsOptions"
+            :key="option.value"
+            type="button"
+            class="rounded-md border px-3 py-1.5 text-sm transition-colors"
+            :class="pdfExportOptions.margins === option.value
+              ? 'border-primary bg-primary/5 font-medium text-primary ring-1 ring-primary/20'
+              : 'text-muted-foreground hover:bg-muted/50'"
+            @click="setMargins(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <Button
+        class="h-10 w-full gap-2"
+        :disabled="isExporting"
+        @click="handleExport"
+      >
+        <Loader2 v-if="isExporting" class="size-4 animate-spin" />
+        <Printer v-else class="size-4" />
+        {{ t('pdfExport.export') }}
+      </Button>
+    </template>
+  </PanelDialog>
+</template>

--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -20,7 +20,7 @@ const exportStore = useExportStore()
 const uiStore = useUIStore()
 
 const { isOpenPostSlider, isOpenFolderPanel } = storeToRefs(uiStore)
-const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog, toggleShowEditorStateDialog, toggleShowPreferencesDialog, openShareDialog } = uiStore
+const { toggleShowTemplateDialog, toggleShowImportMdDialog, toggleShowSyncDialog, toggleShowEditorStateDialog, toggleShowPreferencesDialog, openShareDialog, openPdfExportDialog } = uiStore
 const showSyncUi = isSyncUiEnabled()
 const showShareUi = isShareUiEnabled()
 
@@ -53,7 +53,7 @@ function downloadAsCardImage() {
 }
 
 function exportEditorContent2PDF() {
-  exportStore.exportEditorContent2PDF()
+  openPdfExportDialog()
 }
 </script>
 

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -26,6 +26,7 @@ const KeyboardShortcutsDialog = defineAsyncComponent(() => import('./KeyboardSho
 const AccountDialog = defineAsyncComponent(() => import('./AccountDialog.vue'))
 const SyncDialog = defineAsyncComponent(() => import('./SyncDialog.vue'))
 const ShareDialog = defineAsyncComponent(() => import('./ShareDialog.vue'))
+const PdfExportDialog = defineAsyncComponent(() => import('@/components/editor/dialogs/PdfExportDialog.vue'))
 
 const editorStore = useEditorStore()
 const themeStore = useThemeStore()
@@ -37,7 +38,7 @@ const { editorRefresh } = useEditorRefresh()
 const { editor } = storeToRefs(editorStore)
 const { output } = storeToRefs(renderStore)
 const { primaryColor } = storeToRefs(themeStore)
-const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowPreferencesDialog, isShowMarkdownHelpDialog, isShowKeyboardShortcutsDialog, copyMode } = storeToRefs(uiStore)
+const { isOpenRightSlider, isShowSyncDialog, isShowAccountDialog, isShowShareDialog, isShowPdfExportDialog, isShowAboutDialog, isShowFundDialog, isShowEditorStateDialog, isShowPreferencesDialog, isShowMarkdownHelpDialog, isShowKeyboardShortcutsDialog, copyMode } = storeToRefs(uiStore)
 
 const isCopying = ref(false)
 
@@ -293,6 +294,7 @@ function copyToWeChat() {
   <AccountDialog v-if="isShowAccountDialog" v-model:open="isShowAccountDialog" />
   <SyncDialog v-if="isShowSyncDialog" v-model:open="isShowSyncDialog" />
   <ShareDialog v-if="isShowShareDialog" v-model:open="isShowShareDialog" />
+  <PdfExportDialog v-if="isShowPdfExportDialog" v-model:open="isShowPdfExportDialog" />
 </template>
 
 <style lang="less" scoped>

--- a/apps/web/src/i18n/messages/en-US/dialog.ts
+++ b/apps/web/src/i18n/messages/en-US/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `Site footer`,
-      hint: `Show the current site URL in the footer`,
+      hint: `Show {url} in the footer`,
     },
     margins: {
       label: `Margins`,

--- a/apps/web/src/i18n/messages/en-US/dialog.ts
+++ b/apps/web/src/i18n/messages/en-US/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `Site footer`,
-      hint: `Show md.doocs.org in the footer`,
+      hint: `Show the current site URL in the footer`,
     },
     margins: {
       label: `Margins`,

--- a/apps/web/src/i18n/messages/en-US/dialog.ts
+++ b/apps/web/src/i18n/messages/en-US/dialog.ts
@@ -251,4 +251,38 @@ export default {
       hint: `Show word count and reading time at the top of the preview`,
     },
   },
+  pdfExport: {
+    title: `Export PDF`,
+    description: `Configure headers, footers, and layout, then save as PDF via the browser print dialog. Disabled slots are occupied with empty strings so the browser does not fill in its defaults.`,
+    pageNumbers: {
+      label: `Page numbers`,
+      hint: `Show page numbers in the footer`,
+    },
+    pageNumberFormat: {
+      label: `Page number format`,
+      nOfM: `Page N of M`,
+      n: `Page number only`,
+    },
+    pageNumberPosition: {
+      label: `Page number position`,
+      bottomLeft: `Bottom left`,
+      bottomCenter: `Bottom center`,
+      bottomRight: `Bottom right`,
+    },
+    titleHeader: {
+      label: `Title header`,
+      hint: `Show the article title in the header`,
+    },
+    siteFooter: {
+      label: `Site footer`,
+      hint: `Show md.doocs.org in the footer`,
+    },
+    margins: {
+      label: `Margins`,
+      compact: `Compact`,
+      default: `Default`,
+      comfortable: `Comfortable`,
+    },
+    export: `Print / Save as PDF`,
+  },
 }

--- a/apps/web/src/i18n/messages/en-US/store.ts
+++ b/apps/web/src/i18n/messages/en-US/store.ts
@@ -73,6 +73,7 @@ export default {
   },
   pdf: {
     pageFooter: `Page " counter(page) " of " counter(pages) "`,
+    pageFooterN: `" counter(page) "`,
   },
   relativeTime: {
     justNow: `Just now`,

--- a/apps/web/src/i18n/messages/ja-JP/dialog.ts
+++ b/apps/web/src/i18n/messages/ja-JP/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `サイトフッター`,
-      hint: `フッターに md.doocs.org を表示`,
+      hint: `フッターに現在のサイト URL を表示`,
     },
     margins: {
       label: `余白`,

--- a/apps/web/src/i18n/messages/ja-JP/dialog.ts
+++ b/apps/web/src/i18n/messages/ja-JP/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `サイトフッター`,
-      hint: `フッターに現在のサイト URL を表示`,
+      hint: `フッターに {url} を表示`,
     },
     margins: {
       label: `余白`,

--- a/apps/web/src/i18n/messages/ja-JP/dialog.ts
+++ b/apps/web/src/i18n/messages/ja-JP/dialog.ts
@@ -251,4 +251,38 @@ export default {
       hint: `プレビュー上部に文字数と読了時間を表示`,
     },
   },
+  pdfExport: {
+    title: `PDF をエクスポート`,
+    description: `ヘッダー・フッターとレイアウトを設定し、ブラウザの印刷ダイアログから PDF として保存します。オフにした項目は空文字で枠を確保し、ブラウザ既定のヘッダー/フッターが入らないようにします。`,
+    pageNumbers: {
+      label: `ページ番号`,
+      hint: `フッターにページ番号を表示`,
+    },
+    pageNumberFormat: {
+      label: `ページ番号の形式`,
+      nOfM: `N / M ページ`,
+      n: `ページ番号のみ`,
+    },
+    pageNumberPosition: {
+      label: `ページ番号の位置`,
+      bottomLeft: `左下`,
+      bottomCenter: `中央`,
+      bottomRight: `右下`,
+    },
+    titleHeader: {
+      label: `タイトルヘッダー`,
+      hint: `ヘッダーに記事タイトルを表示`,
+    },
+    siteFooter: {
+      label: `サイトフッター`,
+      hint: `フッターに md.doocs.org を表示`,
+    },
+    margins: {
+      label: `余白`,
+      compact: `コンパクト`,
+      default: `標準`,
+      comfortable: `ゆったり`,
+    },
+    export: `印刷 / PDF として保存`,
+  },
 }

--- a/apps/web/src/i18n/messages/ja-JP/store.ts
+++ b/apps/web/src/i18n/messages/ja-JP/store.ts
@@ -73,6 +73,7 @@ export default {
   },
   pdf: {
     pageFooter: `" counter(page) " / " counter(pages) " ページ`,
+    pageFooterN: `" counter(page) "`,
   },
   relativeTime: {
     justNow: `たった今`,

--- a/apps/web/src/i18n/messages/zh-CN/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-CN/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `页脚站点`,
-      hint: `在页脚显示当前站点地址`,
+      hint: `在页脚显示 {url}`,
     },
     margins: {
       label: `页边距`,

--- a/apps/web/src/i18n/messages/zh-CN/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-CN/dialog.ts
@@ -251,4 +251,38 @@ export default {
       hint: `在预览文章顶部显示字数与阅读时间`,
     },
   },
+  pdfExport: {
+    title: `导出 PDF`,
+    description: `配置页眉页脚与版式后，通过浏览器打印对话框另存为 PDF。关闭的项会用空白占位，避免浏览器填入默认页眉页脚。`,
+    pageNumbers: {
+      label: `页码`,
+      hint: `在页脚显示页码`,
+    },
+    pageNumberFormat: {
+      label: `页码格式`,
+      nOfM: `第 N 页，共 M 页`,
+      n: `仅页码`,
+    },
+    pageNumberPosition: {
+      label: `页码位置`,
+      bottomLeft: `左下`,
+      bottomCenter: `居中`,
+      bottomRight: `右下`,
+    },
+    titleHeader: {
+      label: `页眉标题`,
+      hint: `在页眉显示文章标题`,
+    },
+    siteFooter: {
+      label: `页脚站点`,
+      hint: `在页脚显示 md.doocs.org`,
+    },
+    margins: {
+      label: `页边距`,
+      compact: `紧凑`,
+      default: `默认`,
+      comfortable: `宽松`,
+    },
+    export: `打印 / 另存为 PDF`,
+  },
 }

--- a/apps/web/src/i18n/messages/zh-CN/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-CN/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `页脚站点`,
-      hint: `在页脚显示 md.doocs.org`,
+      hint: `在页脚显示当前站点地址`,
     },
     margins: {
       label: `页边距`,

--- a/apps/web/src/i18n/messages/zh-CN/store.ts
+++ b/apps/web/src/i18n/messages/zh-CN/store.ts
@@ -73,6 +73,7 @@ export default {
   },
   pdf: {
     pageFooter: `第 " counter(page) " 页，共 " counter(pages) " 页`,
+    pageFooterN: `" counter(page) "`,
   },
   relativeTime: {
     justNow: `刚刚`,

--- a/apps/web/src/i18n/messages/zh-TW/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-TW/dialog.ts
@@ -251,4 +251,38 @@ export default {
       hint: `在預覽文章頂部顯示字數與閱讀時間`,
     },
   },
+  pdfExport: {
+    title: `匯出 PDF`,
+    description: `設定頁首頁尾與版式後，透過瀏覽器列印對話框另存為 PDF。關閉的項目會以空白佔位，避免瀏覽器填入預設頁首頁尾。`,
+    pageNumbers: {
+      label: `頁碼`,
+      hint: `在頁尾顯示頁碼`,
+    },
+    pageNumberFormat: {
+      label: `頁碼格式`,
+      nOfM: `第 N 頁，共 M 頁`,
+      n: `僅頁碼`,
+    },
+    pageNumberPosition: {
+      label: `頁碼位置`,
+      bottomLeft: `左下`,
+      bottomCenter: `置中`,
+      bottomRight: `右下`,
+    },
+    titleHeader: {
+      label: `頁首標題`,
+      hint: `在頁首顯示文章標題`,
+    },
+    siteFooter: {
+      label: `頁尾站點`,
+      hint: `在頁尾顯示 md.doocs.org`,
+    },
+    margins: {
+      label: `頁邊距`,
+      compact: `緊湊`,
+      default: `預設`,
+      comfortable: `寬鬆`,
+    },
+    export: `列印 / 另存為 PDF`,
+  },
 }

--- a/apps/web/src/i18n/messages/zh-TW/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-TW/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `頁尾站點`,
-      hint: `在頁尾顯示目前站點位址`,
+      hint: `在頁尾顯示 {url}`,
     },
     margins: {
       label: `頁邊距`,

--- a/apps/web/src/i18n/messages/zh-TW/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-TW/dialog.ts
@@ -275,7 +275,7 @@ export default {
     },
     siteFooter: {
       label: `頁尾站點`,
-      hint: `在頁尾顯示 md.doocs.org`,
+      hint: `在頁尾顯示目前站點位址`,
     },
     margins: {
       label: `頁邊距`,

--- a/apps/web/src/i18n/messages/zh-TW/store.ts
+++ b/apps/web/src/i18n/messages/zh-TW/store.ts
@@ -73,6 +73,7 @@ export default {
   },
   pdf: {
     pageFooter: `第 " counter(page) " 頁，共 " counter(pages) " 頁`,
+    pageFooterN: `" counter(page) "`,
   },
   relativeTime: {
     justNow: `剛剛`,

--- a/apps/web/src/services/export/index.ts
+++ b/apps/web/src/services/export/index.ts
@@ -11,6 +11,7 @@ export {
   type PdfMargins,
   type PdfPageNumberFormat,
   type PdfPageNumberPosition,
+  resolvePdfSiteFooterUrl,
 } from './pdf'
 export { exportPNG } from './png'
 export { getExportStyles, getShareExportStyles } from './share-styles'

--- a/apps/web/src/services/export/index.ts
+++ b/apps/web/src/services/export/index.ts
@@ -7,6 +7,7 @@ export {
   DEFAULT_PDF_EXPORT_OPTIONS,
   exportPDF,
   normalizePdfExportOptions,
+  PDF_SITE_FOOTER_FALLBACK_URL,
   type PdfExportOptions,
   type PdfMargins,
   type PdfPageNumberFormat,

--- a/apps/web/src/services/export/index.ts
+++ b/apps/web/src/services/export/index.ts
@@ -2,6 +2,15 @@ export { processClipboardContent, solveWeChatImage } from './clipboard'
 export { exportHTML, exportPureHTML, generatePureHTML } from './html'
 export { getHtmlContent } from './html-content'
 export { downloadMD, exportPostsAsZip } from './markdown'
-export { exportPDF } from './pdf'
+export {
+  buildPageCss,
+  DEFAULT_PDF_EXPORT_OPTIONS,
+  exportPDF,
+  normalizePdfExportOptions,
+  type PdfExportOptions,
+  type PdfMargins,
+  type PdfPageNumberFormat,
+  type PdfPageNumberPosition,
+} from './pdf'
 export { exportPNG } from './png'
 export { getExportStyles, getShareExportStyles } from './share-styles'

--- a/apps/web/src/services/export/pdf-options.test.ts
+++ b/apps/web/src/services/export/pdf-options.test.ts
@@ -12,7 +12,7 @@ vi.mock(`@/i18n/translate`, () => ({
   },
 }))
 
-const { buildPageCss, normalizePdfExportOptions } = await import(`./pdf`)
+const { buildPageCss, normalizePdfExportOptions, resolvePdfSiteFooterUrl } = await import(`./pdf`)
 
 function options(partial: Partial<PdfExportOptions> = {}): PdfExportOptions {
   return { ...DEFAULT_PDF_EXPORT_OPTIONS, ...partial }
@@ -44,13 +44,27 @@ describe(`normalizePdfExportOptions`, () => {
   })
 })
 
+describe(`resolvePdfSiteFooterUrl`, () => {
+  it(`uses origin for http(s) pages`, () => {
+    expect(resolvePdfSiteFooterUrl({ protocol: `https:`, origin: `https://md.doocs.org` }))
+      .toBe(`https://md.doocs.org`)
+    expect(resolvePdfSiteFooterUrl({ protocol: `http:`, origin: `http://localhost:5173` }))
+      .toBe(`http://localhost:5173`)
+  })
+
+  it(`falls back outside http(s) contexts`, () => {
+    expect(resolvePdfSiteFooterUrl({ protocol: `chrome-extension:`, origin: `chrome-extension://abc` }))
+      .toBe(`https://md.doocs.org`)
+  })
+})
+
 describe(`buildPageCss`, () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it(`uses preset margins with chrome aligned toward content`, () => {
-    const css = buildPageCss(options(), `My Title`)
+    const css = buildPageCss(options(), `My Title`, `https://example.com`)
     expect(css).toContain(`margin: 1.5cm 1cm 2cm 1cm`)
     expect(css).toContain(`vertical-align: bottom`)
     expect(css).toContain(`vertical-align: top`)
@@ -59,8 +73,9 @@ describe(`buildPageCss`, () => {
   })
 
   it(`maps margin presets`, () => {
-    expect(buildPageCss(options({ margins: `compact` }), `t`)).toContain(`margin: 1cm`)
-    expect(buildPageCss(options({ margins: `comfortable` }), `t`))
+    expect(buildPageCss(options({ margins: `compact` }), `t`, `https://example.com`))
+      .toContain(`margin: 1cm`)
+    expect(buildPageCss(options({ margins: `comfortable` }), `t`, `https://example.com`))
       .toContain(`margin: 2cm 1.5cm 2.5cm 1.5cm`)
   })
 
@@ -70,13 +85,12 @@ describe(`buildPageCss`, () => {
       showSiteFooter: false,
       showTitleHeader: false,
       margins: `default`,
-    }), `t`)
-    // top/bottom fall back to the horizontal inset (1cm), not 0
+    }), `t`, `https://example.com`)
     expect(css).toContain(`margin: 1cm`)
     expect(css).toContain(`content: "";`)
     expect(css).not.toContain(`content: none`)
     expect(css).not.toContain(`counter(page)`)
-    expect(css).not.toContain(`md.doocs.org`)
+    expect(css).not.toContain(`example.com`)
   })
 
   it(`keeps top content inset when only footer chrome is on`, () => {
@@ -85,7 +99,7 @@ describe(`buildPageCss`, () => {
       showPageNumbers: true,
       showSiteFooter: false,
       margins: `default`,
-    }), `t`)
+    }), `t`, `https://example.com`)
     expect(css).toContain(`margin: 1cm 1cm 2cm 1cm`)
     expect(css).toContain(`vertical-align: top`)
     expect(css).toContain(`padding-top: 0.5cm`)
@@ -97,39 +111,43 @@ describe(`buildPageCss`, () => {
       showPageNumbers: false,
       showSiteFooter: false,
       margins: `default`,
-    }), `t`)
+    }), `t`, `https://example.com`)
     expect(css).toContain(`margin: 1.5cm 1cm 1cm 1cm`)
     expect(css).toContain(`vertical-align: bottom`)
     expect(css).toContain(`padding-bottom: 0.5cm`)
   })
 
   it(`puts title in top-center when enabled`, () => {
-    const css = buildPageCss(options({ showTitleHeader: true }), `Hello "World"`)
+    const css = buildPageCss(options({ showTitleHeader: true }), `Hello "World"`, `https://example.com`)
     expect(css).toContain(`content: "Hello _World_"`)
   })
 
-  it(`puts site footer in bottom-left when enabled`, () => {
-    const css = buildPageCss(options({ showSiteFooter: true, showPageNumbers: false }), `t`)
-    expect(css).toContain(`https://md.doocs.org`)
+  it(`puts the provided site URL in the footer when enabled`, () => {
+    const css = buildPageCss(
+      options({ showSiteFooter: true, showPageNumbers: false }),
+      `t`,
+      `https://example.com`,
+    )
+    expect(css).toContain(`https://example.com`)
   })
 
   it(`uses nOfM page footer format by default`, () => {
-    const css = buildPageCss(options({ showPageNumbers: true, pageNumberFormat: `nOfM` }), `t`)
+    const css = buildPageCss(options({ showPageNumbers: true, pageNumberFormat: `nOfM` }), `t`, `https://example.com`)
     expect(css).toContain(`Page " counter(page) " of " counter(pages) "`)
   })
 
   it(`uses n-only page footer format when selected`, () => {
-    const css = buildPageCss(options({ showPageNumbers: true, pageNumberFormat: `n` }), `t`)
+    const css = buildPageCss(options({ showPageNumbers: true, pageNumberFormat: `n` }), `t`, `https://example.com`)
     expect(css).toContain(`content: "" counter(page) ""`)
     expect(css).not.toContain(`counter(pages)`)
   })
 
   it(`places page numbers at the selected position`, () => {
-    expect(buildPageCss(options({ pageNumberPosition: `bottomLeft` }), `t`))
+    expect(buildPageCss(options({ pageNumberPosition: `bottomLeft` }), `t`, `https://example.com`))
       .toContain(`@bottom-left {\n        content: "Page`)
-    expect(buildPageCss(options({ pageNumberPosition: `bottomCenter` }), `t`))
+    expect(buildPageCss(options({ pageNumberPosition: `bottomCenter` }), `t`, `https://example.com`))
       .toContain(`@bottom-center {\n        content: "Page`)
-    expect(buildPageCss(options({ pageNumberPosition: `bottomRight` }), `t`))
+    expect(buildPageCss(options({ pageNumberPosition: `bottomRight` }), `t`, `https://example.com`))
       .toContain(`@bottom-right {\n        content: "Page`)
   })
 
@@ -138,8 +156,8 @@ describe(`buildPageCss`, () => {
       showPageNumbers: true,
       pageNumberPosition: `bottomLeft`,
       showSiteFooter: true,
-    }), `t`)
+    }), `t`, `https://example.com`)
     expect(css).toContain(`counter(page)`)
-    expect(css).not.toContain(`md.doocs.org`)
+    expect(css).not.toContain(`example.com`)
   })
 })

--- a/apps/web/src/services/export/pdf-options.test.ts
+++ b/apps/web/src/services/export/pdf-options.test.ts
@@ -12,7 +12,12 @@ vi.mock(`@/i18n/translate`, () => ({
   },
 }))
 
-const { buildPageCss, normalizePdfExportOptions, resolvePdfSiteFooterUrl } = await import(`./pdf`)
+const {
+  buildPageCss,
+  normalizePdfExportOptions,
+  PDF_SITE_FOOTER_FALLBACK_URL,
+  resolvePdfSiteFooterUrl,
+} = await import(`./pdf`)
 
 function options(partial: Partial<PdfExportOptions> = {}): PdfExportOptions {
   return { ...DEFAULT_PDF_EXPORT_OPTIONS, ...partial }
@@ -54,7 +59,7 @@ describe(`resolvePdfSiteFooterUrl`, () => {
 
   it(`falls back outside http(s) contexts`, () => {
     expect(resolvePdfSiteFooterUrl({ protocol: `chrome-extension:`, origin: `chrome-extension://abc` }))
-      .toBe(`https://md.doocs.org`)
+      .toBe(PDF_SITE_FOOTER_FALLBACK_URL)
   })
 })
 
@@ -129,6 +134,17 @@ describe(`buildPageCss`, () => {
       `https://example.com`,
     )
     expect(css).toContain(`https://example.com`)
+    expect(css).toContain(`@bottom-left`)
+  })
+
+  it(`collapses empty bottom-edge boxes so the site URL can grow`, () => {
+    const css = buildPageCss(
+      options({ showSiteFooter: true, showPageNumbers: true, pageNumberPosition: `bottomRight` }),
+      `t`,
+      `http://localhost:5173`,
+    )
+    expect(css).toContain(`content: "http://localhost:5173"`)
+    expect(css).toMatch(/@bottom-center \{\s*content: "";\s*width: 0;/)
   })
 
   it(`uses nOfM page footer format by default`, () => {
@@ -151,13 +167,14 @@ describe(`buildPageCss`, () => {
       .toContain(`@bottom-right {\n        content: "Page`)
   })
 
-  it(`prefers page numbers over site footer when both use bottom-left`, () => {
+  it(`moves site footer when page numbers occupy bottom-left`, () => {
     const css = buildPageCss(options({
       showPageNumbers: true,
       pageNumberPosition: `bottomLeft`,
       showSiteFooter: true,
     }), `t`, `https://example.com`)
     expect(css).toContain(`counter(page)`)
-    expect(css).not.toContain(`example.com`)
+    expect(css).toContain(`https://example.com`)
+    expect(css).toMatch(/@bottom-center \{\s*content: "https:\/\/example\.com"/)
   })
 })

--- a/apps/web/src/services/export/pdf-options.test.ts
+++ b/apps/web/src/services/export/pdf-options.test.ts
@@ -1,0 +1,145 @@
+import type { PdfExportOptions } from './pdf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_PDF_EXPORT_OPTIONS } from './pdf'
+
+vi.mock(`@/i18n/translate`, () => ({
+  t: (key: string) => {
+    if (key === `store.pdf.pageFooter`)
+      return `Page " counter(page) " of " counter(pages) "`
+    if (key === `store.pdf.pageFooterN`)
+      return `" counter(page) "`
+    return key
+  },
+}))
+
+const { buildPageCss, normalizePdfExportOptions } = await import(`./pdf`)
+
+function options(partial: Partial<PdfExportOptions> = {}): PdfExportOptions {
+  return { ...DEFAULT_PDF_EXPORT_OPTIONS, ...partial }
+}
+
+describe(`normalizePdfExportOptions`, () => {
+  it(`fills defaults and drops unknown legacy fields`, () => {
+    const normalized = normalizePdfExportOptions({
+      showPageNumbers: false,
+      paperSize: `Letter`,
+    } as Partial<PdfExportOptions> & { paperSize: string })
+
+    expect(normalized).toEqual({
+      ...DEFAULT_PDF_EXPORT_OPTIONS,
+      showPageNumbers: false,
+    })
+    expect(normalized).not.toHaveProperty(`paperSize`)
+  })
+
+  it(`rejects invalid enum values`, () => {
+    const normalized = normalizePdfExportOptions({
+      pageNumberFormat: `weird` as PdfExportOptions[`pageNumberFormat`],
+      pageNumberPosition: `top` as PdfExportOptions[`pageNumberPosition`],
+      margins: `huge` as PdfExportOptions[`margins`],
+    })
+    expect(normalized.pageNumberFormat).toBe(`nOfM`)
+    expect(normalized.pageNumberPosition).toBe(`bottomRight`)
+    expect(normalized.margins).toBe(`default`)
+  })
+})
+
+describe(`buildPageCss`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it(`uses preset margins with chrome aligned toward content`, () => {
+    const css = buildPageCss(options(), `My Title`)
+    expect(css).toContain(`margin: 1.5cm 1cm 2cm 1cm`)
+    expect(css).toContain(`vertical-align: bottom`)
+    expect(css).toContain(`vertical-align: top`)
+    expect(css).toContain(`padding-bottom: 0.5cm`)
+    expect(css).toContain(`padding-top: 0.5cm`)
+  })
+
+  it(`maps margin presets`, () => {
+    expect(buildPageCss(options({ margins: `compact` }), `t`)).toContain(`margin: 1cm`)
+    expect(buildPageCss(options({ margins: `comfortable` }), `t`))
+      .toContain(`margin: 2cm 1.5cm 2.5cm 1.5cm`)
+  })
+
+  it(`keeps content edge inset when all chrome is off`, () => {
+    const css = buildPageCss(options({
+      showPageNumbers: false,
+      showSiteFooter: false,
+      showTitleHeader: false,
+      margins: `default`,
+    }), `t`)
+    // top/bottom fall back to the horizontal inset (1cm), not 0
+    expect(css).toContain(`margin: 1cm`)
+    expect(css).toContain(`content: "";`)
+    expect(css).not.toContain(`content: none`)
+    expect(css).not.toContain(`counter(page)`)
+    expect(css).not.toContain(`md.doocs.org`)
+  })
+
+  it(`keeps top content inset when only footer chrome is on`, () => {
+    const css = buildPageCss(options({
+      showTitleHeader: false,
+      showPageNumbers: true,
+      showSiteFooter: false,
+      margins: `default`,
+    }), `t`)
+    expect(css).toContain(`margin: 1cm 1cm 2cm 1cm`)
+    expect(css).toContain(`vertical-align: top`)
+    expect(css).toContain(`padding-top: 0.5cm`)
+  })
+
+  it(`keeps bottom content inset when only title chrome is on`, () => {
+    const css = buildPageCss(options({
+      showTitleHeader: true,
+      showPageNumbers: false,
+      showSiteFooter: false,
+      margins: `default`,
+    }), `t`)
+    expect(css).toContain(`margin: 1.5cm 1cm 1cm 1cm`)
+    expect(css).toContain(`vertical-align: bottom`)
+    expect(css).toContain(`padding-bottom: 0.5cm`)
+  })
+
+  it(`puts title in top-center when enabled`, () => {
+    const css = buildPageCss(options({ showTitleHeader: true }), `Hello "World"`)
+    expect(css).toContain(`content: "Hello _World_"`)
+  })
+
+  it(`puts site footer in bottom-left when enabled`, () => {
+    const css = buildPageCss(options({ showSiteFooter: true, showPageNumbers: false }), `t`)
+    expect(css).toContain(`https://md.doocs.org`)
+  })
+
+  it(`uses nOfM page footer format by default`, () => {
+    const css = buildPageCss(options({ showPageNumbers: true, pageNumberFormat: `nOfM` }), `t`)
+    expect(css).toContain(`Page " counter(page) " of " counter(pages) "`)
+  })
+
+  it(`uses n-only page footer format when selected`, () => {
+    const css = buildPageCss(options({ showPageNumbers: true, pageNumberFormat: `n` }), `t`)
+    expect(css).toContain(`content: "" counter(page) ""`)
+    expect(css).not.toContain(`counter(pages)`)
+  })
+
+  it(`places page numbers at the selected position`, () => {
+    expect(buildPageCss(options({ pageNumberPosition: `bottomLeft` }), `t`))
+      .toContain(`@bottom-left {\n        content: "Page`)
+    expect(buildPageCss(options({ pageNumberPosition: `bottomCenter` }), `t`))
+      .toContain(`@bottom-center {\n        content: "Page`)
+    expect(buildPageCss(options({ pageNumberPosition: `bottomRight` }), `t`))
+      .toContain(`@bottom-right {\n        content: "Page`)
+  })
+
+  it(`prefers page numbers over site footer when both use bottom-left`, () => {
+    const css = buildPageCss(options({
+      showPageNumbers: true,
+      pageNumberPosition: `bottomLeft`,
+      showSiteFooter: true,
+    }), `t`)
+    expect(css).toContain(`counter(page)`)
+    expect(css).not.toContain(`md.doocs.org`)
+  })
+})

--- a/apps/web/src/services/export/pdf.ts
+++ b/apps/web/src/services/export/pdf.ts
@@ -40,13 +40,16 @@ const MARGIN_VALUES: Record<PdfMargins, string> = {
 /** Gap between chrome text (header / page number) and article content. */
 const CHROME_CONTENT_GAP = `0.5cm`
 
+/** Fallback when the app is not served over http(s) (extension / file). */
+export const PDF_SITE_FOOTER_FALLBACK_URL = `https://md.doocs.org`
+
 /** Prefer the current http(s) origin; fall back for extension / file contexts. */
 export function resolvePdfSiteFooterUrl(
   locationLike: Pick<Location, `protocol` | `origin`> = window.location,
 ): string {
   if (locationLike.protocol === `http:` || locationLike.protocol === `https:`)
     return locationLike.origin
-  return `https://md.doocs.org`
+  return PDF_SITE_FOOTER_FALLBACK_URL
 }
 
 function escapeCssQuotedString(value: string): string {
@@ -58,6 +61,9 @@ const PAGE_NUMBER_BOX: Record<PdfPageNumberPosition, string> = {
   bottomCenter: `@bottom-center`,
   bottomRight: `@bottom-right`,
 }
+
+/** Boxes that share horizontal space on the bottom margin edge (flex-like). */
+const BOTTOM_EDGE_BOXES = [`@bottom-left`, `@bottom-center`, `@bottom-right`] as const
 
 /** All 16 CSS page margin boxes (Chrome 131+). */
 const ALL_MARGIN_BOXES = [
@@ -119,6 +125,31 @@ function marginBoxRule(
       }`
 }
 
+/** Empty boxes still suppress UA chrome; width:0 avoids stealing flex space from neighbors. */
+function emptyMarginBoxRule(box: string, collapseWidth: boolean): string {
+  const extras = collapseWidth
+    ? `
+        width: 0;
+        max-width: 0;
+        padding: 0;
+        margin: 0;
+        overflow: hidden;`
+    : ``
+  return marginBoxRule(box, `""`, extras)
+}
+
+/**
+ * Pick a free bottom box for the site URL.
+ * Prefer left; if page numbers occupy left, use center (or right if center is taken).
+ */
+function resolveSiteFooterBox(pageBox: string | null): string | null {
+  for (const box of BOTTOM_EDGE_BOXES) {
+    if (box !== pageBox)
+      return box
+  }
+  return null
+}
+
 /** Strip unknown/legacy fields (e.g. paperSize) and fill missing keys. */
 export function normalizePdfExportOptions(
   input?: Partial<PdfExportOptions> | null,
@@ -149,9 +180,8 @@ export function normalizePdfExportOptions(
 /**
  * Build `@page` CSS from export options.
  * Unclaimed margin boxes get `content: ""` so Chromium does not fill in defaults.
- * Top/bottom always keep a content inset (never flush to the page edge). When chrome
- * is present on an edge, that edge uses the fuller preset height and chrome text is
- * aligned toward the content with a consistent gap.
+ * Empty bottom-edge siblings collapse to width 0 so a long site URL can grow (Chrome
+ * shares bottom-left/center/right like flex; empty "" boxes otherwise steal space).
  */
 export function buildPageCss(
   options: PdfExportOptions,
@@ -165,11 +195,10 @@ export function buildPageCss(
   const pageBox = resolved.showPageNumbers
     ? PAGE_NUMBER_BOX[resolved.pageNumberPosition]
     : null
+  const siteBox = resolved.showSiteFooter ? resolveSiteFooterBox(pageBox) : null
 
-  // Prefer page numbers when they share the same box as the site footer.
-  const showSiteFooter = resolved.showSiteFooter && pageBox !== `@bottom-left`
   const needsTop = resolved.showTitleHeader
-  const needsBottom = Boolean(resolved.showPageNumbers || showSiteFooter)
+  const needsBottom = Boolean(pageBox || siteBox)
 
   // Side inset doubles as the "no chrome" top/bottom inset so content never flush-cuts.
   const contentEdge = sides.left
@@ -194,15 +223,16 @@ export function buildPageCss(
     ))
   }
 
-  if (showSiteFooter) {
-    claimed.set(`@bottom-left`, marginBoxRule(
-      `@bottom-left`,
+  if (siteBox) {
+    claimed.set(siteBox, marginBoxRule(
+      siteBox,
       `"${safeSiteUrl}"`,
       `
         font-size: 10px;
         color: #999;
         vertical-align: top;
-        padding-top: ${CHROME_CONTENT_GAP};`,
+        padding-top: ${CHROME_CONTENT_GAP};
+        white-space: nowrap;`,
     ))
   }
 
@@ -217,13 +247,20 @@ export function buildPageCss(
         font-size: 10px;
         color: #999;
         vertical-align: top;
-        padding-top: ${CHROME_CONTENT_GAP};`,
+        padding-top: ${CHROME_CONTENT_GAP};
+        white-space: nowrap;`,
     ))
   }
 
-  const boxes = ALL_MARGIN_BOXES.map(box =>
-    claimed.get(box) ?? marginBoxRule(box, `""`),
-  )
+  const boxes = ALL_MARGIN_BOXES.map((box) => {
+    const real = claimed.get(box)
+    if (real)
+      return real
+    // Collapse empty bottom-edge siblings so real footer text can grow.
+    const collapseWidth = (BOTTOM_EDGE_BOXES as readonly string[]).includes(box)
+      && Boolean(siteBox || pageBox)
+    return emptyMarginBoxRule(box, collapseWidth)
+  })
 
   return `
     @page {

--- a/apps/web/src/services/export/pdf.ts
+++ b/apps/web/src/services/export/pdf.ts
@@ -5,13 +5,226 @@ import { EXPORT_LAYOUT_CSS } from './apply-export-layout'
 import { getHtmlContent } from './html-content'
 import { getStylesToAdd, SHARE_SHELL_VARS_CSS } from './share-styles'
 
+export type PdfPageNumberFormat = `nOfM` | `n`
+export type PdfPageNumberPosition = `bottomLeft` | `bottomCenter` | `bottomRight`
+export type PdfMargins = `compact` | `default` | `comfortable`
+
+export interface PdfExportOptions {
+  showPageNumbers: boolean
+  pageNumberFormat: PdfPageNumberFormat
+  pageNumberPosition: PdfPageNumberPosition
+  showTitleHeader: boolean
+  showSiteFooter: boolean
+  margins: PdfMargins
+}
+
+export const DEFAULT_PDF_EXPORT_OPTIONS: PdfExportOptions = {
+  showPageNumbers: true,
+  pageNumberFormat: `nOfM`,
+  pageNumberPosition: `bottomRight`,
+  showTitleHeader: true,
+  showSiteFooter: true,
+  margins: `default`,
+}
+
+const PAGE_NUMBER_FORMATS = new Set<PdfPageNumberFormat>([`nOfM`, `n`])
+const PAGE_NUMBER_POSITIONS = new Set<PdfPageNumberPosition>([`bottomLeft`, `bottomCenter`, `bottomRight`])
+const MARGIN_PRESETS = new Set<PdfMargins>([`compact`, `default`, `comfortable`])
+
+const MARGIN_VALUES: Record<PdfMargins, string> = {
+  compact: `1cm`,
+  default: `1.5cm 1cm 2cm 1cm`,
+  comfortable: `2cm 1.5cm 2.5cm 1.5cm`,
+}
+
+/** Gap between chrome text (header / page number) and article content. */
+const CHROME_CONTENT_GAP = `0.5cm`
+
+const PAGE_NUMBER_BOX: Record<PdfPageNumberPosition, string> = {
+  bottomLeft: `@bottom-left`,
+  bottomCenter: `@bottom-center`,
+  bottomRight: `@bottom-right`,
+}
+
+/** All 16 CSS page margin boxes (Chrome 131+). */
+const ALL_MARGIN_BOXES = [
+  `@top-left-corner`,
+  `@top-left`,
+  `@top-center`,
+  `@top-right`,
+  `@top-right-corner`,
+  `@bottom-left-corner`,
+  `@bottom-left`,
+  `@bottom-center`,
+  `@bottom-right`,
+  `@bottom-right-corner`,
+  `@left-top`,
+  `@left-middle`,
+  `@left-bottom`,
+  `@right-top`,
+  `@right-middle`,
+  `@right-bottom`,
+] as const
+
+interface MarginSides {
+  top: string
+  right: string
+  bottom: string
+  left: string
+}
+
+function resolveMarginSides(margins: PdfMargins): MarginSides {
+  const parts = MARGIN_VALUES[margins].trim().split(/\s+/)
+  if (parts.length === 1) {
+    return { top: parts[0], right: parts[0], bottom: parts[0], left: parts[0] }
+  }
+  if (parts.length === 2) {
+    return { top: parts[0], right: parts[1], bottom: parts[0], left: parts[1] }
+  }
+  if (parts.length === 3) {
+    return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[1] }
+  }
+  return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[3] }
+}
+
+function formatSides({ top, right, bottom, left }: MarginSides): string {
+  if (top === right && right === bottom && bottom === left)
+    return top
+  if (top === bottom && right === left)
+    return `${top} ${right}`
+  return `${top} ${right} ${bottom} ${left}`
+}
+
+function marginBoxRule(
+  box: string,
+  content: string,
+  extras: string = ``,
+): string {
+  return `
+      ${box} {
+        content: ${content};${extras}
+      }`
+}
+
+/** Strip unknown/legacy fields (e.g. paperSize) and fill missing keys. */
+export function normalizePdfExportOptions(
+  input?: Partial<PdfExportOptions> | null,
+): PdfExportOptions {
+  const src = input ?? {}
+  return {
+    showPageNumbers: typeof src.showPageNumbers === `boolean`
+      ? src.showPageNumbers
+      : DEFAULT_PDF_EXPORT_OPTIONS.showPageNumbers,
+    pageNumberFormat: PAGE_NUMBER_FORMATS.has(src.pageNumberFormat as PdfPageNumberFormat)
+      ? src.pageNumberFormat as PdfPageNumberFormat
+      : DEFAULT_PDF_EXPORT_OPTIONS.pageNumberFormat,
+    pageNumberPosition: PAGE_NUMBER_POSITIONS.has(src.pageNumberPosition as PdfPageNumberPosition)
+      ? src.pageNumberPosition as PdfPageNumberPosition
+      : DEFAULT_PDF_EXPORT_OPTIONS.pageNumberPosition,
+    showTitleHeader: typeof src.showTitleHeader === `boolean`
+      ? src.showTitleHeader
+      : DEFAULT_PDF_EXPORT_OPTIONS.showTitleHeader,
+    showSiteFooter: typeof src.showSiteFooter === `boolean`
+      ? src.showSiteFooter
+      : DEFAULT_PDF_EXPORT_OPTIONS.showSiteFooter,
+    margins: MARGIN_PRESETS.has(src.margins as PdfMargins)
+      ? src.margins as PdfMargins
+      : DEFAULT_PDF_EXPORT_OPTIONS.margins,
+  }
+}
+
+/**
+ * Build `@page` CSS from export options.
+ * Unclaimed margin boxes get `content: ""` so Chromium does not fill in defaults.
+ * Top/bottom always keep a content inset (never flush to the page edge). When chrome
+ * is present on an edge, that edge uses the fuller preset height and chrome text is
+ * aligned toward the content with a consistent gap.
+ */
+export function buildPageCss(options: PdfExportOptions, title: string): string {
+  const resolved = normalizePdfExportOptions(options)
+  const safeTitle = sanitizeTitle(title)
+  const sides = resolveMarginSides(resolved.margins)
+  const pageBox = resolved.showPageNumbers
+    ? PAGE_NUMBER_BOX[resolved.pageNumberPosition]
+    : null
+
+  // Prefer page numbers when they share the same box as the site footer.
+  const showSiteFooter = resolved.showSiteFooter && pageBox !== `@bottom-left`
+  const needsTop = resolved.showTitleHeader
+  const needsBottom = Boolean(resolved.showPageNumbers || showSiteFooter)
+
+  // Side inset doubles as the "no chrome" top/bottom inset so content never flush-cuts.
+  const contentEdge = sides.left
+  const pageMargin: MarginSides = {
+    top: needsTop ? sides.top : contentEdge,
+    right: sides.right,
+    bottom: needsBottom ? sides.bottom : contentEdge,
+    left: sides.left,
+  }
+
+  const claimed = new Map<string, string>()
+
+  if (resolved.showTitleHeader) {
+    claimed.set(`@top-center`, marginBoxRule(
+      `@top-center`,
+      `"${safeTitle}"`,
+      `
+        font-size: 12px;
+        color: #666;
+        vertical-align: bottom;
+        padding-bottom: ${CHROME_CONTENT_GAP};`,
+    ))
+  }
+
+  if (showSiteFooter) {
+    claimed.set(`@bottom-left`, marginBoxRule(
+      `@bottom-left`,
+      `"https://md.doocs.org"`,
+      `
+        font-size: 10px;
+        color: #999;
+        vertical-align: top;
+        padding-top: ${CHROME_CONTENT_GAP};`,
+    ))
+  }
+
+  if (resolved.showPageNumbers && pageBox) {
+    const pageFooter = resolved.pageNumberFormat === `n`
+      ? t(`store.pdf.pageFooterN`)
+      : t(`store.pdf.pageFooter`)
+    claimed.set(pageBox, marginBoxRule(
+      pageBox,
+      `"${pageFooter}"`,
+      `
+        font-size: 10px;
+        color: #999;
+        vertical-align: top;
+        padding-top: ${CHROME_CONTENT_GAP};`,
+    ))
+  }
+
+  const boxes = ALL_MARGIN_BOXES.map(box =>
+    claimed.get(box) ?? marginBoxRule(box, `""`),
+  )
+
+  return `
+    @page {
+      margin: ${formatSides(pageMargin)};${boxes.join(``)}
+    }
+
+    html, body {
+      margin: 0;
+    }`
+}
+
 /** Export PDF document (current theme system). */
-export async function exportPDF(title: string = `untitled`) {
+export async function exportPDF(title: string = `untitled`, options?: Partial<PdfExportOptions>) {
   await waitForPreviewReady()
   const htmlStr = getHtmlContent({ staticLayout: true })
   const stylesToAdd = await getStylesToAdd()
   const safeTitle = sanitizeTitle(title)
-  const pageFooter = t('store.pdf.pageFooter')
+  const resolved = normalizePdfExportOptions(options)
+  const pageCss = buildPageCss(resolved, title)
 
   const printHtml = `<!DOCTYPE html>
 <html>
@@ -22,35 +235,13 @@ export async function exportPDF(title: string = `untitled`) {
   ${stylesToAdd}
   <style>${EXPORT_LAYOUT_CSS}</style>
   <style>
-    /* Force print backgrounds and images */
     * {
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
       color-adjust: exact !important;
     }
 
-    /* @page margin boxes */
-    @page {
-      @top-center {
-        content: "${safeTitle}";
-        font-size: 12px;
-        color: #666;
-      }
-      @bottom-left {
-        content: "https://md.doocs.org";
-        font-size: 10px;
-        color: #999;
-      }
-      @bottom-right {
-        content: "${pageFooter}";
-        font-size: 10px;
-        color: #999;
-      }
-    }
-
-    @media print {
-      body { margin: 0; }
-    }
+    ${pageCss}
   </style>
 </head>
 <body>
@@ -59,15 +250,20 @@ export async function exportPDF(title: string = `untitled`) {
   </div>
 </body>
 </html>`
+
+  // Blob URL avoids "about:srcdoc" if browser headers ever leak through.
+  const blob = new Blob([printHtml], { type: `text/html` })
+  const url = URL.createObjectURL(blob)
+
   const iframe = document.createElement(`iframe`)
   iframe.style.cssText = `position:fixed;width:0;height:0;top:-9999px;left:-9999px;border:none;`
-  iframe.srcdoc = printHtml
+  iframe.src = url
   document.body.appendChild(iframe)
 
   const removeIframe = () => {
-    if (iframe.parentNode) {
+    URL.revokeObjectURL(url)
+    if (iframe.parentNode)
       document.body.removeChild(iframe)
-    }
   }
 
   iframe.onload = () => {

--- a/apps/web/src/services/export/pdf.ts
+++ b/apps/web/src/services/export/pdf.ts
@@ -40,6 +40,19 @@ const MARGIN_VALUES: Record<PdfMargins, string> = {
 /** Gap between chrome text (header / page number) and article content. */
 const CHROME_CONTENT_GAP = `0.5cm`
 
+/** Prefer the current http(s) origin; fall back for extension / file contexts. */
+export function resolvePdfSiteFooterUrl(
+  locationLike: Pick<Location, `protocol` | `origin`> = window.location,
+): string {
+  if (locationLike.protocol === `http:` || locationLike.protocol === `https:`)
+    return locationLike.origin
+  return `https://md.doocs.org`
+}
+
+function escapeCssQuotedString(value: string): string {
+  return value.replace(/\\/g, `\\\\`).replace(/"/g, `\\"`)
+}
+
 const PAGE_NUMBER_BOX: Record<PdfPageNumberPosition, string> = {
   bottomLeft: `@bottom-left`,
   bottomCenter: `@bottom-center`,
@@ -140,9 +153,14 @@ export function normalizePdfExportOptions(
  * is present on an edge, that edge uses the fuller preset height and chrome text is
  * aligned toward the content with a consistent gap.
  */
-export function buildPageCss(options: PdfExportOptions, title: string): string {
+export function buildPageCss(
+  options: PdfExportOptions,
+  title: string,
+  siteUrl: string = resolvePdfSiteFooterUrl(),
+): string {
   const resolved = normalizePdfExportOptions(options)
   const safeTitle = sanitizeTitle(title)
+  const safeSiteUrl = escapeCssQuotedString(siteUrl)
   const sides = resolveMarginSides(resolved.margins)
   const pageBox = resolved.showPageNumbers
     ? PAGE_NUMBER_BOX[resolved.pageNumberPosition]
@@ -179,7 +197,7 @@ export function buildPageCss(options: PdfExportOptions, title: string): string {
   if (showSiteFooter) {
     claimed.set(`@bottom-left`, marginBoxRule(
       `@bottom-left`,
-      `"https://md.doocs.org"`,
+      `"${safeSiteUrl}"`,
       `
         font-size: 10px;
         color: #999;
@@ -224,7 +242,7 @@ export async function exportPDF(title: string = `untitled`, options?: Partial<Pd
   const stylesToAdd = await getStylesToAdd()
   const safeTitle = sanitizeTitle(title)
   const resolved = normalizePdfExportOptions(options)
-  const pageCss = buildPageCss(resolved, title)
+  const pageCss = buildPageCss(resolved, title, resolvePdfSiteFooterUrl())
 
   const printHtml = `<!DOCTYPE html>
 <html>

--- a/apps/web/src/stores/export.ts
+++ b/apps/web/src/stores/export.ts
@@ -1,3 +1,4 @@
+import type { PdfExportOptions } from '@/services/export'
 import {
   downloadMD,
   exportHTML,
@@ -42,12 +43,12 @@ export const useExportStore = defineStore(`export`, () => {
     })
   }
 
-  const exportEditorContent2PDF = async () => {
+  const exportEditorContent2PDF = async (options?: Partial<PdfExportOptions>) => {
     const currentPost = postStore.currentPost
     if (!currentPost)
       return
 
-    await exportPDF(currentPost.title)
+    await exportPDF(currentPost.title, options)
   }
 
   const exportEditorContent2MD = (content: string) => {

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -1,3 +1,5 @@
+import type { PdfExportOptions } from '@/services/export'
+import { DEFAULT_PDF_EXPORT_OPTIONS, normalizePdfExportOptions } from '@/services/export'
 import { store } from '@/storage'
 import { addPrefix } from '@/storage/prefix'
 
@@ -112,6 +114,19 @@ export const useUIStore = defineStore(`ui`, () => {
   function openShareDialog(options?: { tab?: `create` | `manage` }) {
     shareDialogInitialTab.value = options?.tab ?? `create`
     isShowShareDialog.value = true
+  }
+
+  const isShowPdfExportDialog = ref(false)
+
+  const pdfExportOptions = store.reactive<PdfExportOptions>(
+    `pdfExportOptions`,
+    { ...DEFAULT_PDF_EXPORT_OPTIONS },
+  )
+
+  function openPdfExportDialog() {
+    // Drop legacy fields (e.g. paperSize) and backfill newly added keys.
+    pdfExportOptions.value = normalizePdfExportOptions(pdfExportOptions.value)
+    isShowPdfExportDialog.value = true
   }
 
   const isShowAboutDialog = ref(false)
@@ -241,6 +256,9 @@ export const useUIStore = defineStore(`ui`, () => {
     isShowShareDialog,
     shareDialogInitialTab,
     openShareDialog,
+    isShowPdfExportDialog,
+    openPdfExportDialog,
+    pdfExportOptions,
     isShowAboutDialog,
     toggleShowAboutDialog,
     isShowFundDialog,


### PR DESCRIPTION
﻿## Summary

- Add a PDF export options panel (page numbers, format/position, title header, site footer, margins) opened from File / context menu instead of one-click print
- Build `@page` CSS from options; claim all margin boxes with `content: ""` when disabled to suppress browser default headers/footers
- Keep consistent content insets and chrome-to-content gaps; drop paper-size setting (use the browser print dialog)

## Related Issue

Closes #1758

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

1. Open File → Export → PDF (or context menu Export PDF) and confirm the options panel appears
2. Toggle page numbers / title / site footer and export; verify print preview matches the selected chrome
3. Disable all chrome and confirm no large empty bands and no browser default headers/footers (Chrome 131+)
4. Change margin presets and confirm side/content spacing updates
5. `pnpm --filter @md/web exec vitest run src/services/export/pdf-options.test.ts`

## Pre-flight Checklist

- [x] Self-tested locally
- [x] Related Issue linked
- [x] i18n updated for zh-CN / zh-TW / en-US / ja-JP
- [x] Unit tests added for `buildPageCss` / `normalizePdfExportOptions`
