### PR TITLE
ci: upgrade GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
           # https://github.com/pnpm/action-setup/issues/276
@@ -87,7 +87,7 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
           # https://github.com/pnpm/action-setup/issues/276

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
           # https://github.com/pnpm/action-setup/issues/276
@@ -50,7 +50,7 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
           # https://github.com/pnpm/action-setup/issues/276
@@ -76,7 +76,7 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
           # https://github.com/pnpm/action-setup/issues/276

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,7 +22,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Pin exact version: pnpm 11.12.0 self-update crashes in action-setup
           # https://github.com/pnpm/action-setup/issues/276

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Create GitHub Release
@@ -33,12 +36,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: |
             # 微信 Markdown 编辑器 ${{ github.ref_name }} 发布🎈
 


### PR DESCRIPTION
﻿## Summary

- Align `pnpm/action-setup` from `v5` to `v6` in lint/deploy/release-cli workflows (other workflows already on v6)
- Replace archived `actions/create-release@v1` with `softprops/action-gh-release@v2`
- Add `contents: write` permission and use `github.ref_name` for release tag/name

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow / CI

## Test Procedure

- [x] Verified action major versions against latest GitHub tags
- [x] Confirmed remaining workflows already use current majors (checkout@v7, setup-node@v6, etc.)
- [ ] CI lint workflow should pass on this PR
- [ ] Next `v*` tag release should create GitHub Release via softprops action

## Pre-flight Checklist

- [x] Change is focused on a single issue
- [x] Commit follows Conventional Commits
- [x] No unrelated local changes included
