### PR TITLE
fix(i18n): store history datetime as epoch ms and format on display

### DIFF
--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -65,7 +65,11 @@ export interface SyncDocument {
   title: string
   content: string
   parentId: string | null
-  history: { datetime: string, content: string }[]
+  /**
+   * history.datetime is epoch ms for new data.
+   * Legacy clients / older sync payloads may still use locale or ISO strings.
+   */
+  history: { datetime: number | string, content: string }[]
   createDatetime: number
   updateDatetime: number
   deleted: boolean

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -14,7 +14,7 @@ import { useLocalizedAllComponents } from '@/composables/useLocalizedBuiltinComp
 import { useLocalizedUploadHostOptions } from '@/composables/useLocalizedUploadHosts'
 import { useSlashCommand } from '@/composables/useSlashCommand'
 import { CONTENT_FONT_LANG } from '@/i18n/constants'
-import { formatLocalDateTime } from '@/i18n/translate'
+import { toStoredDateTime } from '@/lib/format/datetime'
 import { jumpToAdjacentHeading } from '@/lib/markdown/headingNavigation'
 import { contentHasMath, loadMathJax, MATHJAX_READY_EVENT } from '@/lib/preview/mathjax'
 import { validateImageFile } from '@/lib/upload/validate-image'
@@ -635,7 +635,7 @@ onMounted(() => {
     currentPost.history ??= []
     currentPost.history.unshift({
       content: currentPost.content,
-      datetime: formatLocalDateTime(),
+      datetime: toStoredDateTime(),
     })
 
     currentPost.history.length = Math.min(currentPost.history.length, 10)

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -3,6 +3,7 @@ import { CheckSquare, ChevronsDownUp, ChevronsUpDown, Download, Ellipsis, FileTe
 import { initRenderer } from '@md/core'
 import { postProcessHtml, renderMarkdown } from '@md/core/utils'
 import { CONTENT_FONT_LANG } from '@/i18n/constants'
+import { formatLocalDateTime } from '@/i18n/translate'
 import { copyPlain } from '@/lib/browser/clipboard'
 import { downloadMD, exportPostsAsZip } from '@/services/export'
 import { scopeThemeCss } from '@/services/export/share-styles'
@@ -18,8 +19,13 @@ import {
   updatePostSliderMenuOpen,
 } from './postSliderMenu'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const confirmStore = useConfirmStore()
+
+function formatHistoryDatetime(datetime: number | string) {
+  void locale.value
+  return formatLocalDateTime(datetime)
+}
 const uiStore = useUIStore()
 const { isDark, isMobile, isOpenPostSlider } = storeToRefs(uiStore)
 const { toggleShowImportMdDialog } = uiStore
@@ -1181,12 +1187,12 @@ function handleDragEnd() {
         <ul class="w-[160px] shrink-0 space-y-0.5 overflow-y-auto thin-scrollbar">
           <li
             v-for="(item, idx) in currentHistoryList"
-            :key="item.datetime"
+            :key="idx"
             class="flex cursor-pointer items-center rounded-lg px-3 py-2.5 text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-accent-foreground"
             :class="{ 'bg-primary/8 text-primary font-medium': currentHistoryIndex === idx }"
             @click="currentHistoryIndex = idx"
           >
-            <span class="text-xs leading-snug">{{ item.datetime }}</span>
+            <span class="text-xs leading-snug">{{ formatHistoryDatetime(item.datetime) }}</span>
           </li>
         </ul>
 
@@ -1248,12 +1254,12 @@ function handleDragEnd() {
                       :value="String(idx)"
                       :disabled="idx === currentHistoryIndex"
                     >
-                      {{ item.datetime }}
+                      {{ formatHistoryDatetime(item.datetime) }}
                     </SelectItem>
                   </SelectContent>
                 </Select>
                 <span>→</span>
-                <span class="font-medium text-foreground">{{ currentHistoryList[currentHistoryIndex]?.datetime ?? '' }}</span>
+                <span class="font-medium text-foreground">{{ currentHistoryList[currentHistoryIndex] ? formatHistoryDatetime(currentHistoryList[currentHistoryIndex].datetime) : '' }}</span>
               </div>
 
               <div class="flex-1 overflow-hidden rounded-lg border h-[calc(100%-2.5rem)]">

--- a/apps/web/src/i18n/translate.ts
+++ b/apps/web/src/i18n/translate.ts
@@ -13,6 +13,13 @@ export function getLocale(): AppLocale {
   return (typeof current === `string` ? current : current.value) as AppLocale
 }
 
-export function formatLocalDateTime(date: Date = new Date()): string {
-  return date.toLocaleString(getLocale())
+/**
+ * Format a date for display using the current UI locale.
+ * Accepts epoch ms, Date, ISO strings, and legacy locale-formatted strings.
+ */
+export function formatLocalDateTime(date: Date | string | number = new Date()): string {
+  const d = date instanceof Date ? date : new Date(date)
+  if (Number.isNaN(d.getTime()))
+    return String(date)
+  return d.toLocaleString(getLocale())
 }

--- a/apps/web/src/lib/format/datetime.test.ts
+++ b/apps/web/src/lib/format/datetime.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  coerceHistoryDateTime,
+  normalizePostHistory,
+  parseStoredDateTime,
+  toStoredDateTime,
+} from './datetime'
+
+describe(`toStoredDateTime`, () => {
+  it(`returns epoch milliseconds`, () => {
+    const date = new Date(`2024-06-01T12:00:00.000Z`)
+    expect(toStoredDateTime(date)).toBe(Date.parse(`2024-06-01T12:00:00.000Z`))
+  })
+})
+
+describe(`parseStoredDateTime`, () => {
+  it(`parses Date, ISO string and number`, () => {
+    const iso = `2024-06-01T12:00:00.000Z`
+    expect(parseStoredDateTime(new Date(iso))).toBe(Date.parse(iso))
+    expect(parseStoredDateTime(iso)).toBe(Date.parse(iso))
+    expect(parseStoredDateTime(Date.parse(iso))).toBe(Date.parse(iso))
+  })
+
+  it(`parses common locale-formatted strings`, () => {
+    expect(parseStoredDateTime(`2024/6/1 12:00:00`)).toBe(new Date(`2024/6/1 12:00:00`).getTime())
+  })
+
+  it(`returns null for invalid values instead of epoch 0`, () => {
+    expect(parseStoredDateTime(undefined)).toBeNull()
+    expect(parseStoredDateTime(null)).toBeNull()
+    expect(parseStoredDateTime(`not-a-date`)).toBeNull()
+    expect(parseStoredDateTime(Number.NaN)).toBeNull()
+  })
+
+  it(`preserves legitimate epoch 0`, () => {
+    expect(parseStoredDateTime(0)).toBe(0)
+  })
+})
+
+describe(`coerceHistoryDateTime`, () => {
+  it(`converts parseable values to epoch ms`, () => {
+    expect(coerceHistoryDateTime(`2024-01-01T00:00:00.000Z`)).toBe(Date.parse(`2024-01-01T00:00:00.000Z`))
+    expect(coerceHistoryDateTime(1_700_000_000_000)).toBe(1_700_000_000_000)
+  })
+
+  it(`keeps unparseable legacy strings as-is`, () => {
+    expect(coerceHistoryDateTime(`not-a-date`)).toBe(`not-a-date`)
+  })
+})
+
+describe(`normalizePostHistory`, () => {
+  it(`normalizes mixed legacy and numeric entries`, () => {
+    const history = normalizePostHistory([
+      { datetime: `2024-01-01T00:00:00.000Z`, content: `iso` },
+      { datetime: 1_700_000_000_000, content: `ms` },
+      { datetime: `not-a-date`, content: `legacy` },
+    ])
+
+    expect(history).toEqual([
+      { datetime: Date.parse(`2024-01-01T00:00:00.000Z`), content: `iso` },
+      { datetime: 1_700_000_000_000, content: `ms` },
+      { datetime: `not-a-date`, content: `legacy` },
+    ])
+  })
+
+  it(`returns empty array for missing history`, () => {
+    expect(normalizePostHistory(undefined)).toEqual([])
+    expect(normalizePostHistory(null)).toEqual([])
+  })
+})

--- a/apps/web/src/lib/format/datetime.ts
+++ b/apps/web/src/lib/format/datetime.ts
@@ -1,0 +1,36 @@
+import type { PostHistory } from '@/types/post'
+
+/** Epoch ms for persistence (history, sync). */
+export function toStoredDateTime(date: Date = new Date()): number {
+  return date.getTime()
+}
+
+/**
+ * Coerce stored datetime values to epoch ms.
+ * Returns null when the value cannot be parsed (do not substitute epoch 0).
+ */
+export function parseStoredDateTime(value: Date | string | number | null | undefined): number | null {
+  if (value == null)
+    return null
+  if (typeof value === `number`)
+    return Number.isFinite(value) ? value : null
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime()
+  return Number.isFinite(ms) ? ms : null
+}
+
+/**
+ * Normalize a history datetime: prefer epoch ms, keep legacy strings when unparseable.
+ */
+export function coerceHistoryDateTime(value: number | string): number | string {
+  return parseStoredDateTime(value) ?? value
+}
+
+/** Normalize post/sync history entries for persistence and in-memory use. */
+export function normalizePostHistory(
+  history: { datetime: number | string, content: string }[] | undefined | null,
+): PostHistory[] {
+  return (history ?? []).map(({ datetime, content }) => ({
+    datetime: coerceHistoryDateTime(datetime),
+    content: String(content),
+  }))
+}

--- a/apps/web/src/services/sync/merge.test.ts
+++ b/apps/web/src/services/sync/merge.test.ts
@@ -103,7 +103,10 @@ describe(`mergeRemoteIntoLocal`, () => {
     const { posts, changed } = mergeRemoteIntoLocal(local, remote)
     expect(changed).toBe(true)
     expect(posts[0].content).toBe(`remote-new`)
-    expect(posts[0].history.some(h => h.content === `local-old`)).toBe(true)
+    const entry = posts[0].history.find(h => h.content === `local-old`)
+    expect(entry).toBeTruthy()
+    expect(typeof entry!.datetime).toBe(`number`)
+    expect(entry!.datetime).toBe(Date.parse(`2024-01-01T00:00:00.000Z`))
   })
 
   it(`removes local post when newer remote is soft-deleted`, () => {
@@ -145,7 +148,7 @@ describe(`mergeRemoteIntoLocal`, () => {
       id: `shared`,
       content: `same`,
       updateDatetime: new Date(`2024-03-01T00:00:00.000Z`),
-      history: [{ datetime: `2024-01-01 00:00:00`, content: `remote-old` }],
+      history: [{ datetime: Date.parse(`2024-01-01T00:00:00.000Z`), content: `remote-old` }],
     })]
     const remote = [makeDoc({
       id: `shared`,
@@ -156,6 +159,23 @@ describe(`mergeRemoteIntoLocal`, () => {
     const { posts, changed } = mergeRemoteIntoLocal(local, remote)
     expect(changed).toBe(false)
     expect(posts[0].history.filter(h => h.content === `remote-old`)).toHaveLength(1)
+  })
+
+  it(`coerces legacy string history datetimes from remote without writing epoch 0`, () => {
+    const local = [makePost({ id: `shared`, content: `local` })]
+    const remote = [makeDoc({
+      id: `shared-new`,
+      content: `from-cloud`,
+      history: [
+        { datetime: `2024-01-01T00:00:00.000Z`, content: `iso` },
+        { datetime: `not-a-date`, content: `unparseable` },
+      ],
+    })]
+
+    const { posts } = mergeRemoteIntoLocal(local, remote)
+    const imported = posts.find(p => p.id === `shared-new`)!
+    expect(imported.history[0].datetime).toBe(Date.parse(`2024-01-01T00:00:00.000Z`))
+    expect(imported.history[1].datetime).toBe(`not-a-date`)
   })
 
   it(`preserves local collapsed state when remote wins`, () => {

--- a/apps/web/src/services/sync/merge.ts
+++ b/apps/web/src/services/sync/merge.ts
@@ -1,12 +1,9 @@
 import type { SyncDocument } from './types'
 import type { Post, PostHistory } from '@/types/post'
-import { formatLocalDateTime } from '@/i18n/translate'
+import { normalizePostHistory, parseStoredDateTime } from '@/lib/format/datetime'
 
 export function toMs(value: Date | string | number | undefined): number {
-  if (value == null)
-    return 0
-  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime()
-  return Number.isFinite(ms) ? ms : 0
+  return parseStoredDateTime(value) ?? 0
 }
 
 export function postToDoc(post: Post): SyncDocument {
@@ -15,7 +12,7 @@ export function postToDoc(post: Post): SyncDocument {
     title: post.title,
     content: post.content,
     parentId: post.parentId ?? null,
-    history: post.history ?? [],
+    history: normalizePostHistory(post.history),
     createDatetime: toMs(post.createDatetime),
     updateDatetime: toMs(post.updateDatetime),
     deleted: false,
@@ -27,7 +24,7 @@ function docToPost(doc: SyncDocument): Post {
     id: doc.id,
     title: doc.title,
     content: doc.content,
-    history: doc.history ?? [],
+    history: normalizePostHistory(doc.history),
     createDatetime: new Date(doc.createDatetime),
     updateDatetime: new Date(doc.updateDatetime),
     parentId: doc.parentId ?? null,
@@ -45,7 +42,7 @@ function mergeHistory(winner: Post, loserContent: string, loserDatetime: number)
   if (exists)
     return false
   history.push({
-    datetime: formatLocalDateTime(new Date(loserDatetime)),
+    datetime: loserDatetime,
     content: loserContent,
   })
   return true

--- a/apps/web/src/services/sync/types.ts
+++ b/apps/web/src/services/sync/types.ts
@@ -12,7 +12,11 @@ export interface SyncDocument {
   title: string
   content: string
   parentId: string | null
-  history: { datetime: string, content: string }[]
+  /**
+   * history.datetime is epoch ms for new data.
+   * Legacy clients / older sync payloads may still use locale or ISO strings.
+   */
+  history: { datetime: number | string, content: string }[]
   createDatetime: number
   updateDatetime: number
   deleted: boolean

--- a/apps/web/src/storage/db.ts
+++ b/apps/web/src/storage/db.ts
@@ -14,7 +14,7 @@ export interface StoredDocument {
   id: string
   title: string
   content: string
-  history: { datetime: string, content: string }[]
+  history: { datetime: number | string, content: string }[]
   createDatetime: string
   updateDatetime: string
   parentId?: string | null

--- a/apps/web/src/storage/migrate/from-local-storage.ts
+++ b/apps/web/src/storage/migrate/from-local-storage.ts
@@ -4,6 +4,7 @@ import type { IndexedDBEngine } from '@/storage/engines/indexed-db'
 import type { Post } from '@/types/post'
 import { defaultPerThemeSettings, defaultStyleConfig } from '@md/shared/configs'
 import { uuidv4 } from '@md/shared/utils/uuid'
+import { normalizePostHistory } from '@/lib/format/datetime'
 import { getDatabase } from '@/storage/db'
 import {
   isAppLocalStorageKey,
@@ -107,7 +108,7 @@ function parsePosts(raw: string): Post[] | null {
         ...post,
         createDatetime: new Date(post.createDatetime ?? now + index),
         updateDatetime: new Date(post.updateDatetime ?? now + index),
-        history: post.history ?? [],
+        history: normalizePostHistory(post.history),
       }
     })
   }

--- a/apps/web/src/storage/repositories/documents.ts
+++ b/apps/web/src/storage/repositories/documents.ts
@@ -1,5 +1,6 @@
 import type { StoredDocument } from '@/storage/db'
 import type { Post } from '@/types/post'
+import { normalizePostHistory } from '@/lib/format/datetime'
 import { getDatabase } from '@/storage/db'
 import { LEGACY_POSTS_KEY, STORE_DOCUMENTS } from '@/storage/keys'
 import { store } from '@/storage/manager'
@@ -10,10 +11,7 @@ function toStored(post: Post): StoredDocument {
     id: post.id,
     title: post.title,
     content: post.content,
-    history: (post.history ?? []).map(({ datetime, content }) => ({
-      datetime: String(datetime),
-      content: String(content),
-    })),
+    history: normalizePostHistory(post.history),
     createDatetime: new Date(post.createDatetime).toISOString(),
     updateDatetime: new Date(post.updateDatetime).toISOString(),
     parentId: post.parentId ?? null,
@@ -26,7 +24,7 @@ function fromStored(doc: StoredDocument): Post {
     id: doc.id,
     title: doc.title,
     content: doc.content,
-    history: doc.history ?? [],
+    history: normalizePostHistory(doc.history),
     createDatetime: new Date(doc.createDatetime),
     updateDatetime: new Date(doc.updateDatetime),
     parentId: doc.parentId ?? null,
@@ -73,7 +71,7 @@ async function loadFromLegacy(): Promise<Post[]> {
       ...post,
       createDatetime: new Date(post.createDatetime ?? Date.now() + index),
       updateDatetime: new Date(post.updateDatetime ?? Date.now() + index),
-      history: post.history ?? [],
+      history: normalizePostHistory(post.history),
     }))
   }
   catch {

--- a/apps/web/src/stores/post.ts
+++ b/apps/web/src/stores/post.ts
@@ -1,8 +1,9 @@
 import type { Post } from '@/types/post'
 import { uuidv4 } from '@md/shared/utils/uuid'
 import { getDefaultContent } from '@/assets/example/default-content'
-import { formatLocalDateTime, t } from '@/i18n/translate'
+import { t } from '@/i18n/translate'
 import { debounce } from '@/lib/debounce'
+import { normalizePostHistory, toStoredDateTime } from '@/lib/format/datetime'
 import { documentRepo, getLoadedDocuments, store } from '@/storage'
 import { addPrefix } from '@/storage/prefix'
 import { useEditorStore } from '@/stores/editor'
@@ -16,7 +17,7 @@ function createDefaultPost(): Post {
     title: t('store.post.defaultTitle'),
     content,
     history: [
-      { datetime: formatLocalDateTime(), content },
+      { datetime: toStoredDateTime(), content },
     ],
     createDatetime: new Date(),
     updateDatetime: new Date(),
@@ -31,7 +32,7 @@ function normalizePosts(raw: Post[]): Post[] {
       id: post.id ?? uuidv4(),
       createDatetime: new Date(post.createDatetime ?? now + index),
       updateDatetime: new Date(post.updateDatetime ?? now + index),
-      history: post.history ?? [],
+      history: normalizePostHistory(post.history),
     }
   })
 }
@@ -163,7 +164,7 @@ export const usePostStore = defineStore(`post`, () => {
       title,
       content: `# ${title}`,
       history: [
-        { datetime: formatLocalDateTime(), content: `# ${title}` },
+        { datetime: toStoredDateTime(), content: `# ${title}` },
       ],
       createDatetime: new Date(),
       updateDatetime: new Date(),

--- a/apps/web/src/types/post.ts
+++ b/apps/web/src/types/post.ts
@@ -1,5 +1,9 @@
 export interface PostHistory {
-  datetime: string
+  /**
+   * Epoch milliseconds for new entries.
+   * Legacy locale/ISO strings may remain when they cannot be parsed reliably.
+   */
+  datetime: number | string
   content: string
 }
 


### PR DESCRIPTION
﻿## Summary
- Store post history `datetime` as epoch milliseconds instead of locale-formatted strings
- Format history timestamps at render time with the current UI locale so language switches stay consistent
- Normalize legacy locale/ISO history values on load; keep unparseable strings as-is (do not rewrite to epoch 0)

## Related Issue
Closes #1838

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow / CI

## Test Procedure
- [x] Unit tests: `pnpm --filter @md/web exec vitest run src/lib/format/datetime.test.ts src/services/sync/merge.test.ts`
- [ ] Manual: open history dialog, switch locale in preferences, confirm all history timestamps use the new locale format
- [ ] Manual: existing posts with old locale-formatted history still display without becoming `1970-01-01`

## Pre-flight Checklist
- [x] Change is focused on one issue
- [x] Commit follows Conventional Commits
- [x] Includes tests for datetime parse/normalize and sync merge coercion
- [ ] CI passes
