### PR TITLE
fix(web): reduce title size in AIImageConfig

### DIFF
--- a/apps/web/src/components/ai/image-generator/AIImageConfig.vue
+++ b/apps/web/src/components/ai/image-generator/AIImageConfig.vue
@@ -125,7 +125,7 @@ const styleOptions = computed(() => [
 
 <template>
   <div class="space-y-4 max-w-full">
-    <div class="text-lg font-semibold border-b pb-2">
+    <div class="font-medium">
       {{ t('ai.imageConfig.title') }}
     </div>
 


### PR DESCRIPTION
降低设置标题字号，避免比弹窗标题还大。

<img width="1792" height="1370" alt="image" src="https://github.com/user-attachments/assets/073a31f4-2757-4276-af28-f388e7458f34" />
