### PR TITLE
fix(web): use FunctionSquare icon for formula entry

### DIFF
--- a/apps/web/src/components/editor/EditorContextMenu.vue
+++ b/apps/web/src/components/editor/EditorContextMenu.vue
@@ -9,6 +9,7 @@ import {
   FileImage,
   FileText,
   FileUp,
+  FunctionSquare,
   Heading1,
   Heading2,
   Heading3,
@@ -139,7 +140,7 @@ function downloadAsCardImage() {
             {{ t('menu.image') }}
           </ContextMenuItem>
           <ContextMenuItem @click="openFormulaEditor()">
-            <span class="mr-2 inline-flex h-4 w-4 items-center justify-center text-xs font-semibold">ƒ</span>
+            <FunctionSquare class="mr-2 h-4 w-4" />
             {{ t('menu.formula') }}
           </ContextMenuItem>
           <ContextMenuItem @click="toggleShowInsertFormDialog()">

--- a/apps/web/src/components/editor/editor-header/InsertDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/InsertDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Blocks, Image, Table } from '@lucide/vue'
+import { Blocks, FunctionSquare, Image, Table } from '@lucide/vue'
 import { normalizeFormulaInput } from '@/lib/markdown/formula'
 import { useEditorStore } from '@/stores/editor'
 import { useUIStore } from '@/stores/ui'
@@ -37,7 +37,7 @@ function openFormulaEditor() {
         {{ t('menu.image') }}
       </MenubarItem>
       <MenubarItem @click="openFormulaEditor()">
-        <span class="mr-2 inline-flex h-4 w-4 items-center justify-center text-xs font-semibold">ƒ</span>
+        <FunctionSquare class="mr-2 h-4 w-4" />
         {{ t('menu.formula') }}
       </MenubarItem>
       <MenubarItem @click="toggleShowInsertFormDialog()">
@@ -61,7 +61,7 @@ function openFormulaEditor() {
         {{ t('menu.image') }}
       </MenubarItem>
       <MenubarItem @click="openFormulaEditor()">
-        <span class="mr-2 inline-flex h-4 w-4 items-center justify-center text-xs font-semibold">ƒ</span>
+        <FunctionSquare class="mr-2 h-4 w-4" />
         {{ t('menu.formula') }}
       </MenubarItem>
       <MenubarItem @click="toggleShowInsertFormDialog()">


### PR DESCRIPTION
公式图标统一替换为 Lucide 的 FunctionSquare，替换原来手写的 ƒ 字符