### PR TITLE
fix(web): keep post list item height consistent in multi-select mode

### DIFF
--- a/apps/web/src/components/editor/post-slider/PostItem.vue
+++ b/apps/web/src/components/editor/post-slider/PostItem.vue
@@ -226,7 +226,7 @@ function cancelInlineRename() {
         <DropdownMenuTrigger as-child>
           <button
             type="button"
-            class="flex shrink-0 items-center justify-center size-6 rounded-md text-muted-foreground/40 transition-all duration-150 hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 data-[state=open]:opacity-100 data-[state=open]:text-foreground"
+            class="flex shrink-0 items-center justify-center size-5 rounded-md text-muted-foreground/40 transition-all duration-150 hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 data-[state=open]:opacity-100 data-[state=open]:text-foreground"
             :class="isMobile ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
             :aria-label="t('common.moreActions')"
             :title="t('common.moreActions')"


### PR DESCRIPTION
将文章列表项的展开按钮由 size-6 改为 size-5，使进入多选模式前后列表项高度保持一致，避免切到多选模式时各行变矮。

<img width="410" height="404" alt="PixPin_2026-07-29_10-32-14" src="https://github.com/user-attachments/assets/6a3f45dc-3a8d-46c6-8a21-40456604459c" />
