### PR TITLE
fix(web): parse text/plain JSON responses in mp image upload

### DIFF
--- a/apps/web/src/services/upload/providers.test.ts
+++ b/apps/web/src/services/upload/providers.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// In-memory replacement for the persistent storage engine
+const memStore = new Map<string, string>()
+
+vi.mock(`@/i18n/translate`, () => ({
+  t: (key: string) => key,
+}))
+
+vi.mock(`@/storage`, () => ({
+  store: {
+    get: async (key: string) => memStore.get(key) ?? null,
+    set: async (key: string, value: string) => {
+      memStore.set(key, value)
+    },
+    setJSON: async (key: string, value: unknown) => {
+      memStore.set(key, JSON.stringify(value))
+    },
+  },
+}))
+
+vi.mock(`@/services/upload/client`, () => ({
+  uploadDefaultImage: vi.fn(),
+}))
+
+const { fileUpload } = await import(`./providers`)
+
+function wechatResponse(body: unknown, contentType: string) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': contentType },
+  })
+}
+
+interface WechatStubs {
+  tokenBody: unknown
+  uploadBody: unknown
+  // WeChat quirks: uploadimg answers JSON with a text/plain Content-Type
+  uploadContentType?: string
+}
+
+function stubWechatApi({ tokenBody, uploadBody, uploadContentType = `text/plain` }: WechatStubs) {
+  const mock = vi.fn((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes(`stable_token`))
+      return Promise.resolve(wechatResponse(tokenBody, `application/json`))
+    if (url.includes(`media/uploadimg`) || url.includes(`material/add_material`))
+      return Promise.resolve(wechatResponse(uploadBody, uploadContentType))
+    return Promise.reject(new Error(`unexpected url: ${url}`))
+  })
+  vi.stubGlobal(`fetch`, mock)
+  return mock
+}
+
+const pngFile = () => new File([new Uint8Array(1024)], `a.png`, { type: `image/png` })
+
+describe(`mp (WeChat Official Account) image upload`, () => {
+  beforeEach(() => {
+    memStore.clear()
+    memStore.set(`imgHost`, `mp`)
+    memStore.set(`mpConfig`, JSON.stringify({ appID: `wx1234567890`, appsecret: `secret` }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // doocs/md#1877: the upload succeeds on WeChat's side but answers with
+  // Content-Type text/plain; the client must still read the returned URL
+  it(`returns the image URL when WeChat answers JSON with a text/plain Content-Type`, async () => {
+    stubWechatApi({
+      tokenBody: { access_token: `TOKEN`, expires_in: 7200 },
+      uploadBody: { url: `https://mmbiz.qpic.cn/pic` },
+    })
+
+    await expect(fileUpload(`content`, pngFile())).resolves.toBe(`https://mmbiz.qpic.cn/pic`)
+  })
+
+  it(`reuses the cached access_token while it is still valid`, async () => {
+    const mock = stubWechatApi({
+      tokenBody: { access_token: `TOKEN`, expires_in: 7200 },
+      uploadBody: { url: `https://mmbiz.qpic.cn/pic` },
+    })
+
+    await fileUpload(`content`, pngFile())
+    await fileUpload(`content`, pngFile())
+
+    const tokenCalls = mock.mock.calls.filter(([input]) => String(input).includes(`stable_token`))
+    expect(tokenCalls).toHaveLength(1)
+  })
+
+  it(`throws with the WeChat errcode detail when the upload returns no URL`, async () => {
+    stubWechatApi({
+      tokenBody: { access_token: `TOKEN`, expires_in: 7200 },
+      uploadBody: { errcode: 41005, errmsg: `media data missing` },
+    })
+
+    await expect(fileUpload(`content`, pngFile())).rejects.toThrow(
+      `upload.provider.uploadNoUrl: [41005] media data missing`,
+    )
+  })
+
+  it(`throws with the errcode detail when the access_token request fails (e.g. IP not in whitelist)`, async () => {
+    stubWechatApi({
+      tokenBody: { errcode: 40164, errmsg: `invalid ip 1.2.3.4 not in whitelist hint` },
+      uploadBody: { url: `https://mmbiz.qpic.cn/pic` },
+    })
+
+    await expect(fileUpload(`content`, pngFile())).rejects.toThrow(
+      `upload.provider.accessTokenFailed: [40164] invalid ip 1.2.3.4 not in whitelist hint`,
+    )
+  })
+})

--- a/apps/web/src/services/upload/providers.ts
+++ b/apps/web/src/services/upload/providers.ts
@@ -447,6 +447,11 @@ async function getMpToken(appID: string, appsecret: string, proxyOrigin?: string
     await store.setJSON(`mpToken:${appID}`, tokenInfo)
     return res.access_token
   }
+  // Surface WeChat error detail (e.g. errcode 40164: egress IP not in the
+  // MP platform IP whitelist) to make misconfiguration diagnosable
+  if (res.errcode) {
+    throw new Error(`${t(`upload.provider.accessTokenFailed`)}: [${res.errcode}] ${res.errmsg}`)
+  }
   return ``
 }
 const isCfWorkers = import.meta.env.CF_WORKERS === `1`
@@ -481,10 +486,11 @@ async function mpFileUpload(file: File) {
     url = url.replace(`https://api.weixin.qq.com`, proxyOrigin)
   }
 
-  const res = await fetch<any, { url: string }>(url, requestOptions)
+  const res = await fetch<any, { url?: string, errcode?: number, errmsg?: string }>(url, requestOptions)
 
   if (!res.url) {
-    throw new Error(t(`upload.provider.uploadNoUrl`))
+    const detail = res.errcode ? `: [${res.errcode}] ${res.errmsg}` : ``
+    throw new Error(t(`upload.provider.uploadNoUrl`) + detail)
   }
 
   let imageUrl = res.url

--- a/packages/shared/src/utils/fetch.test.ts
+++ b/packages/shared/src/utils/fetch.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import fetch from './fetch'
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    ...init,
+    headers: { 'content-type': `application/json`, ...init?.headers },
+  })
+}
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const mock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => Promise.resolve(handler(String(input), init)))
+  vi.stubGlobal(`fetch`, mock)
+  return mock
+}
+
+describe(`fetch utils`, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it(`parses application/json responses`, async () => {
+    stubFetch(() => jsonResponse({ url: `https://example.com/a.png` }))
+
+    const res = await fetch<any, { url: string }>(`https://api.example.com/upload`, { method: `POST` })
+    expect(res.url).toBe(`https://example.com/a.png`)
+  })
+
+  // Regression test for doocs/md#1877: WeChat media/uploadimg answers a JSON
+  // body with Content-Type text/plain, which must still be parsed as JSON
+  it(`parses JSON bodies returned with a text/plain Content-Type`, async () => {
+    stubFetch(() => new Response(JSON.stringify({ url: `https://mmbiz.qpic.cn/pic` }), {
+      status: 200,
+      headers: { 'content-type': `text/plain` },
+    }))
+
+    const res = await fetch<any, { url: string }>(`https://api.weixin.qq.com/cgi-bin/media/uploadimg`, { method: `POST` })
+    expect(res.url).toBe(`https://mmbiz.qpic.cn/pic`)
+  })
+
+  it(`returns non-JSON text bodies as strings`, async () => {
+    stubFetch(() => new Response(`plain text`, {
+      status: 200,
+      headers: { 'content-type': `text/plain` },
+    }))
+
+    const res = await fetch(`https://api.example.com/raw`)
+    expect(res).toBe(`plain text`)
+  })
+
+  it(`keeps malformed JSON-looking text as a string`, async () => {
+    stubFetch(() => new Response(`{broken`, {
+      status: 200,
+      headers: { 'content-type': `text/plain` },
+    }))
+
+    const res = await fetch(`https://api.example.com/raw`)
+    expect(res).toBe(`{broken`)
+  })
+
+  it(`rejects on empty response bodies`, async () => {
+    stubFetch(() => new Response(``, {
+      status: 200,
+      headers: { 'content-type': `text/plain` },
+    }))
+
+    await expect(fetch(`https://api.example.com/empty`)).rejects.toThrow(`Empty response`)
+  })
+
+  it(`rejects with the status code on non-OK responses`, async () => {
+    stubFetch(() => jsonResponse({ errcode: 40013 }, { status: 401 }))
+
+    await expect(fetch(`https://api.example.com/fail`)).rejects.toThrow(`Request failed with status 401`)
+  })
+
+  it(`serializes object bodies as JSON with a Content-Type header`, async () => {
+    const mock = stubFetch(() => jsonResponse({ ok: true }))
+
+    await fetch(`https://api.example.com/post`, { method: `POST`, data: { a: 1 } })
+
+    const init = mock.mock.calls[0][1]
+    expect(init?.body).toBe(JSON.stringify({ a: 1 }))
+    expect((init?.headers as Record<string, string>)[`Content-Type`]).toBe(`application/json`)
+  })
+
+  it(`passes FormData bodies through without a manual Content-Type`, async () => {
+    const mock = stubFetch(() => jsonResponse({ ok: true }))
+
+    const form = new FormData()
+    form.append(`media`, new Blob([`x`]), `a.png`)
+    await fetch(`https://api.example.com/upload`, {
+      method: `POST`,
+      headers: { 'content-type': `multipart/form-data` },
+      data: form,
+    })
+
+    const init = mock.mock.calls[0][1]
+    expect(init?.body).toBe(form)
+    expect((init?.headers as Record<string, string>)[`content-type`]).toBeUndefined()
+  })
+})

