### PR TITLE
docs: replace star-history chart with repo-hosted starcharts

### DIFF
--- a/.github/workflows/starcharts.yml
+++ b/.github/workflows/starcharts.yml
@@ -1,0 +1,19 @@
+name: update-starcharts
+
+on:
+  schedule:
+    - cron: "0 0/12 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    name: Generate starcharts
+    runs-on: ubuntu-latest
+    if: github.repository == 'doocs/md'
+    steps:
+      - uses: MaoLongLong/actions-starcharts@main
+        with:
+          github_token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
+          svg_path: images/starcharts.svg
+          commit_message: "chore: auto update starcharts"
+          stars_change: ${{ secrets.STARS_CHANGE }}

--- a/README-EN.md
+++ b/README-EN.md
@@ -144,13 +144,7 @@ Then open http://localhost:8080 in your browser. For more details on the Docker 
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=doocs%2Fmd&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
- </picture>
-</a>
+<a href="https://github.com/doocs/md/stargazers" target="_blank"><img src="./images/starcharts.svg" alt="Stargazers over time" /></a>
 
 ## Who's Using It
 

--- a/README.md
+++ b/README.md
@@ -143,13 +143,7 @@ docker run -d -p 8080:80 doocs/md:latest
 
 ## Star 趋势
 
-<a href="https://www.star-history.com/?repos=doocs%2Fmd&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=doocs/md&type=date&legend=top-left" />
- </picture>
-</a>
+<a href="https://github.com/doocs/md/stargazers" target="_blank"><img src="./images/starcharts.svg" alt="Stargazers over time" /></a>
 
 ## 谁在使用
 


### PR DESCRIPTION
## Summary

star-history.com 的图表接口已被限流，README 中的 Star 趋势图无法正常加载。本 PR 参照 [doocs/leetcode](https://github.com/doocs/leetcode) 的做法，改为仓库自托管的星图：

- 新增 `.github/workflows/update-starcharts`：通过 [MaoLongLong/actions-starcharts](https://github.com/MaoLongLong/actions-starcharts) 每 12 小时生成 `images/starcharts.svg` 并自动提交到仓库（支持 `workflow_dispatch` 手动触发）
- `README.md` / `README-EN.md`：移除 star-history.com 的实时图表，改为引用仓库本地 `./images/starcharts.svg`，点击跳转至 stargazers 页面

**合并后需要注意：**

1. Workflow 沿用了 leetcode 的 `DOOCS_BOT_ACTION_TOKEN` 与 `STARS_CHANGE` 两个 secrets。若本仓库无法访问这两个 org 级 secret，`github_token` 改用默认的 `secrets.GITHUB_TOKEN` 即可（`stars_change` 入参可省略，默认为 1）。
2. `images/starcharts.svg` 需由 workflow 首次运行后生成，合并后请在 Actions 页面手动触发一次 `update-starcharts`，否则 README 会暂时显示裂图。

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [x] Workflow / CI

## Test Procedure

- 本地校验了 workflow YAML 语法及 README 改动后的渲染结构
- 该方案与 doocs/leetcode 线上运行中的配置一致（仅仓库守护条件改为 `doocs/md`）
- 合并后手动触发 workflow，确认 `images/starcharts.svg` 生成且 README 正常展示

## Pre-flight Checklist

- [x] 分支命名符合 `docs/<简要描述>` 规范
- [x] Commit message 遵循 Conventional Commits 且使用英文
- [x] PR 只包含本变更相关的 3 个文件（`README.md`、`README-EN.md`、`.github/workflows/starcharts.yml`）
