### PR TITLE
ci: pin pnpm to 11.11.0 in GitHub Actions

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy-gitee.yml
+++ b/.github/workflows/deploy-gitee.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install
@@ -87,7 +89,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install
@@ -50,7 +52,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install
@@ -74,7 +78,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Update npm
         run: npm install -g npm@latest

--- a/.github/workflows/surge-preview-build.yml
+++ b/.github/workflows/surge-preview-build.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
+          # https://github.com/pnpm/action-setup/issues/276
+          version: 11.11.0
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary

- Pin GitHub Actions pnpm version from `11` to `11.11.0` across CI workflows
- Avoids `pnpm/action-setup` self-update crash on pnpm `11.12.0` (`Cannot use 'in' operator to search for 'integrity' in undefined`) that broke Gitee Pages deploy
- Upstream: https://github.com/pnpm/action-setup/issues/276

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow / CI

## Test Procedure

- [x] Confirmed failed job log: Setup pnpm switched `11.7.0 → 11.12.0` then crashed
- [x] Confirmed last successful Gitee deploy switched to `11.11.0`
- [ ] After merge, re-run or wait for `Build and Deploy to Gitee Pages` on `main`

## Pre-flight Checklist

- [x] Change is focused on a single issue
- [x] Commit follows Conventional Commits
- [x] No unrelated local changes included