### PR TITLE
feat(web): adapt theme options to compact blocks in narrow right slider

### DIFF
--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -205,15 +205,18 @@ const pickColorsContainer = useTemplateRef<HTMLElement | undefined>(`pickColorsC
 const format = ref<Format>(`rgb`)
 const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
 
+// Grid width below which option buttons switch to compact blocks
+const COMPACT_GRID_WIDTH = 280
+
 // Show color swatch only when right sidebar is narrow
 const colorGridRef = useTemplateRef<HTMLElement | undefined>(`colorGridRef`)
 const { width: colorGridWidth } = useElementSize(colorGridRef)
-const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth.value < 280)
+const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth.value < COMPACT_GRID_WIDTH)
 
 // Shrink theme buttons to compact blocks when right sidebar is narrow
 const themeGridRef = useTemplateRef<HTMLElement | undefined>(`themeGridRef`)
 const { width: themeGridWidth } = useElementSize(themeGridRef)
-const isThemeCompact = computed(() => themeGridWidth.value > 0 && themeGridWidth.value < 280)
+const isThemeCompact = computed(() => themeGridWidth.value > 0 && themeGridWidth.value < COMPACT_GRID_WIDTH)
 </script>
 
 <template>

--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -209,6 +209,11 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
 const colorGridRef = useTemplateRef<HTMLElement | undefined>(`colorGridRef`)
 const { width: colorGridWidth } = useElementSize(colorGridRef)
 const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth.value < 280)
+
+// Shrink theme buttons to compact blocks when right sidebar is narrow
+const themeGridRef = useTemplateRef<HTMLElement | undefined>(`themeGridRef`)
+const { width: themeGridWidth } = useElementSize(themeGridRef)
+const isThemeCompact = computed(() => themeGridWidth.value > 0 && themeGridWidth.value < 280)
 </script>
 
 <template>
@@ -246,13 +251,27 @@ const isColorCompact = computed(() => colorGridWidth.value > 0 && colorGridWidth
         <h2 class="text-sm font-medium">
           {{ t('menu.theme') }}
         </h2>
-        <div class="grid grid-cols-3 gap-2">
+        <div
+          ref="themeGridRef"
+          class="grid gap-2"
+          :class="isThemeCompact ? 'grid-cols-4 sm:grid-cols-5' : 'grid-cols-3'"
+        >
           <Button
-            v-for="{ label, value } in localizedStyleOptions.themeOptions" :key="value" class="h-auto w-full px-1.5 py-2 text-xs whitespace-nowrap" variant="outline" :class="{
-              'bg-accent text-accent-foreground ring-1 ring-primary/20 border-primary': theme === value,
-            }" @click="themeChanged(value)"
+            v-for="{ label, value } in localizedStyleOptions.themeOptions"
+            :key="value"
+            class="h-auto w-full text-xs whitespace-nowrap"
+            :class="[
+              isThemeCompact ? 'justify-center px-1 py-2' : 'px-1.5 py-2',
+              {
+                'bg-accent text-accent-foreground ring-1 ring-primary/20 border-primary': theme === value,
+              },
+            ]"
+            variant="outline"
+            :title="label"
+            :aria-label="label"
+            @click="themeChanged(value)"
           >
-            {{ label }}
+            <span :class="{ 'min-w-0 truncate': isThemeCompact }">{{ label }}</span>
           </Button>
         </div>
         <Button


### PR DESCRIPTION
## Summary
- Adapt theme option buttons in the right slider when the panel is narrow: switch the theme grid to compact blocks (denser columns, centered, tighter padding), mirroring the primary color swatches behavior from #1770.
- Truncate long theme names (e.g. marketplace themes) in compact mode and keep the full name available via `title` hover tooltip and `aria-label`.

## Type of Change
- [x] 新特性
- [ ] Bug 修复
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 样式 / UI 调整
- [ ] 文档更新
- [ ] 工作流 / CI

## Test Procedure
- [x] Open the right style slider on desktop
- [x] Drag the panel narrower until the theme grid width is under ~280px and confirm theme buttons become compact blocks
- [x] Widen the panel again and confirm the normal 3-column layout returns
- [x] Hover a compact theme block and confirm the full theme name appears in the tooltip
- [x] Select different themes in both modes and confirm the preview updates normally

## Pre-flight Checklist
- [x] 已自测，确认无回归
- [x] 变更范围聚焦，未夹带无关改动
- [x] Commit message 遵循 Conventional Commits
