### PR TITLE
feat(web): show header actions as text on desktop and icons on mobile

### DIFF
--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Post, PostAccount } from '@md/shared/types'
-import { Check, ChevronDown, ChevronRight, Info, Loader2, Minus, Send } from '@lucide/vue'
+import { Check, ChevronDown, ChevronRight, Info, Loader2, Minus } from '@lucide/vue'
 import { CheckboxIndicator, CheckboxRoot, Primitive } from 'reka-ui'
 import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
@@ -307,7 +307,6 @@ onBeforeMount(() => {
     <Dialog v-model:open="dialogVisible" @update:open="onUpdate">
       <DialogTrigger>
         <Button v-if="!isMobile" variant="outline" class="h-9">
-          <Send class="mr-2 h-4 w-4" />
           {{ t('postInfo.publish') }}
         </Button>
       </DialogTrigger>

--- a/apps/web/src/components/editor/editor-header/index.vue
+++ b/apps/web/src/components/editor/editor-header/index.vue
@@ -262,26 +262,28 @@ function copyToWeChat() {
     <div class="flex flex-wrap items-center gap-2">
       <Button
         variant="outline"
-        class="h-9"
+        class="h-9 max-md:w-9 max-md:px-0"
         :disabled="isCopying"
         :aria-busy="isCopying"
+        :aria-label="t('header.copy')"
         @click="copyToWeChat"
       >
-        <Loader2 v-if="isCopying" class="mr-2 h-4 w-4 animate-spin" />
-        <Copy v-else class="mr-2 h-4 w-4" />
-        <span>{{ t('header.copy') }}</span>
+        <Loader2 v-if="isCopying" class="h-4 w-4 animate-spin md:mr-2" />
+        <Copy v-else class="h-4 w-4 md:hidden" />
+        <span class="max-md:hidden">{{ t('header.copy') }}</span>
       </Button>
 
       <PostInfo class="hidden md:inline-flex" />
 
       <Button
         variant="outline"
-        class="h-9"
+        class="h-9 max-md:w-9 max-md:px-0"
         :class="{ 'bg-accent text-accent-foreground': isOpenRightSlider }"
+        :aria-label="t('header.style')"
         @click="isOpenRightSlider = !isOpenRightSlider"
       >
-        <Palette class="mr-2 h-4 w-4" />
-        <span>{{ t('header.style') }}</span>
+        <Palette class="h-4 w-4 md:hidden" />
+        <span class="max-md:hidden">{{ t('header.style') }}</span>
       </Button>
     </div>
   </header>


### PR DESCRIPTION
## Summary

- Editor header actions (Copy, Style) now render as text-only buttons on desktop and collapse to icon-only square buttons on mobile, saving horizontal space on small screens.
- Publish button is text-only on desktop and remains hidden on mobile, since publishing depends on the companion browser extension.
- Icon-only buttons include `aria-label` for accessibility.

## Type of Change

- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation

## Test Procedure

- Desktop viewport (>=768px): Copy / Publish / Style show labels without icons; Copy shows a spinner next to the label while copying.
- Mobile viewport (<768px): Copy and Style collapse to icon-only square buttons; Copy shows the spinner in place of the icon while copying; Publish stays hidden.
