### PR TITLE
fix(vscode): shrink vsix size and fix packaging checks

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "1.120.0",
     "@vscode/vsce": "^3.9.2",
     "ts-loader": "^9.6.2",
     "tsconfig-paths-webpack-plugin": "^4.2.0",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.120.0",
     "@vscode/vsce": "^3.9.2",
     "ts-loader": "^9.6.2",
     "tsconfig-paths-webpack-plugin": "^4.2.0",

--- a/apps/vscode/scripts/smoke-test.mjs
+++ b/apps/vscode/scripts/smoke-test.mjs
@@ -43,7 +43,8 @@ runCase(`citeStatus enabled`, { citeStatus: true }, [
 ])
 
 runCase(`countStatus enabled`, { countStatus: true }, [
-  [`includes reading stats`, html => /阅读|分钟|字/.test(html)],
+  // Core fallbacks are locale-neutral English; the web app injects localized strings.
+  [`includes reading stats`, html => /words.*min read|阅读|分钟|字/.test(html)],
 ])
 
 runCase(`mac code block`, { isMacCodeBlock: true }, [

--- a/apps/vscode/webpack.config.mjs
+++ b/apps/vscode/webpack.config.mjs
@@ -21,11 +21,17 @@ export default function config() {
       path: path.resolve(currentDir, `dist`),
       filename: `[name].js`,
       libraryTarget: `commonjs2`,
+      // Remove stale async chunks from previous builds; without this they
+      // accumulate in dist/ and get packaged into the vsix.
+      clean: true,
     },
     externals: {
       'vscode': `commonjs vscode`,
       // Shipped in runtime/node_modules for --no-dependencies vsix packaging.
       'isomorphic-dompurify': `commonjs ../runtime/node_modules/isomorphic-dompurify`,
+      // Keep the renderer as a separate bundle loaded on demand; webpack would
+      // otherwise rewrite the createRequire call and inline it into extension.js.
+      './previewRenderer': `commonjs ./previewRenderer`,
     },
     resolve: {
       extensions: [`.ts`, `.js`],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
         specifier: 'catalog:'
         version: 26.1.2
       '@types/vscode':
-        specifier: ^1.125.0
+        specifier: ^1.120.0
         version: 1.125.0
       '@vscode/vsce':
         specifier: ^3.9.2
@@ -188,7 +188,7 @@ importers:
         version: 4.23.1
       webpack:
         specifier: ^5.109.2
-        version: 5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2)
+        version: 5.109.2(esbuild@0.28.1)(postcss@8.5.25)(webpack-cli@7.2.2)
       webpack-cli:
         specifier: ^7.2.2
         version: 7.2.2(js-yaml@4.3.1)(json5@2.2.3)(webpack@5.109.2)
@@ -439,7 +439,7 @@ importers:
     dependencies:
       express:
         specifier: ^5.2.1
-        version: 5.2.1
+        version: 5.2.1(supports-color@5.5.0)
       form-data:
         specifier: 4.0.6
         version: 4.0.6
@@ -7275,7 +7275,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
@@ -7339,7 +7339,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.29.7
@@ -8250,7 +8250,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       express-rate-limit: 8.6.1(express@5.2.1)(supports-color@5.5.0)
       hono: 4.12.33
       jose: 6.2.6
@@ -9513,7 +9513,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -10674,15 +10674,15 @@ snapshots:
   express-rate-limit@8.6.1(express@5.2.1)(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       ip-address: 10.4.0
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@5.5.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -10692,7 +10692,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10703,8 +10703,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -10768,7 +10768,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -11965,15 +11965,16 @@ snapshots:
       postcss: 8.5.25
     optional: true
 
-  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.109.2):
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.25)(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2)
+      webpack: 5.109.2(esbuild@0.28.1)(postcss@8.5.25)(webpack-cli@7.2.2)
     optionalDependencies:
       esbuild: 0.28.1
+      postcss: 8.5.25
 
   minipass@7.1.3: {}
 
@@ -12643,7 +12644,7 @@ snapshots:
 
   round-polygon@0.6.7: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -12702,7 +12703,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -12723,7 +12724,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13154,7 +13155,7 @@ snapshots:
       picomatch: 4.0.5
       source-map: 0.7.6
       typescript: 6.0.3
-      webpack: 5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2)
+      webpack: 5.109.2(esbuild@0.28.1)(postcss@8.5.25)(webpack-cli@7.2.2)
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -13585,7 +13586,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2)
+      webpack: 5.109.2(esbuild@0.28.1)(postcss@8.5.25)(webpack-cli@7.2.2)
       webpack-merge: 6.0.1
     optionalDependencies:
       js-yaml: 4.3.1
