### PR TITLE
fix(core): add boundary rules to markup extension delimiters

### DIFF
--- a/packages/core/src/extensions/extensions.test.ts
+++ b/packages/core/src/extensions/extensions.test.ts
@@ -100,6 +100,40 @@ describe(`markup extension`, () => {
     expect(html).toContain(`ul`)
     expect(html).toContain(`wv`)
   })
+
+  it(`keeps C++ as literal text instead of pairing the pluses`, () => {
+    const html = render(`C++是最好的语言，C++是最好的语言`)
+
+    expect(html).not.toContain(`markup-underline`)
+    expect(html).toContain(`C++是最好的语言，C++是最好的语言`)
+  })
+
+  it(`keeps delimiters attached to word chars as literal text`, () => {
+    expect(render(`x==1==y`)).not.toContain(`markup-highlight`)
+    expect(render(`v1~2~3`)).not.toContain(`markup-wavyline`)
+    expect(render(`C++17`)).toContain(`C++17`)
+  })
+
+  it(`keeps delimiters after a word-char token as literal text`, () => {
+    const html = render(`**C**++不是下划线++`)
+
+    expect(html).toContain(`<strong class="strong">C</strong>`)
+    expect(html).not.toContain(`markup-underline`)
+  })
+
+  it(`rejects content wrapped in whitespace`, () => {
+    expect(render(`++ 文字 ++`)).not.toContain(`markup-underline`)
+    expect(render(`a == b == c`)).not.toContain(`markup-highlight`)
+    expect(render(`~ 文字 ~`)).not.toContain(`markup-wavyline`)
+  })
+
+  it(`still renders intraword CJK markup`, () => {
+    const html = render(`把++重点++标出==高亮==和~波浪~`)
+
+    expect(html).toContain(`class="markup-underline"`)
+    expect(html).toContain(`class="markup-highlight"`)
+    expect(html).toContain(`class="markup-wavyline"`)
+  })
 })
 
 describe(`slider extension`, () => {

--- a/packages/core/src/extensions/markup.ts
+++ b/packages/core/src/extensions/markup.ts
@@ -26,6 +26,18 @@ function followsWordChar(tokens: Token[] | undefined): boolean {
   return WORD_CHAR.test(prevInlineChar(tokens))
 }
 
+// Regex lookbehind throws at parse time in JS engines without support (older
+// WebViews) and would take down the whole renderer, so boundaries are enforced
+// with plain scans/character classes instead of `(?<!...)`/`(?<=...)`.
+function boundaryStart(src: string, delimiter: RegExp): number | undefined {
+  const rule = new RegExp(delimiter.source, `g`)
+  for (let match = rule.exec(src); match !== null; match = rule.exec(src)) {
+    if (!WORD_CHAR.test(src.charAt(match.index - 1))) {
+      return match.index
+    }
+  }
+}
+
 /** Extended markup: ==highlight==, ++underline++, ~wavyline~ */
 export function markedMarkup(): MarkedExtension {
   return {
@@ -34,13 +46,13 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_highlight`,
         level: `inline`,
         start(src: string) {
-          return src.match(/(?<![A-Z0-9])==(?!=)/i)?.index
+          return boundaryStart(src, /==(?!=)/)
         },
         tokenizer(src: string, tokens: Token[]) {
           if (followsWordChar(tokens)) {
             return
           }
-          const rule = /^==(?=\S)((?:[^=]|=(?!=))+)(?<=\S)==/
+          const rule = /^==(?=\S)((?:[^=]|=(?!=))*[^\s=])==/
           const match = rule.exec(src)
           if (match) {
             return {
@@ -59,13 +71,13 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_underline`,
         level: `inline`,
         start(src: string) {
-          return src.match(/(?<![A-Z0-9])\+\+(?!\+)/i)?.index
+          return boundaryStart(src, /\+\+(?!\+)/)
         },
         tokenizer(src: string, tokens: Token[]) {
           if (followsWordChar(tokens)) {
             return
           }
-          const rule = /^\+\+(?=\S)((?:[^+]|\+(?!\+))+)(?<=\S)\+\+/
+          const rule = /^\+\+(?=\S)((?:[^+]|\+(?!\+))*[^\s+])\+\+/
           const match = rule.exec(src)
           if (match) {
             return {
@@ -84,13 +96,13 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_wavyline`,
         level: `inline`,
         start(src: string) {
-          return src.match(/(?<![A-Z0-9])~(?!~)/i)?.index
+          return boundaryStart(src, /~(?!~)/)
         },
         tokenizer(src: string, tokens: Token[]) {
           if (followsWordChar(tokens)) {
             return
           }
-          const rule = /^~(?=\S)([^~\n]+)(?<=\S)~(?!~)/
+          const rule = /^~(?=\S)([^~\n]*[^\s~])~(?!~)/
           const match = rule.exec(src)
           if (match) {
             return {

--- a/packages/core/src/extensions/markup.ts
+++ b/packages/core/src/extensions/markup.ts
@@ -1,6 +1,30 @@
-import type { MarkedExtension } from 'marked'
+import type { MarkedExtension, Token } from 'marked'
 import type { MarkupHighlightToken, MarkupUnderlineToken, MarkupWavylineToken } from '../types/marked-tokens'
 import { asTextTokenRenderer } from '../types/marked-tokens'
+
+// ASCII-only on purpose: `C++`/`x==1`/`v1~2` must stay literal, while CJK
+// intraword usage like `把++重点++标出` should keep rendering.
+const WORD_CHAR = /[A-Z0-9]/i
+
+// Inline tokenizers only see `src` from the candidate position on, so the left
+// boundary is recovered from the already-tokenized inline tokens instead.
+function prevInlineChar(tokens: Token[] | undefined): string {
+  const last = tokens?.[tokens.length - 1]
+  if (!last) {
+    return ``
+  }
+  const nested = (last as { tokens?: Token[] }).tokens
+  if (Array.isArray(nested) && nested.length > 0) {
+    return prevInlineChar(nested)
+  }
+  const text = (last as { text?: string }).text ?? last.raw ?? ``
+  return text.charAt(text.length - 1)
+}
+
+/** Opening delimiter must not directly follow a word char (blocks `C++`). */
+function followsWordChar(tokens: Token[] | undefined): boolean {
+  return WORD_CHAR.test(prevInlineChar(tokens))
+}
 
 /** Extended markup: ==highlight==, ++underline++, ~wavyline~ */
 export function markedMarkup(): MarkedExtension {
@@ -10,10 +34,13 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_highlight`,
         level: `inline`,
         start(src: string) {
-          return src.match(/==(?!=)/)?.index
+          return src.match(/(?<![A-Z0-9])==(?!=)/i)?.index
         },
-        tokenizer(src: string) {
-          const rule = /^==((?:[^=]|=(?!=))+)==/
+        tokenizer(src: string, tokens: Token[]) {
+          if (followsWordChar(tokens)) {
+            return
+          }
+          const rule = /^==(?=\S)((?:[^=]|=(?!=))+)(?<=\S)==/
           const match = rule.exec(src)
           if (match) {
             return {
@@ -32,10 +59,13 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_underline`,
         level: `inline`,
         start(src: string) {
-          return src.match(/\+\+(?!\+)/)?.index
+          return src.match(/(?<![A-Z0-9])\+\+(?!\+)/i)?.index
         },
-        tokenizer(src: string) {
-          const rule = /^\+\+((?:[^+]|\+(?!\+))+)\+\+/
+        tokenizer(src: string, tokens: Token[]) {
+          if (followsWordChar(tokens)) {
+            return
+          }
+          const rule = /^\+\+(?=\S)((?:[^+]|\+(?!\+))+)(?<=\S)\+\+/
           const match = rule.exec(src)
           if (match) {
             return {
@@ -54,10 +84,13 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_wavyline`,
         level: `inline`,
         start(src: string) {
-          return src.match(/~(?!~)/)?.index
+          return src.match(/(?<![A-Z0-9])~(?!~)/i)?.index
         },
-        tokenizer(src: string) {
-          const rule = /^~([^~\n]+)~(?!~)/
+        tokenizer(src: string, tokens: Token[]) {
+          if (followsWordChar(tokens)) {
+            return
+          }
+          const rule = /^~(?=\S)([^~\n]+)(?<=\S)~(?!~)/
           const match = rule.exec(src)
           if (match) {
             return {


### PR DESCRIPTION
## Summary

- Add boundary (flanking) rules to the custom markup extension (`==highlight==`, `++underline++`, `~wavyline~`): the opening delimiter must not directly follow an ASCII letter/digit, and the delimiters must not wrap whitespace-only boundaries (`++ 文字 ++` stays literal, matching CommonMark emphasis flanking behavior).
- Previously, intraword text like `C++是最好的语言，C++是最好的语言` had its two `++` sequences paired as underline delimiters: `是最好的语言，C` was rendered underlined and the `++` delimiters were swallowed. The same class of issue affected `x==1==y` and `v1~2~3`.
- The left boundary is enforced both in `start` (lookbehind) and in the tokenizer via the preceding inline token chain, so cross-token cases like `**C**++text++` stay literal as well. CJK intraword usage such as `把++重点++标出` keeps rendering.

## Type of Change

- [x] Bug fix

## Test Procedure

- Added 5 unit tests covering: literal `C++`, intraword `x==1==y` / `v1~2~3`, cross-token boundary (`**C**++...++`), whitespace-wrapped delimiters, and continued CJK intraword rendering.
- `pnpm --filter @md/core test` — 62/62 passing
- `pnpm --filter @md/core type-check` — clean
