### PR TITLE
fix(vscode): configure i18n-ally display and fallback languages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,6 +49,7 @@
 
   // i18n Ally
   "i18n-ally.sourceLanguage": "zh-CN",
+  "i18n-ally.displayLanguage": "zh-CN",
   "i18n-ally.localesPaths": ["apps/web/src/i18n/messages"],
   "i18n-ally.keystyle": "nested",
   "i18n-ally.enabledFrameworks": ["vue"],


### PR DESCRIPTION
配置 i18n-ally 的显示语言与回退语言，修复因缺失通用 en 语言包导致的误报缺失翻译警告。