### PR TITLE
fix(web): deduplicate filenames when exporting posts as zip

### DIFF
--- a/apps/web/src/services/export/markdown.ts
+++ b/apps/web/src/services/export/markdown.ts
@@ -11,9 +11,18 @@ export function downloadMD(doc: string, title: string = `untitled`) {
 export async function exportPostsAsZip(posts: Array<{ title: string, content: string }>) {
   const JSZip = (await import(`jszip`)).default
   const zip = new JSZip()
+  const usedNames = new Set<string>()
   posts.forEach(({ title, content }) => {
     const safeTitle = sanitizeTitle(title)
-    zip.file(`${safeTitle}.md`, content)
+    let filename = `${safeTitle}.md`
+    if (usedNames.has(filename)) {
+      let counter = 1
+      while (usedNames.has(`${safeTitle}-${counter}.md`))
+        counter++
+      filename = `${safeTitle}-${counter}.md`
+    }
+    usedNames.add(filename)
+    zip.file(filename, content)
   })
   const blob = await zip.generateAsync({ type: `blob` })
   const date = new Date().toISOString().slice(0, 10)


### PR DESCRIPTION
修复：导出全部文章时，如存在重名文章，导出只会有一个。对相同标题的文件名自动追加 -1、-2 序号去重。