### PR TITLE
fix(web): reset replace panel state when closing search tab

### DIFF
--- a/apps/web/src/components/ui/search-tab/SearchTab.vue
+++ b/apps/web/src/components/ui/search-tab/SearchTab.vue
@@ -81,6 +81,7 @@ watch([indexOfMatch, matchPositions], () => {
 watch(showSearchTab, async () => {
   if (!showSearchTab.value) {
     clearAllMarks()
+    showReplace.value = false
     findInSelection.value = false
     selectionRange.value = null
   }


### PR DESCRIPTION
关闭搜索面板时，重置替换区域的展开状态，避免下次打开时残留