### PR TITLE
feat(ai): make builtin quick commands read-only and locale-aware

### DIFF
--- a/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
+++ b/apps/web/src/components/ai/chat-box/QuickCommandManager.vue
@@ -36,7 +36,9 @@ const editingId = ref<string | null>(null)
 const editLabel = ref(``)
 const editTemplate = ref(``)
 
-function beginEdit(cmd: { id: string, label: string, template: string }) {
+function beginEdit(cmd: { id: string, label: string, template: string, builtin: boolean }) {
+  if (cmd.builtin)
+    return
   confirmDeleteId.value = null
   editingId.value = cmd.id
   editLabel.value = cmd.label
@@ -68,7 +70,7 @@ function saveEdit() {
           :key="cmd.id"
           class="flex flex-col gap-2 border rounded-md p-3"
         >
-          <template v-if="editingId === cmd.id">
+          <template v-if="!cmd.builtin && editingId === cmd.id">
             <Input v-model="editLabel" :placeholder="t('ai.quickCommand.namePlaceholder')" />
             <Textarea
               v-model="editTemplate"
@@ -86,9 +88,17 @@ function saveEdit() {
           </template>
 
           <template v-else>
-            <div class="flex items-center justify-between">
-              <span class="break-all text-sm">{{ cmd.label }}</span>
-              <div class="flex gap-1">
+            <div class="flex items-center justify-between gap-2">
+              <div class="flex min-w-0 items-center gap-2">
+                <span class="break-all text-sm">{{ cmd.label }}</span>
+                <span
+                  v-if="cmd.builtin"
+                  class="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none"
+                >
+                  {{ t('ai.quickCommand.builtin') }}
+                </span>
+              </div>
+              <div v-if="!cmd.builtin" class="flex shrink-0 gap-1">
                 <Button variant="ghost" size="xs" @click="beginEdit(cmd)">
                   {{ t('common.edit') }}
                 </Button>
@@ -119,6 +129,12 @@ function saveEdit() {
                 </Popover>
               </div>
             </div>
+            <p
+              v-if="cmd.builtin"
+              class="text-muted-foreground whitespace-pre-wrap break-all text-xs"
+            >
+              {{ cmd.template }}
+            </p>
           </template>
         </div>
       </div>

--- a/apps/web/src/i18n/messages/en-US/ai.ts
+++ b/apps/web/src/i18n/messages/en-US/ai.ts
@@ -113,6 +113,7 @@ export default {
     templatePlaceholder: `Template with {'{'}{'{'}sel{'}'}{'}'} placeholder`,
     nameExamplePlaceholder: `Command name (e.g. Rewrite as SEO copy)`,
     templateExamplePlaceholder: `Template with {'{'}{'{'}sel{'}'}{'}'}, e.g.:\nRewrite the following as an SEO-friendly title:\n\n{'{'}{'{'}sel{'}'}{'}'}`,
+    builtin: `Built-in`,
     polish: { label: `Polish`, template: `Please polish the following:\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toEn: { label: `Translate to English`, template: `Please translate the following into English:\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toZh: { label: `Translate to Chinese`, template: `Please translate the following into Chinese:\n\n{'{'}{'{'}sel{'}'}{'}'}` },

--- a/apps/web/src/i18n/messages/ja-JP/ai.ts
+++ b/apps/web/src/i18n/messages/ja-JP/ai.ts
@@ -113,6 +113,7 @@ export default {
     templatePlaceholder: `{'{'}{'{'}sel{'}'}{'}'} プレースホルダー付きテンプレート`,
     nameExamplePlaceholder: `コマンド名（例: SEO コピーに書き換え）`,
     templateExamplePlaceholder: `{'{'}{'{'}sel{'}'}{'}'} 付きテンプレート、例:\n以下を SEO 向けタイトルに書き換えてください:\n\n{'{'}{'{'}sel{'}'}{'}'}`,
+    builtin: `組み込み`,
     polish: { label: `推敲`, template: `以下を推敲してください:\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toEn: { label: `英語に翻訳`, template: `以下を英語に翻訳してください:\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toZh: { label: `中国語に翻訳`, template: `以下を中国語に翻訳してください:\n\n{'{'}{'{'}sel{'}'}{'}'}` },

--- a/apps/web/src/i18n/messages/zh-CN/ai.ts
+++ b/apps/web/src/i18n/messages/zh-CN/ai.ts
@@ -113,6 +113,7 @@ export default {
     templatePlaceholder: `模板内容，支持 {'{'}{'{'}sel{'}'}{'}'} 占位`,
     nameExamplePlaceholder: `指令名称 (如：改写为 SEO 文案)`,
     templateExamplePlaceholder: `模板，可用 {'{'}{'{'}sel{'}'}{'}'} 占位，例如：\n请把以下文字改写为 SEO 友好的标题：\n\n{'{'}{'{'}sel{'}'}{'}'}`,
+    builtin: `内置`,
     polish: { label: `润色`, template: `请润色以下内容：\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toEn: { label: `翻译成英文`, template: `请将以下内容翻译为英文：\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toZh: { label: `翻译成中文`, template: `请将以下内容翻译为中文：\n\n{'{'}{'{'}sel{'}'}{'}'}` },

--- a/apps/web/src/i18n/messages/zh-TW/ai.ts
+++ b/apps/web/src/i18n/messages/zh-TW/ai.ts
@@ -113,6 +113,7 @@ export default {
     templatePlaceholder: `模板內容，支援 {'{'}{'{'}sel{'}'}{'}'} 佔位`,
     nameExamplePlaceholder: `指令名稱 (如：改寫為 SEO 文案)`,
     templateExamplePlaceholder: `模板，可用 {'{'}{'{'}sel{'}'}{'}'} 佔位，例如：\n請把以下文字改寫為 SEO 友好的標題：\n\n{'{'}{'{'}sel{'}'}{'}'}`,
+    builtin: `內建`,
     polish: { label: `潤色`, template: `請潤色以下內容：\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toEn: { label: `翻譯成英文`, template: `請將以下內容翻譯為英文：\n\n{'{'}{'{'}sel{'}'}{'}'}` },
     toZh: { label: `翻譯成中文`, template: `請將以下內容翻譯為中文：\n\n{'{'}{'{'}sel{'}'}{'}'}` },

--- a/apps/web/src/stores/quickCommands.ts
+++ b/apps/web/src/stores/quickCommands.ts
@@ -1,6 +1,7 @@
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { t } from '@/i18n/translate'
 import { store } from '@/storage'
+import { useLocaleStore } from '@/stores/locale'
 
 export interface QuickCommandPersisted {
   id: string
@@ -9,78 +10,117 @@ export interface QuickCommandPersisted {
 }
 
 export interface QuickCommandRuntime extends QuickCommandPersisted {
+  builtin: boolean
   buildPrompt: (sel?: string) => string
 }
 
 const STORAGE_KEY = `quick_commands`
 
-function hydrate(cmd: QuickCommandPersisted): QuickCommandRuntime {
+/** Built-in command ids — labels/templates always resolve from i18n; not editable or removable. */
+export const BUILTIN_QUICK_COMMAND_IDS = [`polish`, `to-en`, `to-zh`, `summary`] as const
+
+const BUILTIN_ID_SET = new Set<string>(BUILTIN_QUICK_COMMAND_IDS)
+
+const BUILTIN_I18N_KEYS: Record<(typeof BUILTIN_QUICK_COMMAND_IDS)[number], { label: string, template: string }> = {
+  'polish': { label: `ai.quickCommand.polish.label`, template: `ai.quickCommand.polish.template` },
+  'to-en': { label: `ai.quickCommand.toEn.label`, template: `ai.quickCommand.toEn.template` },
+  'to-zh': { label: `ai.quickCommand.toZh.label`, template: `ai.quickCommand.toZh.template` },
+  'summary': { label: `ai.quickCommand.summary.label`, template: `ai.quickCommand.summary.template` },
+}
+
+export function isBuiltinQuickCommand(id: string): boolean {
+  return BUILTIN_ID_SET.has(id)
+}
+
+function hydrate(cmd: QuickCommandPersisted, builtin: boolean): QuickCommandRuntime {
   return {
     ...cmd,
+    builtin,
     buildPrompt: (sel = ``) =>
       cmd.template.replace(/\{\{\s*sel\s*\}\}/gi, sel),
   }
 }
 
-function getDefaultCommands(): QuickCommandPersisted[] {
-  return [
-    { id: `polish`, label: t('ai.quickCommand.polish.label'), template: t('ai.quickCommand.polish.template') },
-    { id: `to-en`, label: t('ai.quickCommand.toEn.label'), template: t('ai.quickCommand.toEn.template') },
-    { id: `to-zh`, label: t('ai.quickCommand.toZh.label'), template: t('ai.quickCommand.toZh.template') },
-    { id: `summary`, label: t('ai.quickCommand.summary.label'), template: t('ai.quickCommand.summary.template') },
-  ]
+function getBuiltinCommands(): QuickCommandRuntime[] {
+  return BUILTIN_QUICK_COMMAND_IDS.map((id) => {
+    const keys = BUILTIN_I18N_KEYS[id]
+    return hydrate({ id, label: t(keys.label), template: t(keys.template) }, true)
+  })
+}
+
+function normalizeCustom(list: unknown[]): QuickCommandPersisted[] {
+  return list
+    .filter((item): item is QuickCommandPersisted => {
+      if (!item || typeof item !== `object`)
+        return false
+      const cmd = item as Record<string, unknown>
+      return typeof cmd.id === `string`
+        && typeof cmd.label === `string`
+        && typeof cmd.template === `string`
+        && !isBuiltinQuickCommand(cmd.id)
+    })
+    .map(({ id, label, template }) => ({ id, label, template }))
 }
 
 export const useQuickCommandsStore = defineStore(`quickCommands`, () => {
-  // ---------- state ----------
-  const commands = ref<QuickCommandRuntime[]>([])
+  const localeStore = useLocaleStore()
+  const customCommands = ref<QuickCommandPersisted[]>([])
 
-  // ---------- helpers ----------
+  // Built-ins always resolve from i18n so they follow the active locale.
+  const commands = computed<QuickCommandRuntime[]>(() => {
+    void localeStore.locale
+    return [
+      ...getBuiltinCommands(),
+      ...customCommands.value.map(cmd => hydrate(cmd, false)),
+    ]
+  })
+
   async function save() {
-    const toSave: QuickCommandPersisted[] = commands.value.map(
-      ({ id, label, template }) => ({ id, label, template }),
-    )
-    await store.setJSON(STORAGE_KEY, toSave)
+    await store.setJSON(STORAGE_KEY, customCommands.value)
   }
 
   async function reloadFromStorage() {
-    const parsed = await store.getJSON<QuickCommandPersisted[]>(STORAGE_KEY)
+    const parsed = await store.getJSON<unknown[]>(STORAGE_KEY)
 
     if (parsed && Array.isArray(parsed)) {
       try {
-        commands.value = parsed.map(hydrate)
+        customCommands.value = normalizeCustom(parsed)
+        // Migrate away from persisting built-in copies (old format stored all commands).
+        await save()
       }
       catch (e) {
-        console.warn(t('ai.quickCommand.parseFailed'), e)
-        commands.value = getDefaultCommands().map(hydrate)
+        console.warn(t(`ai.quickCommand.parseFailed`), e)
+        customCommands.value = []
         await save()
       }
     }
     else {
-      commands.value = getDefaultCommands().map(hydrate)
+      customCommands.value = []
       await save()
     }
   }
 
-  // ---------- CRUD ----------
   function add(label: string, template: string) {
     const id = crypto.randomUUID()
-    commands.value.push(hydrate({ id, label, template }))
+    customCommands.value.push({ id, label, template })
   }
 
   function update(id: string, label: string, template: string) {
-    const idx = commands.value.findIndex(c => c.id === id)
+    if (isBuiltinQuickCommand(id))
+      return
+    const idx = customCommands.value.findIndex(c => c.id === id)
     if (idx !== -1)
-      commands.value[idx] = hydrate({ id, label, template })
+      customCommands.value[idx] = { id, label, template }
   }
 
   function remove(id: string) {
-    commands.value = commands.value.filter(c => c.id !== id)
+    if (isBuiltinQuickCommand(id))
+      return
+    customCommands.value = customCommands.value.filter(c => c.id !== id)
   }
 
-  // ---------- init ----------
   reloadFromStorage()
-  watch(commands, save, { deep: true })
+  watch(customCommands, save, { deep: true })
 
   return { commands, add, update, remove, reloadFromStorage }
 })


### PR DESCRIPTION
﻿## Summary

- Make built-in AI quick commands (polish / translate / summarize) read-only: they can no longer be edited or deleted in the manager UI or store
- Resolve built-in labels and templates from i18n at runtime so they follow the active locale
- Persist only custom quick commands; migrate away from storing built-in copies in local storage

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure

- [ ] Open AI assistant → manage quick commands: built-ins show a “Built-in” badge, no edit/delete actions, template is visible read-only
- [ ] Switch UI language (zh-CN / zh-TW / en-US / ja-JP): built-in command labels and templates update immediately
- [ ] Add / edit / delete a custom quick command still works
- [ ] Apply a built-in quick command from the chat chip bar still fills the prompt with `{{sel}}` replaced
- [ ] Reload the app: built-ins remain present; previously persisted built-in copies are dropped from storage

## Pre-flight Checklist

- [x] Self-reviewed the diff
- [x] No secrets committed
- [x] Follows Conventional Commits
- [ ] CI passes (will run on this PR)