--- a/packages/shared/src/utils/fetch.ts
+++ b/packages/shared/src/utils/fetch.ts
@@ -6,6 +6,21 @@ export interface RequestConfig {
   timeout?: number
 }
 
+// Some APIs (e.g. WeChat media/uploadimg) return a JSON body with a
+// text/plain Content-Type. Mirror axios's forcedJSONParsing behavior so
+// such responses are still parsed into objects.
+function tryParseJson(text: string): unknown {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith(`{`) && !trimmed.startsWith(`[`))
+    return text
+  try {
+    return JSON.parse(trimmed)
+  }
+  catch {
+    return text
+  }
+}
+
 async function request<T = unknown>(config: RequestConfig): Promise<T> {
   const method = (config.method || `GET`).toUpperCase()
   const url = config.url || ``
@@ -45,7 +60,7 @@ async function request<T = unknown>(config: RequestConfig): Promise<T> {
     const contentType = res.headers.get(`content-type`) || ``
     const data = contentType.includes(`application/json`)
       ? await res.json()
-      : await res.text()
+      : tryParseJson(await res.text())
 
     if (!res.ok) {
       const err = Object.assign(new Error(`Request failed with status ${res.status}`), {


### PR DESCRIPTION
## Summary

微信公众号图床上传图片时，图片实际已成功上传（素材库可见），客户端却报错「上传失败，未获取到URL」。

根因是 #1787 引入的回归：axios 被替换为自研 fetch 封装后，仅在 `Content-Type` 为 `application/json` 时才解析 JSON。而微信 `media/uploadimg` 等接口的已知怪癖是返回 JSON 正文但 `Content-Type` 为 `text/plain`，导致响应被当作纯字符串，`res.url` 为 `undefined`。

变更内容：

- `packages/shared/src/utils/fetch.ts`：恢复 axios `forcedJSONParsing` 式的容错解析——非 JSON Content-Type 的响应体若形如 JSON（`{`/`[` 开头）则尝试 `JSON.parse`，失败则原样返回文本
- `apps/web/src/services/upload/providers.ts`：mp token / 上传失败时，错误信息附带微信返回的 `[errcode] errmsg` 细节（如 errcode 40164 = 出口 IP 不在公众号 IP 白名单，便于该 issue 这类动态公网 IP 场景自查）
- 新增 12 个测试用例：`fetch.test.ts`（8 个，含 text/plain JSON 回归用例）与 `providers.test.ts`（4 个，端到端复现 issue 场景）

## Related Issue

Closes #1877

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Test Procedure

- `pnpm --filter @md/shared exec vitest run`：12/12 通过
- `pnpm --filter @md/web exec vitest run`：122/122 通过（含全部既有测试，无回归）
- 变异测试：临时回退 `fetch.ts` 修复后重跑，新测试精确复现 issue 现象（微信已返回 URL，客户端抛 `uploadNoUrl`），恢复修复后全绿，证明测试有效锁定该回归
- `pnpm run type-check`：全部 10 个 workspace 项目通过
- ESLint：修改文件无错误

## Pre-flight Checklist

- [x] 代码通过 lint 与类型检查
- [x] 新增/变更功能已自测并补充单元测试
- [x] 一个 PR 只做一件事（修复 + 对应测试）
- [x] 提交信息遵循 Conventional Commits
