### PR TITLE
chore: configure i18n Ally for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["Vue.volar"]
+  "recommendations": [
+    "Vue.volar",
+    "lokalise.i18n-ally"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,14 @@
     "scss",
     "pcss",
     "postcss"
-  ]
+  ],
+
+  // i18n Ally
+  "i18n-ally.sourceLanguage": "zh-CN",
+  "i18n-ally.localesPaths": ["apps/web/src/i18n/messages"],
+  "i18n-ally.keystyle": "nested",
+  "i18n-ally.enabledFrameworks": ["vue"],
+  "i18n-ally.enabledParsers": ["ts"],
+  "i18n-ally.annotations": true,
+  "i18n-ally.keysInUse": ["apps/web/src/**/*.vue", "apps/web/src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "./packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "."
+  },
   "exclude": ["apps", "packages"]
 }


### PR DESCRIPTION
适配 i18n-ally 配置

<img width="1148" height="1037" alt="image" src="https://github.com/user-attachments/assets/0dd5a5e9-130e-4fee-be2b-7744128dd0b3" />