### PR TITLE
fix(web): change command palette shortcut to Mod+Shift+.

### DIFF
--- a/apps/web/src/components/editor/editor-header/HelpDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/HelpDropdown.vue
@@ -67,7 +67,7 @@ function openReleases() {
           <span class="inline-flex items-center gap-0.5">
             <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ ctrlSign }}</kbd>
             <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ shiftSign }}</kbd>
-            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">P</kbd>
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">.</kbd>
           </span>
         </MenubarShortcut>
       </MenubarItem>
@@ -109,7 +109,7 @@ function openReleases() {
           <span class="inline-flex items-center gap-0.5">
             <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ ctrlSign }}</kbd>
             <kbd class="bg-gray-2 px-1 dark:bg-stone-9">{{ shiftSign }}</kbd>
-            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">P</kbd>
+            <kbd class="bg-gray-2 px-1 dark:bg-stone-9">.</kbd>
           </span>
         </MenubarShortcut>
       </MenubarItem>

--- a/apps/web/src/composables/useCommandPalette.ts
+++ b/apps/web/src/composables/useCommandPalette.ts
@@ -244,7 +244,7 @@ export function useCommandPalette() {
     return commands
   }
 
-  const paletteShortcutLabel = `${ctrlSign} ${shiftSign} P`
+  const paletteShortcutLabel = `${ctrlSign} ${shiftSign} .`
 
   return {
     buildCommands,

--- a/apps/web/src/composables/useCommandPaletteHotkey.ts
+++ b/apps/web/src/composables/useCommandPaletteHotkey.ts
@@ -1,13 +1,14 @@
 import { useUIStore } from '@/stores/ui'
 
-/** Register global command palette shortcut Mod+Shift+P */
+/** Register global command palette shortcut Mod+Shift+. */
 export function useCommandPaletteHotkey() {
   const uiStore = useUIStore()
 
   function onKeydown(event: KeyboardEvent) {
     if (!(event.metaKey || event.ctrlKey) || !event.shiftKey)
       return
-    if (event.key.toLowerCase() !== `p`)
+    // Use code so Shift+. (key becomes ">") still matches the period key
+    if (event.code !== `Period`)
       return
 
     event.preventDefault()

--- a/apps/web/src/configs/keyboard-shortcuts.ts
+++ b/apps/web/src/configs/keyboard-shortcuts.ts
@@ -20,7 +20,7 @@ export function buildKeyboardShortcutCategories(): ShortcutCategory[] {
     {
       title: t(`keyboard.category.general`),
       items: [
-        { label: t(`menu.commandPalette`), keys: mod(shiftSign, `P`) },
+        { label: t(`menu.commandPalette`), keys: mod(shiftSign, `.`) },
         { label: t(`menu.preferences`), keys: mod(`,`) },
         { label: t(`keyboard.slashCommand`), keys: [`/`] },
         { label: t(`keyboard.closeSearchPanel`), keys: [`Esc`] },


### PR DESCRIPTION
﻿## Summary

- Change the command palette shortcut from `Mod+Shift+P` to `Mod+Shift+.` so it works in Firefox (where `Mod+Shift+P` opens a private window and cannot be intercepted).
- Match the period key via `event.code === 'Period'` so Shift+. still triggers when `event.key` becomes `>`.
- Update shortcut labels in the help menu, keyboard shortcuts dialog, and palette description.

## Related Issue

Closes #1840

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Test Procedure

1. Open the app in Firefox and Chrome/Edge.
2. Press `Ctrl+Shift+.` (Windows/Linux) or `⌘⇧.` (macOS) — command palette should open.
3. Confirm `Ctrl/Cmd+Shift+P` no longer claims to open the palette in UI labels (Help → Command Palette, Keyboard Shortcuts).
4. In Firefox, confirm `Ctrl/Cmd+Shift+P` still opens a private window (browser behavior), while `Mod+Shift+.` opens the palette.

## Pre-flight Checklist

- [x] Change is focused on a single concern
- [x] Related UI labels updated with the new shortcut
- [x] Commit follows Conventional Commits
