### PR TITLE
refactor(web): remove palette description from shortcuts dialog

### DIFF
--- a/apps/web/src/components/editor/editor-header/KeyboardShortcutsDialog.vue
+++ b/apps/web/src/components/editor/editor-header/KeyboardShortcutsDialog.vue
@@ -2,7 +2,6 @@
 import { Keyboard } from '@lucide/vue'
 import { computed } from 'vue'
 import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
-import { useCommandPalette } from '@/composables/useCommandPalette'
 import { buildKeyboardShortcutCategories } from '@/configs/keyboard-shortcuts'
 
 const props = defineProps<{
@@ -14,7 +13,6 @@ const emit = defineEmits<{
 }>()
 
 const { t, locale } = useI18n()
-const { paletteShortcutLabel } = useCommandPalette()
 
 const shortcutCategories = computed(() => {
   void locale.value
@@ -31,7 +29,6 @@ const dialogOpen = computed({
   <PanelDialog
     v-model:open="dialogOpen"
     :title="t('menu.keyboardShortcuts')"
-    :description="t('keyboard.description', { shortcut: paletteShortcutLabel })"
     :icon="Keyboard"
     size="2xl"
   >

--- a/apps/web/src/i18n/messages/en-US/chrome.ts
+++ b/apps/web/src/i18n/messages/en-US/chrome.ts
@@ -110,7 +110,6 @@ export default {
     formulaBlock: `Formula`,
   },
   keyboard: {
-    description: `Command palette: {shortcut}`,
     category: {
       general: `General`,
       edit: `Edit`,

--- a/apps/web/src/i18n/messages/ja-JP/chrome.ts
+++ b/apps/web/src/i18n/messages/ja-JP/chrome.ts
@@ -110,7 +110,6 @@ export default {
     formulaBlock: `数式`,
   },
   keyboard: {
-    description: `コマンドパレット: {shortcut}`,
     category: {
       general: `一般`,
       edit: `編集`,

--- a/apps/web/src/i18n/messages/zh-CN/chrome.ts
+++ b/apps/web/src/i18n/messages/zh-CN/chrome.ts
@@ -110,7 +110,6 @@ export default {
     formulaBlock: `公式`,
   },
   keyboard: {
-    description: `命令面板：{shortcut}`,
     category: {
       general: `通用`,
       edit: `编辑`,

--- a/apps/web/src/i18n/messages/zh-TW/chrome.ts
+++ b/apps/web/src/i18n/messages/zh-TW/chrome.ts
@@ -110,7 +110,6 @@ export default {
     formulaBlock: `公式`,
   },
   keyboard: {
-    description: `命令面板：{shortcut}`,
     category: {
       general: `通用`,
       edit: `編輯`,


### PR DESCRIPTION
移除快捷键弹窗中的命令面板描述，与内容有所重复