### PR TITLE
chore(web): remove Discussions theme-share hint from CSS editor

### DIFF
--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -635,18 +635,6 @@ function exportCurrentTheme() {
         </DialogHeader>
         <div class="space-y-3 text-sm text-muted-foreground leading-relaxed">
           <p>{{ t('cssEditor.editorHint') }}</p>
-          <p>
-            <i18n-t keypath="cssEditor.shareThemeHint" tag="span">
-              <template #link>
-                <a
-                  href="https://github.com/doocs/md/discussions/426"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-foreground hover:text-primary underline-offset-2 hover:underline"
-                >{{ t('cssEditor.shareThemeLinkText') }}</a>
-              </template>
-            </i18n-t>
-          </p>
         </div>
         <DialogFooter>
           <Button @click="isOpenTipsDialog = false">

--- a/apps/web/src/i18n/messages/en-US/editor.ts
+++ b/apps/web/src/i18n/messages/en-US/editor.ts
@@ -415,8 +415,6 @@ export default {
     cssPlaceholder: `Your custom CSS here`,
     tipsTitle: `Tips`,
     editorHint: `Press Alt/Option + Shift + F to format. Use var(--md-primary-color) for the theme color, e.g. color: var(--md-primary-color);. Open “View built-in themes” to inspect class names.`,
-    shareThemeHint: `Have a nice theme? Share it so others can use it: {link}`,
-    shareThemeLinkText: `Discussions`,
     selectedUnit: `items`,
     deleteSchemeMinOne: `Keep at least one scheme`,
   },

--- a/apps/web/src/i18n/messages/ja-JP/editor.ts
+++ b/apps/web/src/i18n/messages/ja-JP/editor.ts
@@ -415,8 +415,6 @@ export default {
     cssPlaceholder: `カスタム CSS をここに入力`,
     tipsTitle: `ヒント`,
     editorHint: `Alt/Option + Shift + F でフォーマットできます。テーマ色は var(--md-primary-color) を使ってください（例: color: var(--md-primary-color);）。「組み込みテーマを表示」からクラス名を確認できます。`,
-    shareThemeHint: `素敵なテーマがあれば共有してください: {link}`,
-    shareThemeLinkText: `Discussions`,
     selectedUnit: `件`,
     deleteSchemeMinOne: `少なくとも 1 つのスキームを残してください`,
   },

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -415,8 +415,6 @@ export default {
     cssPlaceholder: `在此编写自定义 CSS`,
     tipsTitle: `使用提示`,
     editorHint: `按 Alt/Option + Shift + F 可格式化。主题色请使用 var(--md-primary-color)，例如 color: var(--md-primary-color);。可从「查看内置主题样式」对照类名。`,
-    shareThemeHint: `欢迎分享好看的主题样式，让更多人用到：{link}`,
-    shareThemeLinkText: `Discussions`,
     selectedUnit: `个`,
     deleteSchemeMinOne: `至少保留一个方案`,
   },

--- a/apps/web/src/i18n/messages/zh-TW/editor.ts
+++ b/apps/web/src/i18n/messages/zh-TW/editor.ts
@@ -415,8 +415,6 @@ export default {
     cssPlaceholder: `在此編寫自訂 CSS`,
     tipsTitle: `使用提示`,
     editorHint: `按 Alt/Option + Shift + F 可格式化。主題色請使用 var(--md-primary-color)，例如 color: var(--md-primary-color);。可從「檢視內建主題樣式」對照類名。`,
-    shareThemeHint: `歡迎分享好看的主題樣式，讓更多人用到：{link}`,
-    shareThemeLinkText: `Discussions`,
     selectedUnit: `個`,
     deleteSchemeMinOne: `至少保留一個方案`,
   },


### PR DESCRIPTION
﻿## Summary
- Remove the CSS editor tips link that guided users to share themes via GitHub Discussions
- Drop unused `shareThemeHint` / `shareThemeLinkText` i18n keys (zh-CN, zh-TW, en-US, ja-JP)
- Theme marketplace is now the place to browse and publish community themes

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Cosmetic (changes that do not affect meaning or function)
- [ ] Documentation
- [ ] Workflow (GitHub Actions / CI)

## Test Procedure
1. Open CSS editor → tips dialog
2. Confirm only the usage hint remains (no Discussions share link)
3. Spot-check locale switch if convenient

## Pre-flight Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas (N/A)
- [x] I have ensured that my changes do not introduce new warnings or errors
- [ ] Corresponding tests have been added / updated (N/A — copy/UI only)
- [ ] Documentation has been updated if needed (N/A)
- [x] All CI checks will pass
