### PR TITLE
refactor(web): unify markdown help dialog icon with help menu

### DIFF
--- a/apps/web/src/components/editor/editor-header/MarkdownHelpDialog.vue
+++ b/apps/web/src/components/editor/editor-header/MarkdownHelpDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
-import { BookOpen, Code2, FileText, FunctionSquare, PieChart } from '@lucide/vue'
+import { BookText, Code2, FileText, FunctionSquare, PieChart } from '@lucide/vue'
 import { computed, ref } from 'vue'
 import PanelDialog from '@/components/shared/panel-dialog/PanelDialog.vue'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -43,7 +43,7 @@ const syntaxIcons: Record<string, Component> = {
   code: Code2,
   math: FunctionSquare,
   diagram: PieChart,
-  other: BookOpen,
+  other: BookText,
 }
 
 const syntaxCategories = computed<SyntaxCategory[]>(() =>
@@ -76,7 +76,7 @@ async function copySyntax(syntax: string) {
     v-model:open="dialogOpen"
     :title="t('markdownHelp.title')"
     :description="t('markdownHelp.description')"
-    :icon="BookOpen"
+    :icon="BookText"
     size="2xl"
   >
     <div class="px-4 py-4 sm:px-6">


### PR DESCRIPTION
统一「语法帮助」在菜单与弹窗中的 icon 显示