### PR TITLE
ci: ignore prettier and mathjax in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: vue
       - dependency-name: vite
+      - dependency-name: prettier
+      - dependency-name: mathjax
 
     open-pull-requests-limit: 100
     groups:


### PR DESCRIPTION
﻿## Summary

- Ignore `prettier` and `mathjax` in Dependabot npm version updates so they no longer open upgrade PRs
- Prettier stays pinned at 2.8.8 (catalog + overrides); MathJax is loaded via CDN / local static assets, not as an npm upgrade target

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [x] Workflow / CI

## Test Procedure

- [ ] Confirm `.github/dependabot.yml` lists `prettier` and `mathjax` under `ignore`
- [ ] After merge, Dependabot should not open new version-update PRs for these packages

## Pre-flight Checklist

- [x] Self-reviewed the diff
- [x] No secrets committed
- [x] Follows Conventional Commits
- [ ] CI passes (will run on this PR)
