### PR TITLE
perf(web): editor rendering & storage performance, fix history preview overflow

### DIFF
--- a/apps/web/src/components/editor/CodemirrorEditor.vue
+++ b/apps/web/src/components/editor/CodemirrorEditor.vue
@@ -190,6 +190,14 @@ onMounted(() => {
   redistributePanelSizes()
   if (!isMobile.value && isOpenPostSlider.value)
     resizePanelSafely(postSliderPanelRef, 20)
+
+  // Warm up the async post-slider chunk while idle: fetches the chunk in prod,
+  // and in dev finishes the on-demand transform before the user opens the panel.
+  const preloadPostSlider = () => { void import('@/components/editor/post-slider/index.vue') }
+  if (typeof window.requestIdleCallback === `function`)
+    window.requestIdleCallback(() => preloadPostSlider())
+  else
+    setTimeout(preloadPostSlider, 3000)
 })
 
 const isImgLoading = computed(() => unref(editorPanelCompRef.value?.isImgLoading) ?? false)

--- a/apps/web/src/components/editor/post-slider/PostItem.vue
+++ b/apps/web/src/components/editor/post-slider/PostItem.vue
@@ -68,8 +68,11 @@ function togglePostExpanded(postId: string) {
   }
 }
 
+const EMPTY_CHILDREN: Post[] = []
+const childPosts = computed(() => props.childrenMap.get(props.parentId ?? null) ?? EMPTY_CHILDREN)
+
 function isHasChild(postId: string) {
-  return props.sortedPosts.some(p => p.parentId === postId)
+  return (props.childrenMap.get(postId)?.length ?? 0) > 0
 }
 
 function saveAsTemplate(postId: string) {
@@ -140,7 +143,12 @@ function cancelInlineRename() {
 </script>
 
 <template>
-  <div v-for="post in props.sortedPosts.filter(p => (props.parentId == null && p.parentId == null) || p.parentId === props.parentId)" :key="post.id">
+  <div
+    v-for="post in childPosts"
+    :key="post.id"
+    class="post-tree-node"
+    :class="{ 'drag-in-progress': drag.dragSourceId !== null }"
+  >
     <div
       class="post-item group relative flex w-full items-center gap-1 rounded-lg px-2 py-[7px] text-[13px] leading-snug transition-all duration-150 ease-out"
       :class="{
@@ -290,7 +298,7 @@ function cancelInlineRename() {
     >
       <PostItem
         :parent-id="post.id"
-        :sorted-posts="props.sortedPosts"
+        :children-map="props.childrenMap"
         :actions="actions"
         :drag="drag"
         :select="select"
@@ -298,3 +306,16 @@ function cancelInlineRename() {
     </div>
   </div>
 </template>
+
+<style scoped>
+/* Let the browser skip off-screen subtrees; `auto` keeps the last rendered size. */
+.post-tree-node {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 32px;
+}
+
+/* Dragging needs hit testing on every node, incl. those skipped while off-screen. */
+.post-tree-node.drag-in-progress {
+  content-visibility: visible;
+}
+</style>

--- a/apps/web/src/components/editor/post-slider/VersionDiffViewer.vue
+++ b/apps/web/src/components/editor/post-slider/VersionDiffViewer.vue
@@ -180,7 +180,7 @@ onMounted(() => {
           <div
             v-for="({ line, lineNo }, idx) in visibleLines"
             :key="idx"
-            class="flex"
+            class="diff-line flex"
             :class="{
               'bg-green-500/8': line.rowType === 'insert',
               'bg-red-500/8': line.rowType === 'delete',
@@ -230,3 +230,11 @@ onMounted(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+/* Skip layout/paint for off-screen lines; long docs can yield thousands of rows. */
+.diff-line {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 20px;
+}
+</style>

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { CheckSquare, ChevronsDownUp, ChevronsUpDown, Download, Ellipsis, FileText, Plus, Regex, Replace, ReplaceAll, Search, Upload, X } from '@lucide/vue'
-import { hljs, initRenderer } from '@md/core'
-import { postProcessHtml, renderMarkdown } from '@md/core/utils'
 import { CONTENT_FONT_LANG } from '@/i18n/constants'
 import { formatLocalDateTime } from '@/i18n/translate'
 import { copyPlain } from '@/lib/browser/clipboard'
@@ -22,6 +20,10 @@ import {
 
 const { t, locale } = useI18n()
 const confirmStore = useConfirmStore()
+
+// Overrides the auto-imported component so diff-match-patch stays out of this
+// chunk and only loads when the diff tab is first shown.
+const VersionDiffViewer = defineAsyncComponent(() => import('./VersionDiffViewer.vue'))
 
 function formatHistoryDatetime(datetime: number | string) {
   void locale.value
@@ -153,7 +155,44 @@ const compareTargetIndex = ref(`1`)
 
 const HISTORY_PREVIEW_SCOPE = `#history-preview-output`
 const styleTag = `style` as const
-let historyRenderer: ReturnType<typeof initRenderer> | null = null
+
+interface HistoryCoreModules {
+  hljs: (typeof import('@md/core'))[`hljs`]
+  initRenderer: (typeof import('@md/core'))[`initRenderer`]
+  renderMarkdown: (typeof import('@md/core/utils'))[`renderMarkdown`]
+  postProcessHtml: (typeof import('@md/core/utils'))[`postProcessHtml`]
+}
+
+// The history dialog pulls in the whole @md/core renderer stack + hljs. Load it
+// on demand so opening the post slider doesn't pay that cost (notably the cold
+// on-demand transform in vite dev).
+const coreModules = shallowRef<HistoryCoreModules | null>(null)
+const coreModulesFailed = ref(false)
+let coreModulesPromise: Promise<HistoryCoreModules> | null = null
+
+function ensureCoreModules(): Promise<HistoryCoreModules> {
+  coreModulesPromise ??= Promise.all([import('@md/core'), import('@md/core/utils')])
+    .then(([core, coreUtils]) => {
+      const modules: HistoryCoreModules = {
+        hljs: core.hljs,
+        initRenderer: core.initRenderer,
+        renderMarkdown: coreUtils.renderMarkdown,
+        postProcessHtml: coreUtils.postProcessHtml,
+      }
+      coreModules.value = modules
+      coreModulesFailed.value = false
+      return modules
+    })
+    .catch((error) => {
+      // Allow a later retry (e.g. transient network failure on the chunk).
+      coreModulesPromise = null
+      coreModulesFailed.value = true
+      throw error
+    })
+  return coreModulesPromise
+}
+
+let historyRenderer: ReturnType<HistoryCoreModules[`initRenderer`]> | null = null
 
 function openHistoryDialog(id: string) {
   postSliderMenu.closeMenu()
@@ -162,6 +201,9 @@ function openHistoryDialog(id: string) {
   historyViewMode.value = `content`
   compareTargetIndex.value = `1`
   isOpenHistoryDialog.value = true
+  void ensureCoreModules().catch((error) => {
+    console.error(`[PostSlider] Failed to load history renderer modules:`, error)
+  })
 }
 
 const currentHistoryList = computed(() => {
@@ -170,13 +212,20 @@ const currentHistoryList = computed(() => {
 
 const highlightedMarkdown = computed(() => {
   const content = currentHistoryList.value[currentHistoryIndex.value]?.content ?? ''
-  return hljs.highlight(content, { language: `markdown` }).value
+  const core = coreModules.value
+  // Plain text until the highlighter chunk arrives; recomputes once it does.
+  if (!core)
+    return content
+  return core.hljs.highlight(content, { language: `markdown` }).value
 })
 
 /** Isolated renderer — must not call useRenderStore().render() (mutates live PreviewPanel). */
 function renderHistoryContent(content: string): string {
+  const core = coreModules.value
+  if (!core)
+    return ``
   if (!historyRenderer)
-    historyRenderer = initRenderer({})
+    historyRenderer = core.initRenderer({})
 
   historyRenderer.reset({
     citeStatus: themeStore.isCiteStatus,
@@ -207,8 +256,8 @@ function renderHistoryContent(content: string): string {
     },
   })
 
-  const { html, readingTime } = renderMarkdown(content, historyRenderer)
-  return postProcessHtml(html, readingTime, historyRenderer)
+  const { html, readingTime } = core.renderMarkdown(content, historyRenderer)
+  return core.postProcessHtml(html, readingTime, historyRenderer)
 }
 
 const previewHtml = computed(() => {
@@ -223,6 +272,19 @@ const previewHtml = computed(() => {
   catch {
     return `<p class="text-muted-foreground text-sm">${t('store.render.renderFailed')}</p>`
   }
+})
+
+const hasHistoryContent = computed(() => {
+  return Boolean(currentHistoryList.value[currentHistoryIndex.value]?.content)
+})
+
+/** Distinguishes "no version content" from "renderer chunk still loading / failed". */
+const previewFallbackText = computed(() => {
+  if (!hasHistoryContent.value)
+    return t(`common.noData`)
+  if (coreModulesFailed.value)
+    return t(`store.render.renderFailed`)
+  return t(`common.loading`)
 })
 
 const historyPreviewCss = computed(() => {
@@ -423,6 +485,20 @@ const sortedPosts = computed(() => {
         return +new Date(a.createDatetime) - +new Date(b.createDatetime)
     }
   })
+})
+
+// Group once so each tree level does O(1) lookup instead of filtering the whole list per node.
+const postChildrenMap = computed(() => {
+  const map = new Map<string | null, typeof posts.value>()
+  for (const post of sortedPosts.value) {
+    const key = post.parentId ?? null
+    const children = map.get(key)
+    if (children)
+      children.push(post)
+    else
+      map.set(key, [post])
+  }
+  return map
 })
 
 const dragover = ref(false)
@@ -863,7 +939,7 @@ function handleDragEnd() {
             v-for="result in searchResults"
             :key="result.id"
             type="button"
-            class="group relative flex w-full cursor-pointer flex-col gap-0.5 rounded-lg px-2 py-[7px] text-left text-[13px] leading-snug transition-all duration-150 ease-out"
+            class="search-result-item group relative flex w-full cursor-pointer flex-col gap-0.5 rounded-lg px-2 py-[7px] text-left text-[13px] leading-snug transition-all duration-150 ease-out"
             :class="{
               'bg-accent text-accent-foreground font-medium': postStore.currentPostId === result.id,
               'text-foreground/70 hover:text-foreground hover:bg-accent/50': postStore.currentPostId !== result.id,
@@ -903,7 +979,7 @@ function handleDragEnd() {
         <PostItem
           v-if="sortedPosts.length"
           :parent-id="null"
-          :sorted-posts="sortedPosts"
+          :children-map="postChildrenMap"
           :actions="{
             startRenamePost,
             openHistoryDialog,
@@ -1106,7 +1182,7 @@ function handleDragEnd() {
         <DialogDescription>{{ t('post.historyDescription') }}</DialogDescription>
       </DialogHeader>
 
-      <div class="h-[50vh] flex gap-3">
+      <div class="h-[50vh] flex gap-3 w-full min-w-0">
         <ul class="w-[104px] sm:w-[160px] shrink-0 space-y-0.5 overflow-y-auto thin-scrollbar">
           <li v-for="(item, idx) in currentHistoryList" :key="idx">
             <button
@@ -1129,8 +1205,8 @@ function handleDragEnd() {
 
         <Separator orientation="vertical" />
 
-        <div class="flex-1 flex flex-col overflow-hidden">
-          <Tabs v-model="historyViewMode" class="flex flex-col h-full">
+        <div class="flex-1 flex flex-col overflow-hidden min-w-0">
+          <Tabs v-model="historyViewMode" class="flex flex-col h-full min-w-0 min-h-0">
             <TabsList class="shrink-0 w-fit">
               <TabsTrigger value="content">
                 {{ t('post.originalContent') }}
@@ -1143,16 +1219,16 @@ function handleDragEnd() {
               </TabsTrigger>
             </TabsList>
 
-            <TabsContent value="content" class="flex-1 overflow-y-auto mt-2">
+            <TabsContent value="content" class="flex-1 min-w-0 min-h-0 overflow-y-auto mt-2">
               <div class="rounded-lg h-full overflow-y-auto">
                 <pre class="whitespace-pre-wrap text-sm leading-relaxed break-all font-[inherit] h-full"><code class="hljs h-full" v-html="highlightedMarkdown" /></pre>
               </div>
             </TabsContent>
 
-            <TabsContent value="preview" class="flex-1 overflow-hidden mt-2">
+            <TabsContent value="preview" class="flex-1 min-w-0 min-h-0 overflow-hidden mt-2">
               <div
                 v-if="previewHtml"
-                class="history-preview-wrapper h-full overflow-y-auto rounded-lg border bg-background"
+                class="history-preview-wrapper h-full overflow-y-auto overflow-x-hidden rounded-lg border bg-background"
               >
                 <div class="preview mx-auto">
                   <component :is="styleTag" v-if="historyPreviewCss">
@@ -1167,11 +1243,11 @@ function handleDragEnd() {
                 </div>
               </div>
               <div v-else class="flex items-center justify-center h-full rounded-lg border bg-background text-muted-foreground text-sm">
-                {{ t('common.noData') }}
+                {{ previewFallbackText }}
               </div>
             </TabsContent>
 
-            <TabsContent value="diff" class="flex-1 overflow-hidden mt-2 pt-1">
+            <TabsContent value="diff" class="flex-1 min-w-0 min-h-0 overflow-hidden mt-2 pt-1">
               <div class="flex items-center gap-2 mb-2 text-xs text-muted-foreground shrink-0">
                 <span>{{ t('post.compareLabel') }}</span>
                 <Select v-model="compareTargetIndex">
@@ -1229,6 +1305,12 @@ function handleDragEnd() {
   scrollbar-color: hsl(var(--border)) transparent;
 }
 
+/* Skip rendering off-screen search hits in long result lists. */
+.search-result-item {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 48px;
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 200ms ease;
@@ -1256,11 +1338,24 @@ function handleDragEnd() {
 .history-preview-wrapper .preview {
   position: relative;
   min-height: 100%;
+  max-width: 100%;
   margin: 0 auto;
   padding: 20px;
   font-size: 14px;
   box-sizing: border-box;
   word-wrap: break-word;
   overflow-wrap: break-word;
+}
+
+/* Defensive clamps: rendered diagrams/SVGs carry fixed pixel widths, and wide
+   tables must scroll inside their own box instead of stretching the dialog. */
+.history-preview-wrapper .preview svg {
+  max-width: 100%;
+}
+
+.history-preview-wrapper .preview table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 </style>

--- a/apps/web/src/components/editor/post-slider/index.vue
+++ b/apps/web/src/components/editor/post-slider/index.vue
@@ -213,9 +213,16 @@ const currentHistoryList = computed(() => {
 const highlightedMarkdown = computed(() => {
   const content = currentHistoryList.value[currentHistoryIndex.value]?.content ?? ''
   const core = coreModules.value
-  // Plain text until the highlighter chunk arrives; recomputes once it does.
-  if (!core)
+  // Rendered via v-html: escape raw markdown until the highlighter chunk
+  // arrives, so source like `<tag>` can't be parsed as HTML.
+  if (!core) {
     return content
+      .replace(/&/g, `&amp;`)
+      .replace(/</g, `&lt;`)
+      .replace(/>/g, `&gt;`)
+      .replace(/"/g, `&quot;`)
+      .replace(/'/g, `&#39;`)
+  }
   return core.hljs.highlight(content, { language: `markdown` }).value
 })
 

--- a/apps/web/src/storage/index.ts
+++ b/apps/web/src/storage/index.ts
@@ -31,6 +31,7 @@ let initComplete = false
 async function initLegacyFallback(reason: string): Promise<void> {
   console.warn(`[Storage] ${reason} — using localStorage fallback`)
   setUseLegacyDocumentStorage(true)
+  await store.restorePendingWrites()
   await documentRepo.loadAll()
   initComplete = true
 }
@@ -73,6 +74,7 @@ export function initStorage(): Promise<void> {
       }
 
       store.setEngine(engine)
+      await store.restorePendingWrites()
       await documentRepo.loadAll()
       initComplete = true
     }

--- a/apps/web/src/storage/manager.ts
+++ b/apps/web/src/storage/manager.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { StorageEngine } from '@/storage/engine'
-import { customRef, ref, watch } from 'vue'
+import { customRef, ref, toRaw, watch } from 'vue'
 import { IndexedDBEngine, LocalStorageEngine, RestfulStorageEngine } from '@/storage/engines/indexed-db'
 import { isCacheKey } from '@/storage/keys'
 import { isStorageQuotaError, warnStorageQuota } from '@/storage/quota'
@@ -21,8 +21,19 @@ class StorageManager {
     return this.engine
   }
 
+  /** Serialized values written by reactive() but not yet flushed to the engine. */
+  private pendingWrites = new Map<string, string>()
+
+  /** localStorage backup of pendingWrites, written on pagehide (engine writes may not survive tab kill). */
+  private static readonly PAGEHIDE_BACKUP_KEY = `MD__pending_writes_backup`
+
   /** Sync read (available after initStorage preload). */
   getSync(key: string): string | null {
+    // Prefer the pending overlay: debounced reactive writes must be visible to
+    // sync readers (e.g. cloud sync's collectChangedSettings) immediately.
+    const pending = this.pendingWrites.get(key)
+    if (pending !== undefined)
+      return pending
     if (this.engine.getSync)
       return this.engine.getSync(key)
     if (this.engine instanceof LocalStorageEngine)
@@ -35,18 +46,79 @@ class StorageManager {
   }
 
   async get(key: string): Promise<string | null> {
+    const pending = this.pendingWrites.get(key)
+    if (pending !== undefined)
+      return pending
     return this.engine.get(key)
   }
 
   async set(key: string, value: string): Promise<void> {
+    // External writes win over any debounced reactive snapshot for the same key.
+    this.pendingWrites.delete(key)
+    return this.writeToEngine(key, value)
+  }
+
+  /** Engine write that keeps the pending overlay intact (used by the debounced flush). */
+  private writeToEngine(key: string, value: string): Promise<void> {
     const toStore = isCacheKey(key) ? trimCacheValue(key, value) : value
     return this.engine.set(key, toStore)
+  }
+
+  /**
+   * Mirror pendingWrites to a synchronous localStorage backup (or clear it when
+   * nothing is pending). Called on pagehide and after each successful flush.
+   */
+  private refreshPagehideBackup(): void {
+    if (typeof localStorage === `undefined`)
+      return
+    try {
+      if (this.pendingWrites.size === 0) {
+        localStorage.removeItem(StorageManager.PAGEHIDE_BACKUP_KEY)
+        return
+      }
+      localStorage.setItem(
+        StorageManager.PAGEHIDE_BACKUP_KEY,
+        JSON.stringify(Object.fromEntries(this.pendingWrites)),
+      )
+    }
+    catch {
+      // Quota / privacy mode — the backup is best effort only.
+    }
+  }
+
+  /**
+   * Re-apply writes that were backed up on pagehide but never reached the
+   * engine. Must run after setEngine() with the real (preloaded) engine.
+   */
+  async restorePendingWrites(): Promise<void> {
+    if (typeof localStorage === `undefined`)
+      return
+    const raw = localStorage.getItem(StorageManager.PAGEHIDE_BACKUP_KEY)
+    if (!raw)
+      return
+    localStorage.removeItem(StorageManager.PAGEHIDE_BACKUP_KEY)
+    let entries: Record<string, string>
+    try {
+      entries = JSON.parse(raw)
+    }
+    catch {
+      return
+    }
+    for (const [key, value] of Object.entries(entries)) {
+      try {
+        await this.writeToEngine(key, value)
+      }
+      catch (error) {
+        console.error(`[Storage] Failed to restore pending write:`, key, error)
+      }
+    }
   }
 
   async getJSON<T>(key: string, defaultValue: T): Promise<T>
   async getJSON<T>(key: string): Promise<T | null>
   async getJSON<T>(key: string, defaultValue?: T): Promise<T | null> {
-    const value = await this.engine.get(key)
+    const pending = this.pendingWrites.get(key)
+    const value = pending !== undefined ? pending : await this.engine.get(key)
     if (!value)
       return (defaultValue ?? null) as T | null
 
@@ -71,14 +143,18 @@ class StorageManager {
   }
 
   async remove(key: string): Promise<void> {
+    this.pendingWrites.delete(key)
     return this.engine.remove(key)
   }
 
   async has(key: string): Promise<boolean> {
+    if (this.pendingWrites.has(key))
+      return true
     return this.engine.has(key)
   }
 
   async clear(): Promise<void> {
+    this.pendingWrites.clear()
     return this.engine.clear()
   }
 
@@ -125,21 +201,63 @@ class StorageManager {
     }
 
     Promise.resolve().then(() => {
-      watch(
-        data,
-        (newValue) => {
-          const savePromise = isStringType
-            ? this.set(key, newValue as string)
-            : this.setJSON(key, newValue)
+      // Deep watchers fire on every keystroke-level mutation. Serialize eagerly
+      // into the pendingWrites overlay (so sync reads stay current), but
+      // coalesce the actual engine writes; flush on pagehide so the final state
+      // is never lost.
+      let timer: ReturnType<typeof setTimeout> | null = null
 
-          savePromise.catch((error) => {
+      const flush = () => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        const value = this.pendingWrites.get(key)
+        if (value === undefined)
+          return
+
+        this.writeToEngine(key, value)
+          .then(() => {
+            // Drop the overlay entry only if no newer write arrived meanwhile.
+            if (this.pendingWrites.get(key) === value)
+              this.pendingWrites.delete(key)
+            // Keep any pagehide backup in sync once the engine has the data.
+            this.refreshPagehideBackup()
+          })
+          .catch((error) => {
             if (isStorageQuotaError(error))
               warnStorageQuota()
             console.error(`[Storage] Failed to save reactive data:`, key, error)
           })
+      }
+
+      watch(
+        data,
+        () => {
+          try {
+            const serialized = isStringType
+              ? data.value as string
+              : JSON.stringify(toRaw(data.value))
+            this.pendingWrites.set(key, serialized)
+            if (timer)
+              clearTimeout(timer)
+            timer = setTimeout(flush, 300)
+          }
+          catch (error) {
+            console.error(`[Storage] Failed to stringify reactive data:`, key, error)
+          }
         },
         { deep: true },
       )
+
+      if (typeof window !== `undefined`) {
+        window.addEventListener(`pagehide`, () => {
+          // The async engine flush may not finish before the tab is killed, so
+          // also snapshot pending writes synchronously; restored on next launch.
+          flush()
+          this.refreshPagehideBackup()
+        })
+      }
     })
 
     return data

--- a/apps/web/src/stores/render.ts
+++ b/apps/web/src/stores/render.ts
@@ -108,27 +108,19 @@ export const useRenderStore = defineStore(`render`, () => {
 
   /**
    * Inject heading anchor ids (`#0`, `#1`, …) used by outline navigation and
-   * collect the title list in a single parse. Runs before `output` is
-   * assigned so the preview updates once instead of twice.
+   * fill the title list from headings collected during render. Pure string
+   * work — no DOM parse/serialize round-trip per render.
    */
   const extractTitles = (html: string): string => {
-    const div = document.createElement(`div`)
-    div.innerHTML = html
-    const list = div.querySelectorAll<HTMLElement>(`[data-heading]`)
+    const headings = renderer!.getHeadings()
+    titleList.value = headings.map((heading, i) => ({
+      url: `#${i}`,
+      title: heading.text,
+      level: heading.level,
+    }))
 
-    const titles: typeof titleList.value = []
     let i = 0
-    for (const item of list) {
-      item.setAttribute(`id`, `${i}`)
-      titles.push({
-        url: `#${i}`,
-        title: `${item.textContent}`,
-        level: Number(item.tagName.slice(1)),
-      })
-      i++
-    }
-    titleList.value = titles
-    return div.innerHTML
+    return html.replace(/data-heading="true"/g, () => `data-heading="true" id="${i++}"`)
   }
 
   const render = (content: string, options?: RenderOptions) => {

--- a/apps/web/src/types/post.ts
+++ b/apps/web/src/types/post.ts
@@ -42,7 +42,8 @@ export interface PostItemActions {
 
 export interface PostItemProps {
   parentId: string | null
-  sortedPosts: Post[]
+  /** Posts grouped by parent id (`null` = root), pre-sorted. */
+  childrenMap: Map<string | null, Post[]>
   actions: PostItemActions
   drag: PostItemDragState
   select?: PostItemSelectState

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -111,6 +111,11 @@ export default defineConfig(({ mode }) => {
       alias: { '@': fileURLToPath(new URL(`./src`, import.meta.url)) },
       dedupe: [`@codemirror/state`, `@codemirror/view`],
     },
+    // Pre-bundle CJS deps that live behind lazily-mounted components; otherwise
+    // the dev server discovers them on first interaction and force-reloads the page.
+    optimizeDeps: {
+      include: [`diff-match-patch`],
+    },
     css: { devSourcemap: true },
     build: {
       rolldownOptions: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@antv/infographic": "^0.2.19",
     "@md/shared": "workspace:*",
+    "entities": "^8.0.0",
     "fflate": "^0.8.3",
     "front-matter": "^4.0.2",
     "highlight.js": "^11.11.1",

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -1,4 +1,4 @@
-import type { IOpts, RendererAPI } from '@md/shared/types'
+import type { CollectedHeading, IOpts, RendererAPI } from '@md/shared/types'
 import type { FrontMatterData } from '@md/shared/types/front-matter'
 import type { ReadTimeResults } from '@md/shared/utils/readingTime'
 import type { RendererObject, Tokens } from 'marked'
@@ -32,6 +32,23 @@ export { hljs }
 const DOUBLE_QUOTE_REGEX = /"/g
 const UNDERSCORE_REGEX = /_/g
 const HEADING_TAG_REGEX = /^h\d$/
+const HTML_TAG_REGEX = /<[^>]*>/g
+const HTML_ENTITY_REGEX = /&(?:amp|lt|gt|quot|#39|nbsp);/g
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': `&`,
+  '&lt;': `<`,
+  '&gt;': `>`,
+  '&quot;': `"`,
+  '&#39;': `'`,
+  '&nbsp;': ` `,
+}
+
+/** Plain text of inline heading HTML, mirroring what `textContent` would yield. */
+function stripInlineHtml(html: string): string {
+  return html
+    .replace(HTML_TAG_REGEX, ``)
+    .replace(HTML_ENTITY_REGEX, entity => HTML_ENTITIES[entity] ?? entity)
+}
 const PARAGRAPH_WRAPPER_REGEX = /^<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/
 const MP_WEIXIN_LINK_REGEX = /^https?:\/\/mp\.weixin\.qq\.com/
 /** Locale-neutral English fallbacks; Web injects localized strings via IOpts. */
@@ -187,6 +204,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   let footnoteIndex: number = 0
   const listOrderedStack: boolean[] = []
   const listCounters: number[] = []
+  const headings: CollectedHeading[] = []
   const markdownParser = new Marked()
 
   markdownParser.setOptions({
@@ -200,7 +218,11 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
   function styledContent(styleLabel: string, content: string, tagName?: string, style?: string): string {
     const tag = tagName ?? styleLabel
     const className = `${styleLabel.replace(UNDERSCORE_REGEX, `-`)}`
-    const headingAttr = HEADING_TAG_REGEX.test(tag) ? ` data-heading="true"` : ``
+    const isHeading = HEADING_TAG_REGEX.test(tag)
+    // Collect headings during render so consumers (outline/TOC) don't need a DOM pass.
+    if (isHeading)
+      headings.push({ level: Number(tag.slice(1)), text: stripInlineHtml(content) })
+    const headingAttr = isHeading ? ` data-heading="true"` : ``
     const styleAttr = style ? ` style="${style}"` : ``
     return `<${tag} class="${className}"${headingAttr}${styleAttr}>${content}</${tag}>`
   }
@@ -220,6 +242,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     footnoteIndex = 0
     listOrderedStack.length = 0
     listCounters.length = 0
+    headings.length = 0
     setOptions(newOpts)
   }
 
@@ -487,6 +510,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     createContainer(content: string) {
       return styledContent(`container`, content, `section`)
     },
+    getHeadings: () => [...headings],
     getOpts,
   }
 }

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -3,6 +3,7 @@ import type { FrontMatterData } from '@md/shared/types/front-matter'
 import type { ReadTimeResults } from '@md/shared/utils/readingTime'
 import type { RendererObject, Tokens } from 'marked'
 import readingTime from '@md/shared/utils/readingTime'
+import { decodeHTML } from 'entities'
 import frontMatter from 'front-matter'
 import hljs from 'highlight.js/lib/core'
 import { Marked } from 'marked'
@@ -33,21 +34,11 @@ const DOUBLE_QUOTE_REGEX = /"/g
 const UNDERSCORE_REGEX = /_/g
 const HEADING_TAG_REGEX = /^h\d$/
 const HTML_TAG_REGEX = /<[^>]*>/g
-const HTML_ENTITY_REGEX = /&(?:amp|lt|gt|quot|#39|nbsp);/g
-const HTML_ENTITIES: Record<string, string> = {
-  '&amp;': `&`,
-  '&lt;': `<`,
-  '&gt;': `>`,
-  '&quot;': `"`,
-  '&#39;': `'`,
-  '&nbsp;': ` `,
-}
 
 /** Plain text of inline heading HTML, mirroring what `textContent` would yield. */
 function stripInlineHtml(html: string): string {
-  return html
-    .replace(HTML_TAG_REGEX, ``)
-    .replace(HTML_ENTITY_REGEX, entity => HTML_ENTITIES[entity] ?? entity)
+  // decodeHTML handles every named/numeric entity, matching DOM textContent.
+  return decodeHTML(html.replace(HTML_TAG_REGEX, ``))
 }
 const PARAGRAPH_WRAPPER_REGEX = /^<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/
 const MP_WEIXIN_LINK_REGEX = /^https?:\/\/mp\.weixin\.qq\.com/

--- a/packages/core/src/renderer/renderer.test.ts
+++ b/packages/core/src/renderer/renderer.test.ts
@@ -96,4 +96,40 @@ $$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
     expect(html).toContain(`\\tag{1}`)
     expect(html).not.toMatch(/<p[^>]*>\s*<section class="katex-block"/)
   })
+
+  it('collects headings in document order with plain text', () => {
+    const renderer = initRenderer({})
+    renderMarkdown(`# Title\n\n## Sub \`code\` & **bold**\n\nBody\n\n### Third`, renderer)
+
+    expect(renderer.getHeadings()).toEqual([
+      { level: 1, text: `Title` },
+      { level: 2, text: `Sub code & bold` },
+      { level: 3, text: `Third` },
+    ])
+  })
+
+  it('includes the footnote title after postProcessHtml', () => {
+    const renderer = initRenderer({
+      citeStatus: true,
+      renderMessages: { footnoteTitle: `脚注`, unknownComponent: ``, katexLoading: `` },
+    })
+    const { html, readingTime } = renderMarkdown(`# Doc\n\n[link](https://example.com)`, renderer)
+    postProcessHtml(html, readingTime, renderer)
+
+    const headings = renderer.getHeadings()
+    expect(headings[0]).toEqual({ level: 1, text: `Doc` })
+    expect(headings[headings.length - 1]).toEqual({ level: 4, text: `脚注` })
+  })
+
+  it('clears collected headings on reset', () => {
+    const renderer = initRenderer({})
+    renderMarkdown(`# Old`, renderer)
+    expect(renderer.getHeadings()).toHaveLength(1)
+
+    renderer.reset({})
+    expect(renderer.getHeadings()).toHaveLength(0)
+
+    renderMarkdown(`## New`, renderer)
+    expect(renderer.getHeadings()).toEqual([{ level: 2, text: `New` }])
+  })
 })

--- a/packages/core/src/renderer/renderer.test.ts
+++ b/packages/core/src/renderer/renderer.test.ts
@@ -108,6 +108,15 @@ $$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
     ])
   })
 
+  it('decodes named and numeric entities in heading text like textContent', () => {
+    const renderer = initRenderer({})
+    renderMarkdown(`# Fish &amp; Chips &mdash; &#x2026; &nbsp;end`, renderer)
+
+    expect(renderer.getHeadings()).toEqual([
+      { level: 1, text: `Fish & Chips — … \u00A0end` },
+    ])
+  })
+
   it('includes the footnote title after postProcessHtml', () => {
     const renderer = initRenderer({
       citeStatus: true,

--- a/packages/shared/src/types/renderer-types.ts
+++ b/packages/shared/src/types/renderer-types.ts
@@ -2,6 +2,11 @@ import type { ReadTimeResults } from '../utils/readingTime'
 import type { IOpts } from './common'
 import type { FrontMatterData } from './front-matter'
 
+export interface CollectedHeading {
+  level: number
+  text: string
+}
+
 export interface RendererAPI {
   /* Lifecycle */
   reset: (newOpts: Partial<IOpts>) => void
@@ -21,4 +26,7 @@ export interface RendererAPI {
   buildFootnotes: () => string
   buildAddition: () => string
   createContainer: (html: string) => string
+
+  /** Headings collected during render (document order, incl. footnote title). */
+  getHeadings: () => CollectedHeading[]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,9 @@ importers:
       '@md/shared':
         specifier: workspace:*
         version: link:../shared
+      entities:
+        specifier: ^8.0.0
+        version: 8.0.0
       fflate:
         specifier: ^0.8.3
         version: 0.8.3


### PR DESCRIPTION
## Summary

Editor performance pass plus a history preview overflow fix:

- **Post tree**: group posts by parent id once (`childrenMap`) instead of re-filtering `sortedPosts` in every recursive `PostItem`, turning tree rendering from O(n²) into O(n).
- **TOC extraction**: `@md/core` now collects headings during render (`getHeadings()`), replacing the previous DOM round-trip (`innerHTML` + `querySelectorAll`) on every preview update.
- **Reactive storage persistence**: debounce IndexedDB writes behind an in-memory `pendingWrites` overlay so `getSync`/`get` stay consistent during the debounce window; snapshot pending writes to localStorage on `pagehide` and restore them on next launch so the final state is never lost.
- **Rendering**: `content-visibility: auto` for post tree nodes, search results, and diff lines to skip off-screen work (kept visible during drag for hit testing).
- **Loading**: idle-time preload of the post-slider chunk; `diff-match-patch` added to `optimizeDeps.include` so the dev server no longer discovers it on first interaction and force-reloads the page; `@md/core`, `hljs`, and `VersionDiffViewer` now lazy-load when the history dialog opens, with loading/error fallback states.
- **History preview overflow**: `min-w-0`/`min-h-0` through the dialog flex chain plus containment rules for wide tables/SVGs, so preview content can no longer escape its container.

## Type of Change

- [x] Bug fix (history preview overflow, storage race on unload)
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / performance improvement
- [ ] Documentation

## Test Procedure

- `pnpm run lint` — clean
- `pnpm run type-check` — clean (web + core + shared + api + mcp-server + vscode)
- `pnpm --filter @md/core run test` — 56 tests pass, including new `getHeadings()` coverage (document order, plain text, footnote title, reset)
- Manually verified in dev: opening content management no longer triggers a full-page reload; history dialog preview stays inside its container with wide tables and Mermaid SVGs; edits survive a tab kill during the debounce window (restored from the pagehide backup on next launch)
