### PR TITLE
feat(web): add preview tab and copy button to post history dialog

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -27,7 +27,6 @@ usePreferencesHotkey()
   <Toaster
     rich-colors
     position="top-center"
-    class="!z-[200]"
     :duration="1200"
     :visible-toasts="1"
     :theme="isDark ? 'dark' : 'light'"

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -1239,7 +1239,7 @@ function handleDragEnd() {
         <Button variant="outline" @click="copyHistoryContent">
           {{ t('common.copy') }}
         </Button>
-        <Button @click="confirmRestoreHistory">
+        <Button variant="outline" @click="confirmRestoreHistory">
           {{ t('post.restore') }}
         </Button>
       </DialogFooter>

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { CheckSquare, ChevronsDownUp, ChevronsUpDown, Download, Ellipsis, FileText, Plus, Regex, Replace, ReplaceAll, Search, Upload, X } from '@lucide/vue'
+import { initRenderer } from '@md/core'
+import { postProcessHtml, renderMarkdown } from '@md/core/utils'
+import { CONTENT_FONT_LANG } from '@/i18n/constants'
 import { copyPlain } from '@/lib/browser/clipboard'
 import { downloadMD, exportPostsAsZip } from '@/services/export'
+import { scopeThemeCss } from '@/services/export/share-styles'
 import { useConfirmStore } from '@/stores/confirm'
+import { useCustomComponentStore } from '@/stores/customComponent'
 import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
-import { useRenderStore } from '@/stores/render'
+import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 import {
   getPostSliderDropdownContentProps,
@@ -16,7 +21,7 @@ import {
 const { t } = useI18n()
 const confirmStore = useConfirmStore()
 const uiStore = useUIStore()
-const { isMobile, isOpenPostSlider } = storeToRefs(uiStore)
+const { isDark, isMobile, isOpenPostSlider } = storeToRefs(uiStore)
 const { toggleShowImportMdDialog } = uiStore
 
 const postSliderMenu = providePostSliderMenu()
@@ -130,13 +135,18 @@ function delPost() {
   toast.success(t('post.deleteSuccess'))
 }
 
-const renderStore = useRenderStore()
+const themeStore = useThemeStore()
+const customComponentStore = useCustomComponentStore()
 
 const isOpenHistoryDialog = ref(false)
 const currentPostId = ref<string | null>(null)
 const currentHistoryIndex = ref(0)
 const historyViewMode = ref<'content' | 'diff' | 'preview'>(`content`)
 const compareTargetIndex = ref(`1`)
+
+const HISTORY_PREVIEW_SCOPE = `#history-preview-output`
+const styleTag = `style` as const
+let historyRenderer: ReturnType<typeof initRenderer> | null = null
 
 function openHistoryDialog(id: string) {
   postSliderMenu.closeMenu()
@@ -151,16 +161,65 @@ const currentHistoryList = computed(() => {
   return postStore.getPostById(currentPostId.value!)?.history ?? []
 })
 
+/** Isolated renderer — must not call useRenderStore().render() (mutates live PreviewPanel). */
+function renderHistoryContent(content: string): string {
+  if (!historyRenderer)
+    historyRenderer = initRenderer({})
+
+  historyRenderer.reset({
+    citeStatus: themeStore.isCiteStatus,
+    legend: themeStore.legend,
+    countStatus: themeStore.isCountStatus,
+    isMacCodeBlock: themeStore.isMacCodeBlock,
+    isShowLineNumber: themeStore.isShowLineNumber,
+    themeMode: isDark.value ? `dark` : `light`,
+    components: customComponentStore.registry,
+    diagramMessages: {
+      mermaidLoading: t(`store.diagram.mermaidLoading`),
+      mermaidError: t(`store.diagram.mermaidError`),
+      plantumlLoading: t(`store.diagram.plantumlLoading`),
+      plantumlError: t(`store.diagram.plantumlError`),
+      infographicLoading: t(`store.diagram.infographicLoading`),
+      infographicError: t(`store.diagram.infographicError`),
+    },
+    countMessages: {
+      summary: t(`store.count.summary`, {
+        words: `{words}`,
+        minutes: `{minutes}`,
+      }),
+    },
+    renderMessages: {
+      footnoteTitle: t(`store.render.footnoteTitle`),
+      unknownComponent: t(`store.render.unknownComponent`),
+      katexLoading: t(`store.render.katexLoading`),
+    },
+  })
+
+  const { html, readingTime } = renderMarkdown(content, historyRenderer)
+  return postProcessHtml(html, readingTime, historyRenderer)
+}
+
 const previewHtml = computed(() => {
+  if (historyViewMode.value !== `preview`)
+    return ``
   const content = currentHistoryList.value[currentHistoryIndex.value]?.content ?? ``
   if (!content)
     return ``
   try {
-    return renderStore.render(content, { force: true })
+    return renderHistoryContent(content)
   }
   catch {
     return `<p class="text-muted-foreground text-sm">${t('store.render.renderFailed')}</p>`
   }
+})
+
+const historyPreviewCss = computed(() => {
+  if (!isOpenHistoryDialog.value || historyViewMode.value !== `preview`)
+    return ``
+  const themeStyle = document.querySelector(`#md-theme`) as HTMLStyleElement | null
+  if (!themeStyle?.textContent)
+    return ``
+  return scopeThemeCss(themeStyle.textContent, HISTORY_PREVIEW_SCOPE)
 })
 
 // Auto-adjust diff target when it conflicts with selected version
@@ -175,8 +234,13 @@ async function copyHistoryContent() {
   const content = currentHistoryList.value[currentHistoryIndex.value]?.content ?? ``
   if (!content)
     return
-  await copyPlain(content)
-  toast.success(t('common.copiedToClipboard'))
+  try {
+    await copyPlain(content)
+    toast.success(t('common.copiedToClipboard'))
+  }
+  catch {
+    toast.error(t('common.copyFailed'))
+  }
 }
 
 function recoverHistory() {
@@ -1122,7 +1186,15 @@ function handleDragEnd() {
                 class="history-preview-wrapper h-full overflow-y-auto rounded-lg border bg-background"
               >
                 <div class="preview mx-auto">
-                  <section id="output" class="w-full" v-html="previewHtml" />
+                  <component :is="styleTag" v-if="historyPreviewCss">
+                    {{ historyPreviewCss }}
+                  </component>
+                  <section
+                    id="history-preview-output"
+                    class="w-full"
+                    :lang="CONTENT_FONT_LANG"
+                    v-html="previewHtml"
+                  />
                 </div>
               </div>
               <div v-else class="flex items-center justify-center h-full rounded-lg border bg-background text-muted-foreground text-sm">

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { CheckSquare, ChevronsDownUp, ChevronsUpDown, Download, Ellipsis, FileText, Plus, Regex, Replace, ReplaceAll, Search, Upload, X } from '@lucide/vue'
+import { copyPlain } from '@/lib/browser/clipboard'
 import { downloadMD, exportPostsAsZip } from '@/services/export'
 import { useConfirmStore } from '@/stores/confirm'
 import { useEditorStore } from '@/stores/editor'
 import { usePostStore } from '@/stores/post'
+import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
 import {
   getPostSliderDropdownContentProps,
@@ -128,10 +130,12 @@ function delPost() {
   toast.success(t('post.deleteSuccess'))
 }
 
+const renderStore = useRenderStore()
+
 const isOpenHistoryDialog = ref(false)
 const currentPostId = ref<string | null>(null)
 const currentHistoryIndex = ref(0)
-const historyViewMode = ref<'content' | 'diff'>(`content`)
+const historyViewMode = ref<'content' | 'diff' | 'preview'>(`content`)
 const compareTargetIndex = ref(`1`)
 
 function openHistoryDialog(id: string) {
@@ -147,6 +151,18 @@ const currentHistoryList = computed(() => {
   return postStore.getPostById(currentPostId.value!)?.history ?? []
 })
 
+const previewHtml = computed(() => {
+  const content = currentHistoryList.value[currentHistoryIndex.value]?.content ?? ``
+  if (!content)
+    return ``
+  try {
+    return renderStore.render(content, { force: true })
+  }
+  catch {
+    return `<p class="text-muted-foreground text-sm">${t('store.render.renderFailed')}</p>`
+  }
+})
+
 // Auto-adjust diff target when it conflicts with selected version
 watch(currentHistoryIndex, (idx) => {
   if (Number(compareTargetIndex.value) === idx) {
@@ -154,6 +170,14 @@ watch(currentHistoryIndex, (idx) => {
     compareTargetIndex.value = String(idx + 1 < len ? idx + 1 : Math.max(0, idx - 1))
   }
 })
+
+async function copyHistoryContent() {
+  const content = currentHistoryList.value[currentHistoryIndex.value]?.content ?? ``
+  if (!content)
+    return
+  await copyPlain(content)
+  toast.success(t('common.copiedToClipboard'))
+}
 
 function recoverHistory() {
   const post = postStore.getPostById(currentPostId.value!)
@@ -1078,6 +1102,9 @@ function handleDragEnd() {
               <TabsTrigger value="content">
                 {{ t('post.originalContent') }}
               </TabsTrigger>
+              <TabsTrigger value="preview">
+                {{ t('common.preview') }}
+              </TabsTrigger>
               <TabsTrigger value="diff">
                 {{ t('post.versionDiff') }}
               </TabsTrigger>
@@ -1086,6 +1113,20 @@ function handleDragEnd() {
             <TabsContent value="content" class="flex-1 overflow-y-auto mt-2">
               <div class="rounded-lg bg-muted/30 p-4 h-full overflow-y-auto">
                 <pre class="whitespace-pre-wrap text-sm leading-relaxed break-all font-[inherit]">{{ currentHistoryList[currentHistoryIndex]?.content ?? '' }}</pre>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="preview" class="flex-1 overflow-hidden mt-2">
+              <div
+                v-if="previewHtml"
+                class="history-preview-wrapper h-full overflow-y-auto rounded-lg border bg-background"
+              >
+                <div class="preview mx-auto">
+                  <section id="output" class="w-full" v-html="previewHtml" />
+                </div>
+              </div>
+              <div v-else class="flex items-center justify-center h-full rounded-lg border bg-background text-muted-foreground text-sm">
+                {{ t('common.noData') }}
               </div>
             </TabsContent>
 
@@ -1123,6 +1164,9 @@ function handleDragEnd() {
       </div>
 
       <DialogFooter>
+        <Button variant="outline" @click="copyHistoryContent">
+          {{ t('common.copy') }}
+        </Button>
         <Button @click="confirmRestoreHistory">
           {{ t('post.restore') }}
         </Button>
@@ -1163,5 +1207,19 @@ function handleDragEnd() {
 .slide-up-leave-to {
   transform: translateY(100%);
   opacity: 0;
+}
+</style>
+
+<style>
+/* History preview container — mirrors .preview class from app.less (scoped in PreviewPanel) */
+.history-preview-wrapper .preview {
+  position: relative;
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 20px;
+  font-size: 14px;
+  box-sizing: border-box;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 </style>

--- a/apps/web/src/i18n/messages/en-US/store.ts
+++ b/apps/web/src/i18n/messages/en-US/store.ts
@@ -99,6 +99,7 @@ export default {
     footnoteTitle: `References`,
     unknownComponent: `Unknown component: {name}`,
     katexLoading: `Loading formula…`,
+    renderFailed: `Render failed`,
   },
   popup: {
     mustRead: `Before you start`,

--- a/apps/web/src/i18n/messages/ja-JP/store.ts
+++ b/apps/web/src/i18n/messages/ja-JP/store.ts
@@ -99,6 +99,7 @@ export default {
     footnoteTitle: `参考文献`,
     unknownComponent: `不明なコンポーネント: {name}`,
     katexLoading: `数式を読み込み中…`,
+    renderFailed: `レンダリングに失敗しました`,
   },
   popup: {
     mustRead: `ご利用前に`,

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -62,7 +62,7 @@ export default {
     originalContent: `原文`,
     versionDiff: `版本对比`,
     compareLabel: `对比：`,
-    restore: `恢 复`,
+    restore: `恢复`,
     restoreArticleDescription: `此操作将用该记录替换当前文章内容，是否继续？`,
     addPost: `新增内容`,
     saveAsTemplate: `存储为模板`,

--- a/apps/web/src/i18n/messages/zh-CN/store.ts
+++ b/apps/web/src/i18n/messages/zh-CN/store.ts
@@ -99,6 +99,7 @@ export default {
     footnoteTitle: `引用链接`,
     unknownComponent: `未知组件: {name}`,
     katexLoading: `正在加载公式…`,
+    renderFailed: `渲染失败`,
   },
   popup: {
     mustRead: `使用必读`,

--- a/apps/web/src/i18n/messages/zh-TW/editor.ts
+++ b/apps/web/src/i18n/messages/zh-TW/editor.ts
@@ -62,7 +62,7 @@ export default {
     originalContent: `原文`,
     versionDiff: `版本對比`,
     compareLabel: `對比：`,
-    restore: `恢 復`,
+    restore: `恢復`,
     restoreArticleDescription: `此操作將用該記錄替換當前文章內容，是否繼續？`,
     addPost: `新增內容`,
     saveAsTemplate: `儲存為模板`,

--- a/apps/web/src/i18n/messages/zh-TW/store.ts
+++ b/apps/web/src/i18n/messages/zh-TW/store.ts
@@ -99,6 +99,7 @@ export default {
     footnoteTitle: `引用連結`,
     unknownComponent: `未知元件: {name}`,
     katexLoading: `正在載入公式…`,
+    renderFailed: `渲染失敗`,
   },
   popup: {
     mustRead: `使用必讀`,

--- a/apps/web/src/services/export/share-styles.ts
+++ b/apps/web/src/services/export/share-styles.ts
@@ -25,7 +25,8 @@ async function getHljsStyles(): Promise<string> {
   }
 }
 
-function scopeThemeCss(cssContent: string, scope: string): string {
+/** Remap `#output` theme selectors to an isolated preview scope (e.g. history / share). */
+export function scopeThemeCss(cssContent: string, scope: string): string {
   let css = cssContent
   css = css.replace(/#output\s*\{/g, `${scope} {`)
   css = css.replace(/#output\s+/g, `${scope} `)


### PR DESCRIPTION
文章历史弹窗新增预览 Tab，可直接查看渲染效果，并支持一键复制历史内容。