### PR TITLE
fix(web): prevent focus ring clipping in diff tab select

### DIFF
--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -1252,7 +1252,7 @@ function handleDragEnd() {
               </div>
             </TabsContent>
 
-            <TabsContent value="diff" class="flex-1 overflow-hidden mt-2">
+            <TabsContent value="diff" class="flex-1 overflow-hidden mt-2 pt-1">
               <div class="flex items-center gap-2 mb-2 text-xs text-muted-foreground shrink-0">
                 <span>{{ t('post.compareLabel') }}</span>
                 <Select v-model="compareTargetIndex">


### PR DESCRIPTION
修复：轮廓溢出

<img width="611" height="190" alt="image" src="https://github.com/user-attachments/assets/5fea6639-0d0e-46b5-b280-eb8df8b63935" />