@@ -13638,7 +13639,7 @@ snapshots:
       - uglify-js
     optional: true
 
-  webpack@5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2):
+  webpack@5.109.2(esbuild@0.28.1)(postcss@8.5.25)(webpack-cli@7.2.2):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -13654,7 +13655,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.109.2)
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.25)(webpack@5.109.2)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: 'catalog:'
         version: 26.1.2
       '@types/vscode':
-        specifier: ^1.120.0
-        version: 1.125.0
+        specifier: 1.120.0
+        version: 1.120.0
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2(supports-color@5.5.0)
@@ -439,7 +439,7 @@ importers:
     dependencies:
       express:
         specifier: ^5.2.1
-        version: 5.2.1(supports-color@5.5.0)
+        version: 5.2.1
       form-data:
         specifier: 4.0.6
         version: 4.0.6
@@ -2374,8 +2374,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/vscode@1.125.0':
-    resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
+  '@types/vscode@1.120.0':
+    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -8250,7 +8250,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1(supports-color@5.5.0)
+      express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)(supports-color@5.5.0)
       hono: 4.12.33
       jose: 6.2.6
@@ -8835,7 +8835,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/vscode@1.125.0': {}
+  '@types/vscode@1.120.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -9513,7 +9513,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.3.0(supports-color@5.5.0):
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -10674,15 +10674,15 @@ snapshots:
   express-rate-limit@8.6.1(express@5.2.1)(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      express: 5.2.1(supports-color@5.5.0)
+      express: 5.2.1
       ip-address: 10.4.0
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@5.5.0):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@5.5.0)
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -10692,7 +10692,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@5.5.0)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10703,8 +10703,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0(supports-color@5.5.0)
-      send: 1.2.1(supports-color@5.5.0)
+      router: 2.2.0
+      send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -10768,7 +10768,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@5.5.0):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -12644,7 +12644,7 @@ snapshots:
 
   round-polygon@0.6.7: {}
 
-  router@2.2.0(supports-color@5.5.0):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -12703,7 +12703,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@5.5.0):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -12724,7 +12724,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@5.5.0)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary
- `dist/` was never cleaned between webpack builds, so stale async chunks accumulated (705 files / ~248 MB locally) and were packaged into the vsix: 26.9 MB → now 7.0 MB.
- `vsce package` failed outright because `@types/vscode` (^1.125.0) was ahead of `engines.vscode` (^1.120.0); aligned the types package to the declared engine range.
- The `createRequire` call in `extension.ts` was rewritten by webpack, silently inlining the whole renderer (marked, core, etc.) into `extension.js`; added a `'./previewRenderer'` external so the renderer bundle loads on demand as originally intended (`extension.js`: 3.97 MiB → 9.7 KB).
- Fixed a pre-existing smoke-test failure: `countStatus` assertion expected Chinese reading stats, but core fallbacks became locale-neutral English in 723a542d (`feat(i18n)`); the extension does not inject `countMessages`, so the assertion now accepts the English fallback too.

## Type of Change
- [ ] 新特性
- [x] Bug 修复
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 样式 / UI 调整
- [ ] 文档更新
- [x] 工作流 / CI

## Test Procedure
- [x] `pnpm vscode build` completes and `dist/` only contains the current build's files (110 files / 67 MB incl. source maps, vs 705 files / 248 MB before)
- [x] `pnpm vscode package` succeeds (previously failed on the `@types/vscode` vs `engines.vscode` check)
- [x] Packaged vsix is 7.0 MB (was 26.9 MB) and contains `dist/`, `runtime/node_modules` (isomorphic-dompurify + jsdom), icons and manifest
- [x] `pnpm vscode test` passes: smoke tests ×4, `verify-preview`, `verify-activate` (8 commands registered), `verify-vsix-deps`
- [x] Installed the packaged vsix into local VS Code and confirmed the preview command works

## Pre-flight Checklist
- [x] 已自测，确认无回归
- [x] 变更范围聚焦，未夹带无关改动
- [x] Commit message 遵循 Conventional Commits
