### PR TITLE
perf(web): shrink initial bundle via chunking and lazy i18n

### DIFF
--- a/apps/web/src/bootstrap.ts
+++ b/apps/web/src/bootstrap.ts
@@ -15,7 +15,7 @@ export async function bootstrap(): Promise<void> {
   setupComponents()
   await initStorage()
 
-  const i18n = setupI18n(detectInitialLocale())
+  const i18n = await setupI18n(detectInitialLocale())
   setAppI18n(i18n)
 
   const app = createApp(AppRoot)

--- a/apps/web/src/components/editor/Footer.vue
+++ b/apps/web/src/components/editor/Footer.vue
@@ -93,7 +93,7 @@ function toggleTheme() {
 
 function toggleLanguage() {
   isMoreOpen.value = false
-  localeStore.cycleLocale()
+  void localeStore.cycleLocale()
 }
 
 const cursorLine = ref(1)

--- a/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
+++ b/apps/web/src/components/editor/dialogs/PreferencesDialog.vue
@@ -74,7 +74,7 @@ function setCountStatus(value: boolean) {
 
 function onLocaleChange(value: string) {
   if ((SUPPORTED_LOCALES as readonly string[]).includes(value))
-    localeStore.setLocale(value as AppLocale)
+    void localeStore.setLocale(value as AppLocale)
 }
 </script>
 

--- a/apps/web/src/composables/useCommandPalette.ts
+++ b/apps/web/src/composables/useCommandPalette.ts
@@ -94,7 +94,7 @@ export function useCommandPalette() {
         label: t(`commandPalette.toggleLanguage`),
         group: t(`commandPalette.group.settings`),
         keywords: [`语言`, `中文`, `英文`, `language`, `locale`, `english`, `chinese`],
-        action: () => { localeStore.cycleLocale() },
+        action: () => { void localeStore.cycleLocale() },
       },
       {
         id: `toggle-style-panel`,

--- a/apps/web/src/composables/useComponentCompletion.test.ts
+++ b/apps/web/src/composables/useComponentCompletion.test.ts
@@ -23,8 +23,8 @@ function ctx(doc: string, explicit = false, pos = doc.length) {
   return new CompletionContext(state, pos, explicit)
 }
 
-beforeAll(() => {
-  setAppI18n(setupI18n(`zh-CN`))
+beforeAll(async () => {
+  setAppI18n(await setupI18n(`zh-CN`))
 })
 
 describe(`createComponentCompletionSource`, () => {

--- a/apps/web/src/entrypoints/popup/popup.ts
+++ b/apps/web/src/entrypoints/popup/popup.ts
@@ -6,7 +6,10 @@ import App from './App.vue'
 import '@/assets/index.css'
 import '@/assets/less/theme.less'
 
-const i18n = setupI18n(detectInitialLocale())
-setAppI18n(i18n)
+async function main() {
+  const i18n = await setupI18n(detectInitialLocale())
+  setAppI18n(i18n)
+  createApp(App).use(i18n).mount(`#app`)
+}
 
-createApp(App).use(i18n).mount(`#app`)
+void main()

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -2,26 +2,69 @@ import type { I18n } from 'vue-i18n'
 import type { AppLocale } from './types'
 import { createI18n } from 'vue-i18n'
 import { DEFAULT_LOCALE } from './constants'
-import enUS from './messages/en-US/index'
-import jaJP from './messages/ja-JP/index'
 import zhCN from './messages/zh-CN/index'
-import zhTW from './messages/zh-TW/index'
 
-export function setupI18n(locale: AppLocale = DEFAULT_LOCALE): I18n {
-  return createI18n({
+type LocaleMessages = typeof zhCN
+type LazyLocale = Exclude<AppLocale, `zh-CN`>
+
+const localeLoaders: Record<LazyLocale, () => Promise<{ default: LocaleMessages }>> = {
+  'zh-TW': () => import(`./messages/zh-TW/index`),
+  'en-US': () => import(`./messages/en-US/index`),
+  'ja-JP': () => import(`./messages/ja-JP/index`),
+}
+
+function isLazyLocale(locale: AppLocale): locale is LazyLocale {
+  return locale !== `zh-CN`
+}
+
+const loadedLocales = new Set<AppLocale>([DEFAULT_LOCALE])
+const loadingLocales = new Map<AppLocale, Promise<void>>()
+
+/** Load locale messages into i18n (no-op if already loaded). */
+export async function ensureLocaleMessages(i18n: I18n, locale: AppLocale): Promise<void> {
+  if (loadedLocales.has(locale))
+    return
+
+  if (!isLazyLocale(locale)) {
+    i18n.global.setLocaleMessage(DEFAULT_LOCALE, zhCN)
+    loadedLocales.add(DEFAULT_LOCALE)
+    return
+  }
+
+  const pending = loadingLocales.get(locale)
+  if (pending) {
+    await pending
+    return
+  }
+
+  const loadPromise = (async () => {
+    const { default: messages } = await localeLoaders[locale]()
+    i18n.global.setLocaleMessage(locale, messages)
+    loadedLocales.add(locale)
+    loadingLocales.delete(locale)
+  })()
+
+  loadingLocales.set(locale, loadPromise)
+  await loadPromise
+}
+
+export async function setupI18n(locale: AppLocale = DEFAULT_LOCALE): Promise<I18n> {
+  const i18n = createI18n({
     legacy: false,
     locale,
     fallbackLocale: DEFAULT_LOCALE,
     messages: {
-      'zh-CN': zhCN,
-      'zh-TW': zhTW,
-      'en-US': enUS,
-      'ja-JP': jaJP,
+      [DEFAULT_LOCALE]: zhCN,
     },
   })
+
+  if (isLazyLocale(locale))
+    await ensureLocaleMessages(i18n, locale)
+
+  return i18n
 }
 
-export type MessageSchema = typeof zhCN
+export type MessageSchema = LocaleMessages
 
 declare module 'vue-i18n' {
 

--- a/apps/web/src/services/sync/hydrate.ts
+++ b/apps/web/src/services/sync/hydrate.ts
@@ -95,7 +95,7 @@ export async function hydrateSyncedSettings(appliedKeys: string[]): Promise<void
   if (keys.has(`locale`)) {
     const raw = store.getSync(`locale`)
     if (isAppLocale(raw))
-      useLocaleStore().setLocale(raw)
+      await useLocaleStore().setLocale(raw)
   }
 
   hydrateRef(`openai_type`, keys, aiConfig.type)

--- a/apps/web/src/services/sync/merge.test.ts
+++ b/apps/web/src/services/sync/merge.test.ts
@@ -4,8 +4,8 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import { setAppI18n, setupI18n } from '@/i18n'
 import { mergeRemoteIntoLocal, postToDoc, toMs } from './merge'
 
-beforeAll(() => {
-  setAppI18n(setupI18n(`en-US`))
+beforeAll(async () => {
+  setAppI18n(await setupI18n(`en-US`))
 })
 
 function makePost(overrides: Partial<Post> & Pick<Post, 'id'>): Post {

--- a/apps/web/src/stores/locale.ts
+++ b/apps/web/src/stores/locale.ts
@@ -1,29 +1,17 @@
 import type { AppLocale } from '@/i18n/types'
 import { getNextLocale, LOCALE_STORAGE_KEY } from '@/i18n/constants'
 import { detectInitialLocale } from '@/i18n/detect'
-import { getAppI18n } from '@/i18n/index'
-import enUS from '@/i18n/messages/en-US'
-import jaJP from '@/i18n/messages/ja-JP'
-import zhCN from '@/i18n/messages/zh-CN'
-import zhTW from '@/i18n/messages/zh-TW'
+import { ensureLocaleMessages, getAppI18n } from '@/i18n/index'
+import { t } from '@/i18n/translate'
 import { store } from '@/storage'
-
-const META_BY_LOCALE = {
-  'zh-CN': zhCN.meta,
-  'zh-TW': zhTW.meta,
-  'en-US': enUS.meta,
-  'ja-JP': jaJP.meta,
-} as const
 
 function syncDocumentLocale(locale: AppLocale) {
   document.documentElement.lang = locale
-
-  const meta = META_BY_LOCALE[locale]
-  document.title = meta.title
+  document.title = t(`meta.title`)
 
   const description = document.querySelector(`meta[name="description"]`)
   if (description)
-    description.setAttribute(`content`, meta.description)
+    description.setAttribute(`content`, t(`meta.description`))
 }
 
 /** Sync locale to localStorage for index.html splash before IndexedDB is ready. */
@@ -57,13 +45,14 @@ export const useLocaleStore = defineStore(`locale`, () => {
     { immediate: true },
   )
 
-  function setLocale(value: AppLocale) {
+  async function setLocale(value: AppLocale) {
+    await ensureLocaleMessages(getAppI18n(), value)
     locale.value = value
   }
 
   /** Cycle to the next locale in SUPPORTED_LOCALES order. */
-  function cycleLocale() {
-    locale.value = getNextLocale(locale.value)
+  async function cycleLocale() {
+    await setLocale(getNextLocale(locale.value))
   }
 
   return {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -20,11 +20,53 @@ const isCfPages = process.env.CF_PAGES === `1`
 
 const base = isNetlify || isCfWorkers || isCfPages ? `/` : isUTools ? `./` : `/md/`
 
-const PKG_NAME_SPECIAL_CHARS = /[^\w-]/g
-
 const cloudflarePlugin = isCfWorkers
   ? (await import(`@cloudflare/vite-plugin`)).cloudflare()
   : undefined
+
+/**
+ * Only force-split heavy / cache-friendly libs.
+ * Do NOT assign every node_modules package to its own chunk — that can pull shared
+ * runtime helpers (e.g. __vitePreload) into large optional vendors like @aws-sdk,
+ * forcing them onto the critical path.
+ */
+function manualChunks(id: string): string | undefined {
+  if (!id.includes(`node_modules`))
+    return
+
+  // Fence language packs stay lazy via dynamic import() in codeLanguages.ts
+  if (id.includes(`@codemirror/lang-`) && !id.includes(`@codemirror/lang-markdown`))
+    return
+
+  // Core CodeMirror stack (+ @lezer); keep together for caching
+  if (id.includes(`codemirror`) || id.includes(`@lezer`))
+    return `codemirror`
+
+  // prettier / highlight are large and already loaded via dedicated entry points
+  if (id.includes(`prettier`))
+    return `prettier`
+  if (id.includes(`highlight.js`))
+    return `highlight`
+
+  // Do not force-chunk mermaid / katex / aws-sdk / etc.
+  // Dynamic import() already creates async chunks; naming them here can suck
+  // shared helpers into those vendors and pull them onto the critical path.
+
+  // Vue core ecosystem together to avoid circular chunk dependencies
+  if (
+    id.includes(`/@vue/`)
+    || id.includes(`/@vue+`)
+    || id.includes(`/node_modules/vue/`)
+    || id.includes(`/node_modules/pinia/`)
+    || id.includes(`\\node_modules\\vue\\`)
+    || id.includes(`\\node_modules\\pinia\\`)
+  ) {
+    return `vendor_vue`
+  }
+
+  if (id.includes(`@vueuse`))
+    return `vendor_vueuse`
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
@@ -77,54 +119,7 @@ export default defineConfig(({ mode }) => {
           chunkFileNames: `static/js/md-[name]-[hash].js`,
           entryFileNames: `static/js/md-[name]-[hash].js`,
           assetFileNames: `static/[ext]/md-[name]-[hash].[ext]`,
-          manualChunks(id: string) {
-            if (id.includes(`node_modules`)) {
-              // @lezer/* are CodeMirror's parser primitives, keep together
-              if (id.includes(`codemirror`) || id.includes(`@lezer`))
-                return `codemirror`
-              if (id.includes(`katex`))
-                return `katex`
-              if (id.includes(`prettier`))
-                return `prettier`
-              if (id.includes(`highlight.js`))
-                return `highlight`
-
-              // Handle pnpm virtual store (symlink-resolved paths contain /.pnpm/)
-              if (id.includes(`/.pnpm/`)) {
-                // Group Vue core ecosystem together to avoid circular chunk dependencies
-                if (
-                  id.includes(`/@vue/`)
-                  || id.includes(`/@vue+`)
-                  || id.includes(`/node_modules/vue/`)
-                  || id.includes(`/node_modules/pinia/`)
-                ) {
-                  return `vendor_vue`
-                }
-                if (id.includes(`/@vueuse+`) || id.includes(`/@vueuse/`))
-                  return `vendor_vueuse`
-
-                // Extract actual package name from the real package path within .pnpm store
-                // Format: .pnpm/<outer>@version/node_modules/<actual-pkg>/...
-                const nmIndex = id.lastIndexOf(`/node_modules/`)
-                if (nmIndex !== -1) {
-                  const afterNm = id.slice(nmIndex + `/node_modules/`.length)
-                  const parts = afterNm.split(`/`)
-                  const pkgName = afterNm.startsWith(`@`)
-                    ? `${parts[0].slice(1)}_${parts[1]}`
-                    : parts[0]
-                  return `vendor_${pkgName.replace(PKG_NAME_SPECIAL_CHARS, `_`)}`
-                }
-                return
-              }
-
-              // Handle regular (non-pnpm) node_modules paths
-              const pkg = id
-                .split(`node_modules/`)[1]
-                .split(`/`)[0]
-                .replace(`@`, `npm_`)
-              return `vendor_${pkg}`
-            }
-          },
+          manualChunks,
         },
       },
       // Mermaid is lazy-loaded (~2.15 MB minified); keep limit above that chunk


### PR DESCRIPTION
﻿## Summary
- Fix Vite `manualChunks` so shared helpers (e.g. `__vitePreload`) no longer land inside optional vendors like `@aws-sdk/client-s3`, which previously forced ~261 KB onto the critical path.
- Keep CodeMirror fence language packs out of the core `codemirror` chunk so dynamic `import()` stays lazy.
- Eager-load `zh-CN` i18n messages; load `zh-TW` / `en-US` / `ja-JP` on demand when switching locales.

Initial HTML-referenced assets dropped from ~3.14 MB to ~2.55 MB raw in local builds.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure
1. `pnpm web build` — type-check + production build succeed.
2. `pnpm --filter @md/web test` — 108 tests passed.
3. Inspect `dist/index.html` modulepreload: no AWS SDK / Mermaid / Prettier / KaTeX / non-zh locales on the critical path; `md-preload-helper-*.js` is a tiny shared chunk (~1.2 KB).

## Pre-flight Checklist
- [x] Self-tested locally
- [x] CI-relevant checks run (build + unit tests)
- [x] No unrelated changes included
