### PR TITLE
fix(web): remove extra border from dark mode toggle

### DIFF
--- a/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
@@ -114,7 +114,7 @@ function onLocaleChange(value: string) {
           />
         </div>
 
-        <div class="flex items-center justify-between gap-4 border-b py-3">
+        <div class="flex items-center justify-between gap-4 py-3">
           <div class="min-w-0 space-y-0.5">
             <Label for="pref-dark-mode">{{ t('preferences.darkMode.label') }}</Label>
           </div>


### PR DESCRIPTION
移除偏好设置弹窗中暗色模式切换项多余的底部边框。