### PR TITLE
feat(web): add transition animation to back-to-top button

### DIFF
--- a/apps/web/src/components/ui/back-top/BackTop.vue
+++ b/apps/web/src/components/ui/back-top/BackTop.vue
@@ -20,6 +20,16 @@ const visible = ref(false)
 
 const target = ref<Target>(null)
 
+// Only emit the sides that are actually provided, otherwise Vue would
+// interpolate `undefined` into the template literal (e.g. `undefinedpx`)
+// and set an invalid CSS value instead of omitting the property.
+const positionStyle = computed(() => ({
+  left: props.left != null ? `${props.left}px` : undefined,
+  top: props.top != null ? `${props.top}px` : undefined,
+  right: props.right != null ? `${props.right}px` : undefined,
+  bottom: props.bottom != null ? `${props.bottom}px` : undefined,
+}))
+
 function scrollToTop(e: MouseEvent) {
   target.value?.scrollTo({ top: 0, left: 0, behavior: `smooth` })
   props.onClick?.(e)
@@ -61,7 +71,7 @@ onUnmounted(() => {
       variant="outline"
       size="icon"
       class="absolute z-50 rounded-full border bg-background/90 text-foreground/80 shadow-md backdrop-blur-sm hover:bg-background hover:text-foreground hover:shadow-lg"
-      :style="{ left: `${left}px`, top: `${top}px`, right: `${right}px`, bottom: `${bottom}px` }"
+      :style="positionStyle"
       :aria-label="t('common.backToTop')"
       :title="t('common.backToTop')"
       @click="scrollToTop"
@@ -81,5 +91,17 @@ onUnmounted(() => {
 .back-top-leave-to {
   opacity: 0;
   transform: translateY(10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .back-top-enter-active,
+  .back-top-leave-active {
+    transition: none;
+  }
+
+  .back-top-enter-from,
+  .back-top-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/apps/web/src/components/ui/back-top/BackTop.vue
+++ b/apps/web/src/components/ui/back-top/BackTop.vue
@@ -55,16 +55,31 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <Button
-    v-if="visible"
-    variant="outline"
-    size="icon"
-    class="absolute z-50 rounded-full border-border/40 bg-background/60 text-muted-foreground/70 backdrop-blur-sm hover:bg-background/80 hover:text-foreground"
-    :style="{ left: `${left}px`, top: `${top}px`, right: `${right}px`, bottom: `${bottom}px` }"
-    :aria-label="t('common.backToTop')"
-    :title="t('common.backToTop')"
-    @click="scrollToTop"
-  >
-    <ArrowUpFromLine />
-  </Button>
+  <Transition name="back-top">
+    <Button
+      v-if="visible"
+      variant="outline"
+      size="icon"
+      class="absolute z-50 rounded-full border bg-background/90 text-foreground/80 shadow-md backdrop-blur-sm hover:bg-background hover:text-foreground hover:shadow-lg"
+      :style="{ left: `${left}px`, top: `${top}px`, right: `${right}px`, bottom: `${bottom}px` }"
+      :aria-label="t('common.backToTop')"
+      :title="t('common.backToTop')"
+      @click="scrollToTop"
+    >
+      <ArrowUpFromLine class="size-5" />
+    </Button>
+  </Transition>
 </template>
+
+<style scoped>
+.back-top-enter-active,
+.back-top-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.back-top-enter-from,
+.back-top-leave-to {
+  opacity: 0;
+  transform: translateY(10px);
+}
+</style>


### PR DESCRIPTION
回到顶部按钮添加了淡入淡出过渡动画，并优化了按钮的视觉样式。