### PR TITLE
fix(docs): repair broken star history chart

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -144,11 +144,11 @@ Then open http://localhost:8080 in your browser. For more details on the Docker 
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=doocs%2Fmd&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#doocs/md&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=doocs/md&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=doocs/md&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=doocs/md&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ docker run -d -p 8080:80 doocs/md:latest
 
 ## Star 趋势
 
-<a href="https://www.star-history.com/?repos=doocs%2Fmd&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#doocs/md&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=doocs/md&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=doocs/md&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=doocs/md&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the README is currently broken and no longer renders, which prevents visitors from seeing the project's growth at a glance.

This change switches the chart image and its wrapping link to a maintained and reliable source that requires no API token, so the chart displays correctly again for both light and dark color schemes.

Updated the Chinese README and the English README to keep them in sync.