### PR TITLE
fix(web): add popover delete confirmation in QuickCommandManager

### DIFF
--- a/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
+++ b/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
 import { useQuickCommandsStore } from '@/stores/quickCommands'
 
@@ -17,6 +18,7 @@ const store = useQuickCommandsStore()
 const { t } = useI18n()
 const label = ref(``)
 const template = ref(``)
+const confirmDeleteId = ref<string | null>(null)
 
 function addCmd() {
   if (!label.value.trim() || !template.value.trim())
@@ -85,9 +87,31 @@ function saveEdit() {
                 <Button variant="ghost" size="xs" @click="beginEdit(cmd)">
                   {{ t('common.edit') }}
                 </Button>
-                <Button variant="outline" size="xs" @click="store.remove(cmd.id)">
-                  {{ t('common.delete') }}
-                </Button>
+                <Popover
+                  :open="confirmDeleteId === cmd.id"
+                  @update:open="v => { if (!v) confirmDeleteId = null }"
+                >
+                  <PopoverTrigger as-child>
+                    <Button variant="outline" size="xs" @click="confirmDeleteId = cmd.id">
+                      {{ t('common.delete') }}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent class="w-auto p-3">
+                    <div class="flex flex-col gap-2">
+                      <p class="text-sm">
+                        {{ t('confirm.deleteItem', { name: cmd.label }) }}
+                      </p>
+                      <div class="flex justify-end gap-2">
+                        <Button size="xs" variant="outline" @click="confirmDeleteId = null">
+                          {{ t('common.cancel') }}
+                        </Button>
+                        <Button size="xs" @click="store.remove(cmd.id); confirmDeleteId = null">
+                          {{ t('common.confirm') }}
+                        </Button>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
           </template>

--- a/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
+++ b/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
@@ -11,14 +11,18 @@ const props = defineProps<{ open: boolean }>()
 const emit = defineEmits([`update:open`])
 
 const dialogOpen = ref(props.open)
+const confirmDeleteId = ref<string | null>(null)
 watch(() => props.open, v => (dialogOpen.value = v))
-watch(dialogOpen, v => emit(`update:open`, v))
+watch(dialogOpen, (v) => {
+  emit(`update:open`, v)
+  if (!v)
+    confirmDeleteId.value = null
+})
 
 const store = useQuickCommandsStore()
 const { t } = useI18n()
 const label = ref(``)
 const template = ref(``)
-const confirmDeleteId = ref<string | null>(null)
 
 function addCmd() {
   if (!label.value.trim() || !template.value.trim())
@@ -33,6 +37,7 @@ const editLabel = ref(``)
 const editTemplate = ref(``)
 
 function beginEdit(cmd: { id: string, label: string, template: string }) {
+  confirmDeleteId.value = null
   editingId.value = cmd.id
   editLabel.value = cmd.label
   editTemplate.value = cmd.template


### PR DESCRIPTION
新增：快捷指令删除需进行 Popover 二次确认