### PR TITLE
build(deps): remove dead inflight override pointing to unpublished package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ catalogs:
 overrides:
   '@codemirror/state': 6.7.1
   '@codemirror/view': 6.43.6
+  '@hono/node-server': ^2.0.5
   '@typescript-eslint/eslint-plugin': 8.65.0
   '@typescript-eslint/parser': 8.65.0
   '@typescript-eslint/project-service': 8.65.0
@@ -46,7 +47,6 @@ overrides:
   '@typescript-eslint/utils': 8.65.0
   '@typescript-eslint/visitor-keys': 8.65.0
   '@webext-core/isolated-element': 1.1.4
-  '@hono/node-server': ^2.0.5
   adm-zip: ^0.6.0
   ajv@^8: ^8.20.0
   bn.js: '>=5.2.5'
@@ -62,7 +62,6 @@ overrides:
   glob@<8: ^13.0.6
   glob@^10: ^13.0.6
   glob@^11: ^11.1.0
-  inflight: npm:@hishprorg/voluptates-laborum@^2.0.0
   ini: '>=7.0.0'
   js-yaml: ^4.3.0
   jsdom>undici: ^7.25.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,6 @@ overrides:
   glob@<8: ^13.0.6
   glob@^10: ^13.0.6
   glob@^11: ^11.1.0
-  inflight: npm:@hishprorg/voluptates-laborum@^2.0.0
   ini: '>=7.0.0'
   js-yaml: ^4.3.0
   jsdom>undici: ^7.25.0


### PR DESCRIPTION
## 变更动机

`pnpm-workspace.yaml` 中 `inflight` 的 override 指向 `@hishprorg/voluptates-laborum`（#1185 引入）。该包目前在 npm 官方源已不存在（404）：

```
$ npm view @hishprorg/voluptates-laborum --registry https://registry.npmjs.org
npm error 404  '@hishprorg/voluptates-laborum@*' is not in this registry.
```

同时，依赖树中已没有任何包会解析到 `inflight`（`glob` 已通过 overrides 统一升到 v11/v13，新版不再依赖它），`pnpm-lock.yaml` 中也没有该包的安装条目——这条 override 目前是死配置。

保留它的风险：将来若某个间接依赖重新引入 `inflight`，将会解析到一个官方源已下架、来源与内容无法审计的替身包（该包名属于 lorem-ipsum 风格批量发布的 fork 农场，npm 已清理）。删除后，即使 `inflight` 回归也只会装到 npm 原版（仅废弃/内存泄漏告警，无安全风险）。

## 变更内容

- 删除 `pnpm-workspace.yaml` 中 `inflight: npm:@hishprorg/voluptates-laborum@^2.0.0` 一行
- 使用 pnpm 11.11.0（与 CI 版本一致）执行 `pnpm install --lockfile-only` 重新生成锁文件

## 影响范围

- `pnpm-lock.yaml` 仅顶部 overrides 快照变化，1579 个包的解析结果零变化（`resolved 1579, downloaded 0, added 0`）
- diff 中 `@hono/node-server` 两行仅为 pnpm 11.11.0 对 overrides 键排序的规范化，值未变
- 无代码变更，不影响构建产物
