### PR TITLE
fix(web): keep Mermaid diagrams intact when copying to WeChat

### DIFF
--- a/apps/web/src/components/editor/PreviewPanel.vue
+++ b/apps/web/src/components/editor/PreviewPanel.vue
@@ -193,6 +193,16 @@ defineExpose({
   position: relative;
 }
 
+/*
+ * Journey (and other useMaxWidth diagrams) emit width="100%" plus a fixed
+ * pixel height. With preserveAspectRatio=xMinYMin meet, leftover height
+ * becomes a blank band under the chart. Let height follow the viewBox.
+ */
+.mermaid-diagram > svg {
+  max-width: 100%;
+  height: auto;
+}
+
 .diagram-download-bar {
   position: absolute;
   top: 8px;

--- a/apps/web/src/services/export/clipboard-dom.ts
+++ b/apps/web/src/services/export/clipboard-dom.ts
@@ -3,6 +3,156 @@
  * Kept free of Pinia/store imports so unit tests can run without app bootstrap.
  */
 
+const GENERIC_FONT_FAMILIES = /^(?:serif|sans-serif|monospace|cursive|fantasy|system-ui|ui-sans-serif|ui-serif|ui-monospace|ui-rounded|inherit|initial|unset|revert|revert-layer)$/i
+
+/** Mermaid may emit `style="undefined;"` on edges; juice's CSS parser then throws. */
+function isUndefinedCssValue(value: string): boolean {
+  const normalized = value.replace(/\s*!important$/i, ``).trim()
+  return !normalized || /^undefined$/i.test(normalized) || /\bundefined\b/i.test(normalized)
+}
+
+/** Multi-word fonts that juice/PostCSS reject when unquoted. WeChat does not ship them anyway. */
+const FONT_FAMILY_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/^open sans$/i, `sans-serif`],
+  [/^trebuchet ms$/i, `sans-serif`],
+  [/^segoe ui$/i, `sans-serif`],
+  [/^helvetica neue$/i, `sans-serif`],
+  [/^noto sans$/i, `sans-serif`],
+  [/^pingfang sc$/i, `sans-serif`],
+  [/^microsoft yahei$/i, `sans-serif`],
+  [/^微软雅黑$/, `sans-serif`],
+  [/^operator mono$/i, `monospace`],
+  [/^fira code$/i, `monospace`],
+  [/^courier new$/i, `monospace`],
+]
+
+function mapFontFamilyName(family: string): string {
+  const unquoted = family.replace(/["']/g, ``).trim()
+  if (!unquoted)
+    return family
+  if (/^var\(/i.test(family))
+    return family
+  if (GENERIC_FONT_FAMILIES.test(unquoted))
+    return unquoted
+  for (const [pattern, replacement] of FONT_FAMILY_REPLACEMENTS) {
+    if (pattern.test(unquoted))
+      return replacement
+  }
+  if (/\s/.test(unquoted) || unquoted.split(``).some(ch => ch.charCodeAt(0) > 127))
+    return `'${unquoted}'`
+  return unquoted
+}
+
+function quoteFontFamilyList(value: string): string {
+  return value
+    .split(/,(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/)
+    .map(part => mapFontFamilyName(part.trim()))
+    .filter(Boolean)
+    .join(`, `)
+}
+
+/** C4 / sequence / gantt default to unquoted `Open Sans`, which juice/PostCSS rejects. */
+function quoteUnquotedFontFamilies(css: string): string {
+  return css
+    .replace(/font-family\s*:\s*([^;}{]+)/gi, (_, value: string) => `font-family: ${quoteFontFamilyList(value)}`)
+    .replace(/(?<!['"])\bOpen Sans\b(?!['"])/gi, `sans-serif`)
+}
+
+function decodeStyleAttr(value: string): string {
+  return value
+    .replace(/&quot;/g, `"`)
+    .replace(/&#34;/g, `"`)
+    .replace(/&apos;|&#39;/g, `'`)
+    .replace(/&amp;/g, `&`)
+}
+
+function encodeStyleAttr(value: string, quote: string): string {
+  let next = value.replace(/&/g, `&amp;`)
+  if (quote === `"`)
+    next = next.replace(/"/g, `&quot;`)
+  else
+    next = next.replace(/'/g, `&#39;`)
+  return next
+}
+
+function sanitizeCssDeclarations(css: string): string {
+  const cleaned = css
+    .split(`;`)
+    .map(part => part.trim())
+    .filter((part) => {
+      if (!part || /^undefined$/i.test(part))
+        return false
+      const colon = part.indexOf(`:`)
+      if (colon === -1)
+        return false
+      return !isUndefinedCssValue(part.slice(colon + 1))
+    })
+    .join(`; `)
+  return quoteUnquotedFontFamilies(cleaned)
+}
+
+function sanitizeEmbeddedStylesheet(css: string): string {
+  return quoteUnquotedFontFamilies(
+    css.replace(/([a-z_-]+)\s*:\s*undefined\b\s*;?/gi, ``),
+  )
+}
+
+/**
+ * Drop / rewrite CSS that juice cannot parse.
+ * Mermaid emits `style="undefined;"` on edges and unquoted `Open Sans` on C4 / sequence / gantt.
+ * Must run before juice inlines styles for WeChat copy.
+ */
+export function stripInvalidCssForJuice(root: ParentNode) {
+  root.querySelectorAll(`[style]`).forEach((el) => {
+    const raw = el.getAttribute(`style`)
+    if (raw == null)
+      return
+    const next = sanitizeCssDeclarations(raw)
+    if (next)
+      el.setAttribute(`style`, next)
+    else
+      el.removeAttribute(`style`)
+  })
+
+  root.querySelectorAll(`style`).forEach((el) => {
+    const raw = el.textContent
+    if (!raw)
+      return
+    if (/\bundefined\b/i.test(raw) || /font-family\s*:/i.test(raw) || /\bOpen Sans\b/i.test(raw))
+      el.textContent = sanitizeEmbeddedStylesheet(raw)
+  })
+}
+
+/**
+ * Quote / drop juice-invalid CSS in the HTML string juice actually parses.
+ * Needed because browsers re-serialize `style="font-family: 'Open Sans'"` as
+ * unquoted `Open Sans`, which PostCSS then rejects (`Unknown word Open`).
+ */
+export function sanitizeHtmlCssForJuice(html: string): string {
+  const withStyleAttrs = html.replace(/\sstyle\s*=\s*(["'])([\s\S]*?)\1/gi, (_full, quote: string, value: string) => {
+    const sanitized = sanitizeCssDeclarations(decodeStyleAttr(value))
+    return ` style=${quote}${encodeStyleAttr(sanitized, quote)}${quote}`
+  })
+
+  const withSheets = withStyleAttrs.replace(/(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi, (_full, open: string, css: string, close: string) => {
+    return `${open}${sanitizeEmbeddedStylesheet(css)}${close}`
+  })
+
+  // Mermaid also sets SVG presentation attributes: font-family="Open Sans, sans-serif"
+  const withFontAttrs = withSheets.replace(/\sfont-family\s*=\s*(["'])([\s\S]*?)\1/gi, (_full, quote: string, value: string) => {
+    return ` font-family=${quote}${encodeStyleAttr(quoteFontFamilyList(decodeStyleAttr(value)), quote)}${quote}`
+  })
+
+  return withFontAttrs.replace(/(?<!['"])\bOpen Sans\b(?!['"])/gi, `sans-serif`)
+}
+
+export function stripFontFamilyForJuiceFallback(html: string): string {
+  return html
+    .replace(/font-family\s*:[^;}{]+;?/gi, ``)
+    .replace(/\sfont-family\s*=\s*(["'])[\s\S]*?\1/gi, ``)
+    .replace(/(?<!['"])\bOpen Sans\b(?!['"])/gi, `sans-serif`)
+}
+
 export function solveWeChatImage(container?: HTMLElement) {
   const clipboardDiv = container ?? document.getElementById(`output`)
   if (!clipboardDiv)
@@ -43,4 +193,31 @@ export function createEmptyNode(): HTMLElement {
   node.style.margin = `0`
   node.innerHTML = `&nbsp;`
   return node
+}
+
+/**
+ * Mermaid labels live in <foreignObject><div xmlns ...> (flowchart nodeLabel,
+ * ER .name / .attribute-*, class, C4, …). WeChat drops that HTML unless the
+ * inner node is a <section>.
+ */
+export function promoteSvgHtmlLabels(root: ParentNode) {
+  if (!root.querySelector(`.mermaid-diagram foreignObject`))
+    return
+
+  root.querySelectorAll(`foreignObject`).forEach((foreign) => {
+    if (!foreign.closest(`.mermaid-diagram`))
+      return
+
+    const inner = foreign.querySelector(`:scope > div, :scope > span, :scope > section`)
+    if (!inner || inner.localName === `section`)
+      return
+
+    const section = document.createElement(`section`)
+    section.setAttribute(`xmlns`, inner.getAttribute(`xmlns`) || `http://www.w3.org/1999/xhtml`)
+    const style = inner.getAttribute(`style`) || ``
+    if (style)
+      section.setAttribute(`style`, style)
+    section.innerHTML = inner.innerHTML
+    foreign.replaceChildren(section)
+  })
 }

--- a/apps/web/src/services/export/clipboard.test.ts
+++ b/apps/web/src/services/export/clipboard.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
-import { modifyHtmlStructure, solveWeChatImage } from './clipboard-dom'
+import { modifyHtmlStructure, promoteSvgHtmlLabels, sanitizeHtmlCssForJuice, solveWeChatImage, stripInvalidCssForJuice } from './clipboard-dom'
 
 describe(`modifyHtmlStructure`, () => {
   it(`moves nested lists out of their parent li`, () => {
@@ -59,5 +59,171 @@ describe(`solveWeChatImage`, () => {
     expect(img.style.height).toBe(`auto`)
 
     container.remove()
+  })
+})
+
+describe(`stripInvalidCssForJuice`, () => {
+  it(`removes mermaid edge styles that are only undefined`, () => {
+    const root = document.createElement(`div`)
+    root.innerHTML = `<svg><path style="undefined;" d="M0 0"></path><path style="undefined;;;undefined" d="M1 1"></path></svg>`
+
+    stripInvalidCssForJuice(root)
+
+    expect(root.querySelectorAll(`[style]`)).toHaveLength(0)
+  })
+
+  it(`keeps valid declarations and drops undefined values`, () => {
+    const root = document.createElement(`div`)
+    root.innerHTML = `<path style="fill:#fff;stroke:undefined;stroke-width:1.5"></path>`
+
+    stripInvalidCssForJuice(root)
+
+    expect(root.querySelector(`path`)?.getAttribute(`style`)).toBe(`fill:#fff; stroke-width:1.5`)
+  })
+
+  it(`strips undefined declarations from embedded stylesheets`, () => {
+    const root = document.createElement(`div`)
+    root.innerHTML = `<style>#n{fill:#fff;stroke:undefined;color:#333}</style>`
+
+    stripInvalidCssForJuice(root)
+
+    expect(root.querySelector(`style`)?.textContent).toBe(`#n{fill:#fff;color:#333}`)
+  })
+
+  it(`lets juice parse mermaid HTML that previously threw Unknown word undefined`, async () => {
+    const { default: juice } = await import(`juice`)
+    const root = document.createElement(`div`)
+    root.innerHTML = `<div><svg><path class="edge" style="undefined;;;undefined" d="M0 0"></path></svg></div>`
+
+    stripInvalidCssForJuice(root)
+
+    expect(() => juice(root.innerHTML, {
+      inlinePseudoElements: true,
+      preserveImportant: true,
+      resolveCSSVariables: false,
+    })).not.toThrow()
+  })
+
+  it(`quotes unquoted Open Sans so juice does not throw Unknown word Open`, async () => {
+    const { default: juice } = await import(`juice`)
+    const root = document.createElement(`div`)
+    root.innerHTML = `<svg><path style="fill: #1168BD;stroke: #0B4884;color: #FFFFFF;font-family:Open Sans, sans-serif"></path></svg>`
+
+    stripInvalidCssForJuice(root)
+
+    expect(root.querySelector(`path`)?.getAttribute(`style`)).toContain(`sans-serif`)
+    expect(root.querySelector(`path`)?.getAttribute(`style`)).not.toMatch(/Open Sans/)
+    expect(() => juice(sanitizeHtmlCssForJuice(root.innerHTML), {
+      inlinePseudoElements: true,
+      preserveImportant: true,
+      resolveCSSVariables: false,
+    })).not.toThrow()
+  })
+
+  it(`rewrites Open Sans in the HTML string after browsers drop style quotes`, async () => {
+    const { default: juice } = await import(`juice`)
+    const html = `<svg><path style="fill: #1168BD;stroke: #0B4884;color: #FFFFFF;font-family:Open Sans, sans-serif"></path></svg>`
+
+    const sanitized = sanitizeHtmlCssForJuice(html)
+    expect(sanitized).toContain(`sans-serif`)
+    expect(sanitized).not.toMatch(/Open Sans/)
+    expect(() => juice(sanitized, {
+      inlinePseudoElements: true,
+      preserveImportant: true,
+      resolveCSSVariables: false,
+    })).not.toThrow()
+  })
+
+  it(`rewrites sequence/C4 text styles that juice reports at column 43`, async () => {
+    const { default: juice } = await import(`juice`)
+    const html = `<svg><text style="dominant-baseline:central;font-family:Open Sans,sans-serif" font-family="Open Sans, sans-serif">A</text></svg>`
+
+    const sanitized = sanitizeHtmlCssForJuice(html)
+    expect(sanitized).not.toMatch(/Open Sans/)
+    expect(() => juice(sanitized, {
+      inlinePseudoElements: true,
+      preserveImportant: true,
+      resolveCSSVariables: false,
+    })).not.toThrow()
+  })
+})
+
+describe(`promoteSvgHtmlLabels`, () => {
+  it(`turns mermaid foreignObject labels into WeChat <section> nodes`, () => {
+    const root = document.createElement(`div`)
+    root.className = `mermaid-diagram`
+    root.innerHTML = `
+      <svg>
+        <g class="label">
+          <foreignObject>
+            <div style="display: table;">
+              <span class="nodeLabel">决策</span>
+            </div>
+          </foreignObject>
+        </g>
+        <g class="name">
+          <foreignObject>
+            <div xmlns="http://www.w3.org/1999/xhtml" style="color:#333">
+              <span>用户</span>
+            </div>
+          </foreignObject>
+        </g>
+      </svg>
+    `
+
+    promoteSvgHtmlLabels(root)
+
+    const sections = root.querySelectorAll(`section`)
+    expect(sections).toHaveLength(2)
+    expect(sections[0].textContent).toContain(`决策`)
+    expect(sections[1].textContent).toContain(`用户`)
+    expect(root.querySelector(`foreignObject section`)).not.toBeNull()
+  })
+})
+
+describe(`juice + sanitize flowchart pipeline`, () => {
+  it(`keeps node colors and unfilled edges after juice inlines mermaid CSS`, async () => {
+    const { default: juice } = await import(`juice`)
+    const { sanitizeSvgsForWeChat } = await import(`./wechat-svg`)
+
+    const root = document.createElement(`div`)
+    root.innerHTML = `
+      <div class="mermaid-diagram">
+        <svg id="mermaid-svg-td" viewBox="0 0 240 160" xmlns="http://www.w3.org/2000/svg">
+          <style>
+            #mermaid-svg-td .node rect,#mermaid-svg-td .node polygon{fill:#ECECFF;stroke:#9370DB;}
+            #mermaid-svg-td .flowchart-link{fill:none;stroke:#333333;stroke-width:1.5px;}
+          </style>
+          <g class="node">
+            <polygon points="40,10 70,40 40,70 10,40"></polygon>
+          </g>
+          <g class="node">
+            <rect x="120" y="20" width="80" height="40"></rect>
+          </g>
+          <path class="flowchart-link" fill="none" d="M70 40h50"></path>
+        </svg>
+      </div>
+    `
+
+    stripInvalidCssForJuice(root)
+    root.innerHTML = juice(root.innerHTML, {
+      inlinePseudoElements: true,
+      preserveImportant: true,
+      resolveCSSVariables: false,
+    })
+    document.body.appendChild(root)
+    sanitizeSvgsForWeChat(root)
+
+    const polygon = root.querySelector(`polygon`)!
+    const rect = root.querySelector(`rect`)!
+    const path = root.querySelector(`path`)!
+    expect(polygon.getAttribute(`fill`)?.toLowerCase()).toMatch(/#ececff|rgb\(236,\s*236,\s*255\)/)
+    expect(rect.getAttribute(`fill`)?.toLowerCase()).toMatch(/#ececff|rgb\(236,\s*236,\s*255\)/)
+    expect(path.getAttribute(`fill`)).toBe(`none`)
+    expect(path.getAttribute(`stroke`)).toBe(`currentColor`)
+    expect(root.querySelector(`svg style`)).toBeNull()
+    expect(root.querySelector(`svg[class], svg [class]`)).toBeNull()
+
+    root.remove()
   })
 })

--- a/apps/web/src/services/export/clipboard.ts
+++ b/apps/web/src/services/export/clipboard.ts
@@ -2,19 +2,37 @@ import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from '@/lib/pre
 import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
 import { useUIStore } from '@/stores/ui'
-import { createEmptyNode, modifyHtmlStructure, solveWeChatImage } from './clipboard-dom'
+import { createEmptyNode, modifyHtmlStructure, promoteSvgHtmlLabels, sanitizeHtmlCssForJuice, solveWeChatImage, stripFontFamilyForJuiceFallback, stripInvalidCssForJuice } from './clipboard-dom'
 import { getStylesToAdd } from './share-styles'
-import { prepareMathFormulasForWeChat, sanitizeSvgsForWeChat } from './wechat-svg'
+import { prepareDiagramSvgsForWeChat, prepareMathFormulasForWeChat, sanitizeSvgsForWeChat } from './wechat-svg'
 
 export { modifyHtmlStructure, solveWeChatImage } from './clipboard-dom'
 
+const JUICE_OPTIONS = {
+  inlinePseudoElements: true,
+  preserveImportant: true,
+  resolveCSSVariables: false,
+} as const
+
 async function mergeCss(html: string): Promise<string> {
   const { default: juice } = await import(`juice`)
-  return juice(html, {
-    inlinePseudoElements: true,
-    preserveImportant: true,
-    resolveCSSVariables: false,
-  })
+  const sanitized = sanitizeHtmlCssForJuice(html)
+  const attempts = [
+    () => juice(sanitized, JUICE_OPTIONS),
+    () => juice(sanitized, { ...JUICE_OPTIONS, inlinePseudoElements: false }),
+    () => juice(stripFontFamilyForJuiceFallback(sanitized), { ...JUICE_OPTIONS, inlinePseudoElements: false }),
+  ]
+
+  for (const attempt of attempts) {
+    try {
+      return attempt()
+    }
+    catch (error) {
+      console.warn(`WeChat copy: juice failed, trying fallback`, error)
+    }
+  }
+
+  return sanitized
 }
 
 /**
@@ -47,6 +65,7 @@ export async function processClipboardContent(primaryColor: string) {
   try {
     const clipboardDiv = outputElement.cloneNode(true) as HTMLElement
     stripUnresolvedAsyncPlaceholders(clipboardDiv)
+    prepareDiagramSvgsForWeChat(clipboardDiv)
 
     const stylesToAdd = await getStylesToAdd()
 
@@ -54,6 +73,7 @@ export async function processClipboardContent(primaryColor: string) {
       clipboardDiv.innerHTML = stylesToAdd + clipboardDiv.innerHTML
     }
 
+    stripInvalidCssForJuice(clipboardDiv)
     clipboardDiv.innerHTML = modifyHtmlStructure(await mergeCss(clipboardDiv.innerHTML))
 
     clipboardDiv.querySelectorAll(`a[href^="#"]`).forEach(a => a.removeAttribute(`href`))
@@ -82,55 +102,7 @@ export async function processClipboardContent(primaryColor: string) {
     clipboardDiv.insertBefore(beforeNode, clipboardDiv.firstChild)
     clipboardDiv.appendChild(afterNode)
 
-    const nodes = clipboardDiv.querySelectorAll(`.nodeLabel`)
-    nodes.forEach((node) => {
-      const parent = node.parentElement
-      if (!parent)
-        return
-      const xmlns = parent.getAttribute(`xmlns`)
-      const style = parent.getAttribute(`style`)
-      if (!xmlns || !style)
-        return
-      const section = document.createElement(`section`)
-      section.setAttribute(`xmlns`, xmlns)
-      section.setAttribute(`style`, style)
-      section.innerHTML = parent.innerHTML
-
-      const grand = parent.parentElement
-      if (!grand)
-        return
-      grand.innerHTML = ``
-      grand.appendChild(section)
-    })
-
-    clipboardDiv.innerHTML = clipboardDiv.innerHTML
-      .replace(
-        /<tspan([^>]*)>/g,
-        `<tspan$1 style="fill: currentColor !important; color: currentColor !important; stroke: none !important;">`,
-      )
-
-    clipboardDiv.querySelectorAll(`.infographic-diagram`).forEach((diagram) => {
-      diagram.querySelectorAll(`text`).forEach((textElem) => {
-        const dominantBaseline = textElem.getAttribute(`dominant-baseline`)
-        const variantMap = {
-          'alphabetic': ``,
-          'central': `0.35em`,
-          'middle': `0.35em`,
-          'hanging': `-0.55em`,
-          'ideographic': `0.18em`,
-          'text-before-edge': `-0.85em`,
-          'text-after-edge': `0.15em`,
-        }
-        if (dominantBaseline) {
-          textElem.removeAttribute(`dominant-baseline`)
-          const dy = variantMap[dominantBaseline as keyof typeof variantMap]
-          if (dy) {
-            textElem.setAttribute(`dy`, dy)
-          }
-        }
-      })
-    })
-
+    promoteSvgHtmlLabels(clipboardDiv)
     sanitizeSvgsForWeChat(clipboardDiv)
     prepareMathFormulasForWeChat(clipboardDiv)
 

--- a/apps/web/src/services/export/wechat-svg.test.ts
+++ b/apps/web/src/services/export/wechat-svg.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
 import {
+  prepareDiagramSvgsForWeChat,
   prepareMathFormulasForWeChat,
   remapDiagramInkToCurrentColor,
   sanitizeSvgForWeChat,
@@ -71,6 +72,321 @@ describe(`sanitizeSvgForWeChat`, () => {
 
     expect(Number(svg.getAttribute(`width`))).toBeLessThanOrEqual(677)
     expect(Number(svg.getAttribute(`height`))).toBeLessThanOrEqual(677)
+
+    svg.remove()
+  })
+
+  it(`bakes sankey gradient strokes into a solid color before stripping ids`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+        <g class="links" fill="none" stroke-opacity="0.5">
+          <g class="link">
+            <linearGradient id="linearGradient-flow" gradientUnits="userSpaceOnUse" x1="20" x2="180">
+              <stop offset="0%" stop-color="#4e79a7"></stop>
+              <stop offset="100%" stop-color="#f28e2c"></stop>
+            </linearGradient>
+            <path d="M20 20C80 20 80 60 180 60" stroke="url(#linearGradient-flow)" stroke-width="12"></path>
+          </g>
+        </g>
+        <g class="nodes">
+          <rect x="10" y="10" width="10" height="20" fill="#4e79a7"></rect>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(svg)
+
+    sanitizeSvgForWeChat(svg)
+
+    const path = svg.querySelector(`path`)!
+    const stroke = path.getAttribute(`stroke`) ?? ``
+    expect(stroke.startsWith(`url(`)).toBe(false)
+    expect(stroke).toMatch(/#|rgb/i)
+    expect(svg.querySelector(`linearGradient`)).toBeNull()
+    expect(svg.querySelector(`rect`)?.getAttribute(`fill`)).toBe(`#4e79a7`)
+
+    svg.remove()
+  })
+
+  it(`keeps flowchart edge fill=none so links are not painted as blobs`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.innerHTML = `
+      <svg id="mermaid-svg-flow" viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+        <style>#mermaid-svg-flow .node rect{fill:#ECECFF;stroke:#9370DB;}</style>
+        <g class="node"><rect width="80" height="40" style="fill:#ECECFF;stroke:#9370DB"></rect></g>
+        <g class="edgePath"><path fill="none" stroke="#333333" d="M0 40h80"></path></g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(svg)
+
+    sanitizeSvgForWeChat(svg)
+
+    expect(svg.querySelector(`path`)?.getAttribute(`fill`)).toBe(`none`)
+    expect(svg.querySelector(`path`)?.getAttribute(`stroke`)).toBe(`currentColor`)
+    expect(svg.querySelector(`rect`)?.getAttribute(`fill`)?.toLowerCase()).toMatch(/#ececff|rgb\(236,\s*236,\s*255\)/)
+    expect(svg.querySelector(`rect`)?.getAttribute(`stroke`)?.toLowerCase()).toMatch(/#9370db|rgb\(147,\s*112,\s*219\)/)
+
+    svg.remove()
+  })
+
+  it(`persists CSS-only fill:none before classes and style tags are stripped`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.innerHTML = `
+      <svg id="mermaid-svg-css-none" viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+        <style>#mermaid-svg-css-none .flowchart-link{fill:none;stroke:#333333;}</style>
+        <path class="flowchart-link" style="fill:none;stroke:#333333" d="M0 40h80"></path>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(svg)
+
+    sanitizeSvgForWeChat(svg)
+
+    expect(svg.querySelector(`path`)?.getAttribute(`fill`)).toBe(`none`)
+    expect(svg.querySelector(`path`)?.getAttribute(`stroke`)).toBe(`currentColor`)
+
+    svg.remove()
+  })
+
+  it(`does not let juice-inlined style fill override an explicit fill=none`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+        <g class="edgePath" style="fill: rgb(51, 51, 51)">
+          <path fill="none" stroke="#333333" style="fill: rgb(51, 51, 51)" d="M0 40h80"></path>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(svg)
+
+    sanitizeSvgForWeChat(svg)
+
+    const path = svg.querySelector(`path`)!
+    expect(path.getAttribute(`fill`)).toBe(`none`)
+    expect(path.getAttribute(`style`) ?? ``).not.toMatch(/fill\s*:/)
+    expect(svg.querySelector(`g`)?.getAttribute(`fill`)).toBeNull()
+    expect(svg.querySelector(`g`)?.getAttribute(`style`) ?? ``).not.toMatch(/fill\s*:/)
+
+    svg.remove()
+  })
+
+  it(`converts mermaid html labels to SVG text without extra dy offset`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.className = `mermaid-diagram`
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 1000 200" width="100%" xmlns="http://www.w3.org/2000/svg">
+        <text font-size="16px" x="10" y="20">决策</text>
+        <g>
+          <foreignObject width="80" height="40">
+            <section style="font-size: 16px; display: table;">
+              <span class="nodeLabel">排除问题</span>
+            </section>
+          </foreignObject>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(wrapper)
+
+    sanitizeSvgForWeChat(svg)
+
+    const labels = Array.from(svg.querySelectorAll(`text`)).map(el => el.textContent)
+    expect(labels).toContain(`决策`)
+    expect(labels).toContain(`排除问题`)
+    expect(svg.querySelector(`foreignObject`)).toBeNull()
+    expect(svg.querySelector(`text`)?.getAttribute(`dy`)).toBeNull()
+
+    wrapper.remove()
+  })
+
+  it(`flattens mermaid labels even after the svg is detached for getComputedStyle`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.className = `mermaid-diagram`
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 240 80" xmlns="http://www.w3.org/2000/svg">
+        <foreignObject x="8" y="40" width="160" height="24">
+          <div style="color:#333333;font-size:16px">Risk: Medium</div>
+        </foreignObject>
+      </svg>
+    `
+    document.body.appendChild(wrapper)
+
+    sanitizeSvgsForWeChat(wrapper)
+
+    expect(wrapper.querySelector(`foreignObject`)).toBeNull()
+    expect(wrapper.querySelector(`text`)?.textContent).toBe(`Risk: Medium`)
+    expect(Number(wrapper.querySelector(`svg`)?.getAttribute(`width`))).toBe(240)
+
+    wrapper.remove()
+  })
+
+  it(`converts mermaid foreignObject labels to SVG text for WeChat`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.className = `mermaid-diagram`
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 240 80" xmlns="http://www.w3.org/2000/svg">
+        <g class="name">
+          <foreignObject x="8" y="10" width="120" height="24">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="color:#333333;font-size:16px">量表</div>
+          </foreignObject>
+        </g>
+        <g class="req">
+          <foreignObject x="8" y="40" width="160" height="24">
+            <div style="color:#333333;font-size:16px">Risk: Medium</div>
+          </foreignObject>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(wrapper)
+
+    sanitizeSvgForWeChat(svg)
+
+    expect(svg.querySelector(`foreignObject`)).toBeNull()
+    const labels = Array.from(svg.querySelectorAll(`text`)).map(el => el.textContent)
+    expect(labels).toContain(`量表`)
+    expect(labels).toContain(`Risk: Medium`)
+    const risk = Array.from(svg.querySelectorAll(`text`)).find(el => el.textContent === `Risk: Medium`)
+    expect(risk?.getAttribute(`fill`)?.toLowerCase()).toMatch(/#333|rgb\(51,\s*51,\s*51\)/)
+    expect(risk?.getAttribute(`dy`)).toBeNull()
+    expect(Number.parseFloat(risk?.getAttribute(`y`) ?? `0`)).toBeGreaterThan(40)
+
+    wrapper.remove()
+  })
+
+  it(`separates overlapping bidirectional state edge labels`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.className = `mermaid-diagram`
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 240 200" xmlns="http://www.w3.org/2000/svg">
+        <g class="edgeLabel" transform="translate(120, 100)">
+          <g class="label" transform="translate(-24, -12)">
+            <foreignObject width="48" height="24">
+              <div style="color:#333333;font-size:16px;background-color:#e8e8e8;text-align:center">条件 2</div>
+            </foreignObject>
+          </g>
+        </g>
+        <g class="edgeLabel" transform="translate(120, 100)">
+          <g class="label" transform="translate(-16, -12)">
+            <foreignObject width="32" height="24">
+              <div style="color:#333333;font-size:16px;background-color:#e8e8e8;text-align:center">返回</div>
+            </foreignObject>
+          </g>
+        </g>
+        <g class="edgeLabel" transform="translate(40, 40)">
+          <g class="label" transform="translate(-24, -12)">
+            <foreignObject width="48" height="24">
+              <div style="color:#333333;font-size:16px;text-align:center">条件 1</div>
+            </foreignObject>
+          </g>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(wrapper)
+
+    sanitizeSvgForWeChat(svg)
+
+    const texts = Array.from(svg.querySelectorAll(`text`))
+    const cond2 = texts.find(el => el.textContent === `条件 2`)
+    const back = texts.find(el => el.textContent === `返回`)
+    const cond1 = texts.find(el => el.textContent === `条件 1`)
+    expect(cond2).toBeTruthy()
+    expect(back).toBeTruthy()
+    expect(cond1).toBeTruthy()
+
+    const outerTranslate = (el: Element) => {
+      let found = { x: 0, y: 0 }
+      let node: Element | null = el
+      while (node && node.localName !== `svg`) {
+        const match = node.getAttribute(`transform`)?.match(/translate\(\s*([-\d.]+)[\s,]+([-\d.]+)\s*\)/)
+        if (match)
+          found = { x: Number.parseFloat(match[1]), y: Number.parseFloat(match[2]) }
+        node = node.parentElement
+      }
+      return found
+    }
+
+    const a = outerTranslate(cond2!)
+    const b = outerTranslate(back!)
+    const c = outerTranslate(cond1!)
+    expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThanOrEqual(40)
+    expect(c.x).toBe(40)
+    expect(c.y).toBe(40)
+    expect(svg.querySelector(`rect`)?.getAttribute(`fill`)).toMatch(/#e8e8e8|rgb\(232,\s*232,\s*232\)/i)
+
+    wrapper.remove()
+  })
+
+  it(`does not paint ER/class labels with the entity box fill`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.className = `mermaid-diagram`
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+        <g class="node" style="fill:#ECECFF;stroke:#9370DB">
+          <path fill="#ECECFF" stroke="#9370DB" d="M0 0h200v80H0z"></path>
+          <text x="10" y="24" style="color:#333333">用户</text>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(wrapper)
+
+    sanitizeSvgForWeChat(svg)
+
+    const fill = (svg.querySelector(`text`)?.getAttribute(`fill`) ?? ``).toLowerCase()
+    expect(fill).not.toMatch(/#ececff|rgb\(236,\s*236,\s*255\)/)
+    expect(fill).toMatch(/#333|rgb\(51,\s*51,\s*51\)/)
+
+    wrapper.remove()
+  })
+
+  it(`keeps C4-style light label fills instead of forcing currentColor`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 120 60" xmlns="http://www.w3.org/2000/svg">
+        <rect width="120" height="60" fill="#1168BD"></rect>
+        <text fill="#FFFFFF"><tspan fill="#FFFFFF">Person</tspan></text>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(svg)
+
+    sanitizeSvgForWeChat(svg)
+
+    expect(svg.querySelector(`rect`)?.getAttribute(`fill`)).toBe(`#1168BD`)
+    expect(svg.querySelector(`text`)?.getAttribute(`fill`)).toBe(`#FFFFFF`)
+    expect(svg.querySelector(`tspan`)?.getAttribute(`fill`)).toBe(`#FFFFFF`)
+
+    svg.remove()
+  })
+
+  it(`inlines architecture icon <use> references before stripping defs`, () => {
+    const wrapper = document.createElement(`div`)
+    wrapper.innerHTML = `
+      <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <g id="icon-cloud">
+            <path d="M10 40h60" fill="#333333"></path>
+          </g>
+        </defs>
+        <g class="architecture-service">
+          <use href="#icon-cloud" x="8" y="8"></use>
+        </g>
+      </svg>
+    `
+    const svg = wrapper.querySelector(`svg`) as SVGSVGElement
+    document.body.appendChild(svg)
+
+    sanitizeSvgForWeChat(svg)
+
+    expect(svg.querySelector(`use`)).toBeNull()
+    expect(svg.querySelector(`defs`)).toBeNull()
+    expect(svg.querySelector(`path`)).not.toBeNull()
+    expect(svg.querySelector(`path`)?.getAttribute(`d`)).toBe(`M10 40h60`)
 
     svg.remove()
   })
@@ -203,6 +519,30 @@ describe(`sanitizeSvgForWeChat`, () => {
     expect(plantumlContainer.querySelector(`svg`)?.getAttribute(`width`)).toBe(`400`)
 
     wrapper.remove()
+  })
+})
+
+describe(`prepareDiagramSvgsForWeChat`, () => {
+  it(`resolves gradient paints before innerHTML/juice can drop defs`, () => {
+    const root = document.createElement(`div`)
+    root.innerHTML = `
+      <div class="mermaid-diagram">
+        <svg viewBox="0 0 100 40" xmlns="http://www.w3.org/2000/svg">
+          <linearGradient id="g1">
+            <stop offset="0%" stop-color="#4e79a7"></stop>
+            <stop offset="100%" stop-color="#f28e2c"></stop>
+          </linearGradient>
+          <path stroke="url(#g1)" fill="none" d="M0 20h100"></path>
+        </svg>
+      </div>
+    `
+
+    prepareDiagramSvgsForWeChat(root)
+
+    const stroke = root.querySelector(`path`)?.getAttribute(`stroke`) ?? ``
+    expect(stroke.startsWith(`url(`)).toBe(false)
+    expect(stroke).toMatch(/#|rgb/i)
+    expect(root.querySelector(`path`)?.getAttribute(`fill`)).toBe(`none`)
   })
 })
 
@@ -360,7 +700,7 @@ describe(`remapDiagramInkToCurrentColor`, () => {
     expect(rects[0].getAttribute(`stroke`)).toBe(`currentColor`)
     expect(rects[1].getAttribute(`fill`)).toBe(`#ECECFF`)
     expect(rects[1].getAttribute(`stroke`)).toBe(`#9370DB`)
-    expect(text.getAttribute(`fill`)).toBe(`currentColor`)
+    expect(text.getAttribute(`fill`)).toBe(`#262626`)
     expect(path.getAttribute(`stroke`)).toBe(`currentColor`)
     expect(path.getAttribute(`fill`)).toBe(`#ECECFF`)
   })

--- a/apps/web/src/services/export/wechat-svg.ts
+++ b/apps/web/src/services/export/wechat-svg.ts
@@ -232,20 +232,306 @@ function expandMarkers(svg: SVGSVGElement) {
   })
 }
 
+function findSvgElementById(svg: SVGSVGElement, id: string): Element | null {
+  const byApi = typeof svg.getElementById === `function` ? svg.getElementById(id) : null
+  if (byApi)
+    return byApi
+  try {
+    return svg.querySelector(`#${CSS.escape(id)}`)
+  }
+  catch {
+    return null
+  }
+}
+
+function stopColorOf(stop: Element): string | null {
+  return stop.getAttribute(`stop-color`)
+    || stop.getAttribute(`style`)?.match(/stop-color:\s*([^;]+)/i)?.[1]?.trim()
+    || null
+}
+
+function mixCssColors(a: string, b: string): string | null {
+  const pa = parseCssColor(a)
+  const pb = parseCssColor(b)
+  if (!pa)
+    return pb ? b : null
+  if (!pb)
+    return a
+  return `rgb(${Math.round((pa[0] + pb[0]) / 2)}, ${Math.round((pa[1] + pb[1]) / 2)}, ${Math.round((pa[2] + pb[2]) / 2)})`
+}
+
+/** WeChat strips defs/id, so url(#gradient) paints vanish. Bake a solid stand-in. */
+function solidColorFromPaintServer(svg: SVGSVGElement, paint: string): string | null {
+  const id = parseMarkerRef(paint)
+  if (!id)
+    return null
+  const ref = findSvgElementById(svg, id)
+  if (!ref)
+    return null
+  if (ref.localName !== `linearGradient` && ref.localName !== `radialGradient`)
+    return null
+  const colors = Array.from(ref.querySelectorAll(`stop`))
+    .map(stopColorOf)
+    .filter((color): color is string => !!color)
+  if (colors.length === 0)
+    return null
+  if (colors.length === 1)
+    return colors[0]
+  return mixCssColors(colors[0], colors[colors.length - 1]) ?? colors[0]
+}
+
+function resolveUrlPaints(svg: SVGSVGElement) {
+  const apply = (el: Element, attr: `fill` | `stroke`) => {
+    const value = el.getAttribute(attr)
+    if (!value?.includes(`url(`))
+      return
+    const solid = solidColorFromPaintServer(svg, value)
+    if (solid)
+      el.setAttribute(attr, solid)
+  }
+
+  svg.querySelectorAll(`*`).forEach((el) => {
+    apply(el, `fill`)
+    apply(el, `stroke`)
+
+    const style = el.getAttribute(`style`)
+    if (!style?.includes(`url(`))
+      return
+    const next = style.replace(/(fill|stroke)\s*:\s*([^;]+)/gi, (full, prop: string, value: string) => {
+      if (!value.includes(`url(`))
+        return full
+      const solid = solidColorFromPaintServer(svg, value.trim())
+      return solid ? `${prop}: ${solid}` : full
+    })
+    if (next !== style)
+      el.setAttribute(`style`, next)
+  })
+}
+
+/** Architecture / Iconify icons often land as <use href="#id"> into defs. */
+function expandUseElements(svg: SVGSVGElement) {
+  Array.from(svg.querySelectorAll(`use`)).forEach((useEl) => {
+    const href = useEl.getAttribute(`href`) || useEl.getAttribute(`xlink:href`)
+    const id = parseMarkerRef(href)
+    if (!id) {
+      useEl.remove()
+      return
+    }
+
+    const ref = findSvgElementById(svg, id)
+    if (!ref) {
+      useEl.remove()
+      return
+    }
+
+    const group = document.createElementNS(SVG_NS, `g`)
+    const x = Number.parseFloat(useEl.getAttribute(`x`) ?? `0`) || 0
+    const y = Number.parseFloat(useEl.getAttribute(`y`) ?? `0`) || 0
+    const transforms: string[] = []
+    if (x || y)
+      transforms.push(`translate(${x}, ${y})`)
+    const existing = useEl.getAttribute(`transform`)
+    if (existing)
+      transforms.push(existing)
+    if (transforms.length)
+      group.setAttribute(`transform`, transforms.join(` `))
+
+    const takeChildren = ref.localName === `symbol` || ref.localName === `svg` || ref.localName === `g`
+    if (takeChildren) {
+      Array.from(ref.childNodes).forEach((child) => {
+        if (child.nodeType === Node.ELEMENT_NODE && (child as Element).localName === `defs`)
+          return
+        group.appendChild(child.cloneNode(true))
+      })
+    }
+    else {
+      const clone = ref.cloneNode(true) as Element
+      clone.removeAttribute(`id`)
+      group.appendChild(clone)
+    }
+
+    for (const attr of [`fill`, `stroke`, `stroke-width`, `opacity`]) {
+      const value = useEl.getAttribute(attr)
+      if (value)
+        group.setAttribute(attr, value)
+    }
+
+    useEl.parentNode?.replaceChild(group, useEl)
+  })
+}
+
+const PAINTED_SHAPES = `path, line, polyline, polygon, rect, circle, ellipse, text, tspan`
+
+function isNonePaint(value: string | null | undefined): boolean {
+  return !!value && value.trim().toLowerCase() === `none`
+}
+
+function isUsablePaint(value: string | null | undefined): value is string {
+  if (!value)
+    return false
+  const normalized = value.trim().toLowerCase()
+  return normalized !== `` && normalized !== `none` && !normalized.includes(`url(`)
+}
+
+function removeStyleProperties(el: Element, keys: string[]) {
+  const style = el.getAttribute(`style`)
+  if (!style)
+    return
+
+  const drop = new Set(keys.map(key => key.toLowerCase()))
+  const next = style
+    .split(`;`)
+    .map(part => part.trim())
+    .filter(Boolean)
+    .filter((part) => {
+      const key = part.split(`:`)[0]?.trim().toLowerCase()
+      return !!key && !drop.has(key)
+    })
+    .join(`; `)
+
+  if (next)
+    el.setAttribute(`style`, next)
+  else
+    el.removeAttribute(`style`)
+}
+
+function paintFromStyle(node: Element, attr: string): string | null {
+  const style = node.getAttribute(`style`)
+  if (!style)
+    return null
+  const match = style.match(new RegExp(`(?:^|;)\\s*${attr}\\s*:\\s*([^;]+)`, `i`))
+  return match?.[1]?.trim() || null
+}
+
+function bakePaint(node: Element, attr: `fill` | `stroke`, computedValue: string) {
+  const explicit = node.getAttribute(attr)
+  const fromStyle = paintFromStyle(node, attr)
+
+  // Explicit / inlined `none` wins over juice painting edge paths as solid blobs.
+  if (isNonePaint(explicit) || isNonePaint(fromStyle)) {
+    node.setAttribute(attr, `none`)
+    removeStyleProperties(node, [attr])
+    return
+  }
+
+  if (isUsablePaint(explicit)) {
+    removeStyleProperties(node, [attr])
+    return
+  }
+
+  if (isUsablePaint(fromStyle)) {
+    node.setAttribute(attr, fromStyle)
+    removeStyleProperties(node, [attr])
+    return
+  }
+
+  if (isNonePaint(computedValue)) {
+    node.setAttribute(attr, `none`)
+    return
+  }
+
+  if (isUsablePaint(computedValue))
+    node.setAttribute(attr, computedValue)
+}
+
+function paintFromColorStyle(node: Element): string | null {
+  const style = node.getAttribute(`style`)
+  if (!style)
+    return null
+  const match = style.match(/(?:^|;)\s*color\s*:\s*([^;]+)/i)
+  return match?.[1]?.trim() || null
+}
+
+/** Text must not inherit the entity/node box fill, or ER/class titles vanish. */
+function bakeTextPaint(node: Element) {
+  const explicit = node.getAttribute(`fill`)
+  const fromStyle = paintFromStyle(node, `fill`)
+  const fromColor = paintFromColorStyle(node)
+
+  if (isNonePaint(explicit) || isNonePaint(fromStyle)) {
+    node.setAttribute(`fill`, `none`)
+    removeStyleProperties(node, [`fill`])
+    return
+  }
+  if (isUsablePaint(explicit)) {
+    removeStyleProperties(node, [`fill`])
+    return
+  }
+  if (isUsablePaint(fromStyle)) {
+    node.setAttribute(`fill`, fromStyle)
+    removeStyleProperties(node, [`fill`])
+    return
+  }
+  if (isUsablePaint(fromColor)) {
+    node.setAttribute(`fill`, fromColor)
+    return
+  }
+
+  const computedColor = window.getComputedStyle(node).color
+  if (isUsablePaint(computedColor))
+    node.setAttribute(`fill`, computedColor)
+}
+
+function bakeHtmlLabelColors(svg: SVGSVGElement) {
+  svg.querySelectorAll(`foreignObject section, foreignObject span, foreignObject div, foreignObject p`).forEach((el) => {
+    const style = el.getAttribute(`style`) ?? ``
+    if (/(?:^|;)\s*color\s*:/i.test(style))
+      return
+    const color = window.getComputedStyle(el).color
+    if (!isUsablePaint(color))
+      return
+    el.setAttribute(`style`, `${style}${style ? `; ` : ``}color: ${color}`)
+  })
+}
+
 function inlinePresentationAttributes(svg: SVGSVGElement) {
-  svg.querySelectorAll(`*[class], path, line, polyline, polygon, rect, circle, ellipse, text`).forEach((node) => {
+  svg.querySelectorAll(PAINTED_SHAPES).forEach((node) => {
     if (!(node instanceof SVGElement))
       return
 
     const computed = window.getComputedStyle(node)
-    if (computed.fill && computed.fill !== `none` && !node.hasAttribute(`fill`))
-      node.setAttribute(`fill`, computed.fill)
-    if (computed.stroke && computed.stroke !== `none` && !node.hasAttribute(`stroke`))
-      node.setAttribute(`stroke`, computed.stroke)
+    const isText = node.localName === `text` || node.localName === `tspan`
+    if (isText)
+      bakeTextPaint(node)
+    else
+      bakePaint(node, `fill`, computed.fill)
+
+    if (isText) {
+      if (!node.getAttribute(`stroke`) && !paintFromStyle(node, `stroke`))
+        node.setAttribute(`stroke`, `none`)
+    }
+    else {
+      bakePaint(node, `stroke`, computed.stroke)
+    }
+
     if (computed.strokeWidth && !node.hasAttribute(`stroke-width`))
       node.setAttribute(`stroke-width`, computed.strokeWidth)
+
+    if (computed.fontSize && isText && !node.hasAttribute(`font-size`))
+      node.setAttribute(`font-size`, computed.fontSize)
+
     if (computed.opacity && computed.opacity !== `1` && !node.hasAttribute(`opacity`))
       node.setAttribute(`opacity`, computed.opacity)
+
+    const strokeOpacity = computed.getPropertyValue(`stroke-opacity`) || computed.strokeOpacity
+    const effectiveStroke = node.getAttribute(`stroke`)
+    if (
+      strokeOpacity
+      && strokeOpacity !== `1`
+      && !node.hasAttribute(`stroke-opacity`)
+      && effectiveStroke
+      && effectiveStroke !== `none`
+    ) {
+      node.setAttribute(`stroke-opacity`, strokeOpacity)
+    }
+  })
+
+  // Juice often inlines fills onto <g>; after leaves have explicit paints, drop group
+  // fills so WeChat inheritance cannot re-color edge paths.
+  svg.querySelectorAll(`g`).forEach((group) => {
+    removeStyleProperties(group, [`fill`, `stroke`])
+    group.removeAttribute(`fill`)
+    group.removeAttribute(`stroke`)
   })
 }
 
@@ -410,9 +696,19 @@ export function prepareMathFormulasForWeChat(root: ParentNode) {
  * Remap dark fill/stroke on diagram SVGs to currentColor so Mermaid / PlantUML /
  * infographic ink stays readable when WeChat reader is in dark mode.
  */
+function isDiagramTextNode(node: Element): boolean {
+  return node.localName === `text`
+    || node.localName === `tspan`
+    || node.closest(`foreignObject`) != null
+}
+
 export function remapDiagramInkToCurrentColor(svg: SVGSVGElement) {
-  remapSvgNodeInkToCurrentColor(svg)
-  svg.querySelectorAll(`*`).forEach(remapSvgNodeInkToCurrentColor)
+  if (!isDiagramTextNode(svg))
+    remapSvgNodeInkToCurrentColor(svg)
+  svg.querySelectorAll(`*`).forEach((node) => {
+    if (!isDiagramTextNode(node))
+      remapSvgNodeInkToCurrentColor(node)
+  })
 }
 
 function isHiddenPlantUmlHelper(el: Element): boolean {
@@ -618,6 +914,45 @@ function wrapWidePlantUmlSvg(svg: SVGSVGElement) {
   outer.appendChild(hint)
 }
 
+function parseStyleMaxWidthPx(svg: SVGSVGElement): number | null {
+  const match = (svg.getAttribute(`style`) ?? ``).match(/max-width:\s*([\d.]+)px/i)
+  if (!match)
+    return null
+  const width = Number.parseFloat(match[1])
+  return Number.isFinite(width) && width > 0 ? width : null
+}
+
+/** Keep Mermaid’s layout size so WeChat cannot scale boxes without the labels. */
+function resolveMermaidPixelSize(svg: SVGSVGElement): { width: number, height: number } {
+  const viewBox = parseViewBox(svg.getAttribute(`viewBox`))
+  const maxWidth = parseStyleMaxWidthPx(svg)
+  const attrWidth = parsePixelAttribute(svg.getAttribute(`width`))
+  let width = maxWidth ?? viewBox?.width ?? attrWidth ?? WECHAT_MAX_WIDTH_PX
+  let height = viewBox && viewBox.width > 0
+    ? width * (viewBox.height / viewBox.width)
+    : (parsePixelAttribute(svg.getAttribute(`height`)) ?? width * 0.75)
+
+  if (width > WECHAT_MAX_WIDTH_PX) {
+    height = height * (WECHAT_MAX_WIDTH_PX / width)
+    width = WECHAT_MAX_WIDTH_PX
+  }
+
+  return {
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  }
+}
+
+function fixMermaidDimensions(svg: SVGSVGElement): { width: number, height: number } {
+  const size = resolveMermaidPixelSize(svg)
+  if (!svg.hasAttribute(`xmlns`))
+    svg.setAttribute(`xmlns`, SVG_NS)
+  svg.setAttribute(`width`, String(size.width))
+  svg.setAttribute(`height`, String(size.height))
+  svg.setAttribute(`preserveAspectRatio`, `xMidYMid meet`)
+  return size
+}
+
 function resolveSvgPixelSize(svg: SVGSVGElement): { width: number, height: number } {
   const rect = svg.getBoundingClientRect()
   const viewBox = parseViewBox(svg.getAttribute(`viewBox`))
@@ -659,6 +994,313 @@ function fixSvgDimensions(svg: SVGSVGElement) {
   svg.setAttribute(`height`, String(height))
 }
 
+const MIN_DIAGRAM_FONT_PX = 9
+
+const DOMINANT_BASELINE_DY: Record<string, string> = {
+  'alphabetic': ``,
+  'central': `0.35em`,
+  'middle': `0.35em`,
+  'hanging': `-0.55em`,
+  'ideographic': `0.18em`,
+  'text-before-edge': `-0.85em`,
+  'text-after-edge': `0.15em`,
+}
+
+function convertDominantBaselineToDy(svg: SVGSVGElement) {
+  svg.querySelectorAll(`text, tspan`).forEach((el) => {
+    const baseline = el.getAttribute(`dominant-baseline`)
+    if (!baseline)
+      return
+    el.removeAttribute(`dominant-baseline`)
+    const em = DOMINANT_BASELINE_DY[baseline]
+    if (!em || el.getAttribute(`dy`))
+      return
+    const fontSize = parseCssNumber(el.getAttribute(`font-size`) || window.getComputedStyle(el).fontSize || `16`)?.n ?? 16
+    const factor = Number.parseFloat(em)
+    if (Number.isFinite(factor))
+      el.setAttribute(`dy`, String(Math.round(fontSize * factor * 10) / 10))
+  })
+}
+
+function isMermaidDiagramSvg(svg: SVGSVGElement, mermaid = false): boolean {
+  return mermaid || svg.closest(`.mermaid-diagram`) != null
+}
+
+function parseCssNumber(value: string): { n: number, unit: string } | null {
+  const match = value.trim().match(/^(-?[\d.]+)(px|pt|em|rem|%)?$/i)
+  if (!match)
+    return null
+  const n = Number.parseFloat(match[1])
+  if (!Number.isFinite(n) || n <= 0)
+    return null
+  return { n, unit: (match[2] || ``).toLowerCase() }
+}
+
+function scaleFontSizeValue(value: string, viewScale: number, labelScale: number): string | null {
+  const parsed = parseCssNumber(value)
+  if (!parsed || parsed.unit === `%` || parsed.unit === `em` || parsed.unit === `rem`)
+    return null
+  const scale = parsed.unit === `em` || parsed.unit === `rem`
+    ? labelScale
+    : viewScale * labelScale
+  const next = Math.max(MIN_DIAGRAM_FONT_PX, Math.round(parsed.n * scale * 10) / 10)
+  return parsed.unit ? `${next}${parsed.unit}` : String(next)
+}
+
+function scaleFontSizeInStyle(style: string, viewScale: number, labelScale: number): string {
+  return style.replace(/(^|;)\s*font-size\s*:\s*([^;]*)/gi, (full, prefix: string, value: string) => {
+    const scaled = scaleFontSizeValue(value, viewScale, labelScale)
+    return scaled ? `${prefix} font-size: ${scaled}` : full
+  })
+}
+
+function collectForeignObjectLines(fo: Element): string[] {
+  const html = fo.innerHTML
+  if (/<br\s*\/?>/i.test(html)) {
+    return html
+      .split(/<br\s*\/?>/i)
+      .map(part => part.replace(/<[^>]+>/g, ``).replace(/&nbsp;/gi, ` `).trim())
+      .filter(Boolean)
+  }
+
+  const text = (fo.textContent || ``).replace(/\u00A0/g, ` `)
+  const lines = text.split(/\n/).map(part => part.trim()).filter(Boolean)
+  if (lines.length)
+    return lines
+  const compact = text.replace(/\s+/g, ` `).trim()
+  return compact ? [compact] : []
+}
+
+function parseTranslate(transform: string | null): { x: number, y: number } | null {
+  if (!transform)
+    return { x: 0, y: 0 }
+  const match = transform.match(/translate\(\s*([-\d.eE]+)(?:[\s,]+([-\d.eE]+))?\s*\)/)
+  if (!match)
+    return null
+  return {
+    x: Number.parseFloat(match[1]) || 0,
+    y: Number.parseFloat(match[2] || `0`) || 0,
+  }
+}
+
+function estimateLabelWidth(text: string, fontSize: number): number {
+  let width = 0
+  for (const ch of text) {
+    width += /[\u1100-\uD7FF\uF900-\uFAFF]/.test(ch) ? fontSize : fontSize * 0.55
+  }
+  return width
+}
+
+function isTransparentPaint(value: string | null | undefined): boolean {
+  if (!value)
+    return true
+  const normalized = value.trim().toLowerCase()
+  return normalized === `` || normalized === `transparent` || normalized === `none`
+    || /^rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\)$/.test(normalized)
+}
+
+function edgeLabelBackground(styled: Element): string {
+  const fromStyle = (styled.getAttribute(`style`) ?? ``).match(/(?:^|;)\s*background(?:-color)?\s*:\s*([^;]+)/i)?.[1]?.trim()
+  if (fromStyle && !isTransparentPaint(fromStyle) && isUsablePaint(fromStyle))
+    return fromStyle
+  try {
+    const computed = window.getComputedStyle(styled).backgroundColor
+    if (computed && !isTransparentPaint(computed) && isUsablePaint(computed))
+      return computed
+  }
+  catch {}
+  return `#e8e8e8`
+}
+
+/**
+ * Bidirectional state/flowchart edges share a path midpoint, so "条件 2" / "返回"
+ * land on the same point after FO flatten. Nudge overlapping edgeLabels apart.
+ */
+function separateOverlappingMermaidEdgeLabels(svg: SVGSVGElement) {
+  const labels = Array.from(svg.querySelectorAll(`g.edgeLabel`))
+  if (labels.length < 2)
+    return
+
+  const items = labels.map((el) => {
+    const pos = parseTranslate(el.getAttribute(`transform`)) ?? { x: 0, y: 0 }
+    const text = el.querySelector(`text`)
+    const fontSize = parseCssNumber(text?.getAttribute(`font-size`) || `16`)?.n ?? 16
+    const rect = el.querySelector(`rect`)
+    const rectWidth = Number.parseFloat(rect?.getAttribute(`width`) ?? `0`) || 0
+    const content = (text?.textContent ?? ``).replace(/\s+/g, ` `).trim()
+    const width = rectWidth > 0 ? rectWidth : Math.max(16, estimateLabelWidth(content, fontSize))
+    return { el, x: pos.x, y: pos.y, halfW: width / 2 }
+  })
+
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      const a = items[i]
+      const b = items[j]
+      const dx = b.x - a.x
+      const dy = b.y - a.y
+      const dist = Math.hypot(dx, dy)
+      const need = a.halfW + b.halfW + 8
+      if (dist >= need)
+        continue
+
+      let dirX = 1
+      let dirY = 0
+      if (dist >= 1) {
+        if (Math.abs(dx) >= Math.abs(dy)) {
+          dirX = dx / dist
+          dirY = 0
+        }
+        else {
+          dirX = 0
+          dirY = dy / dist
+        }
+      }
+
+      const extra = (need - dist) / 2
+      nudgeEdgeLabel(a, -dirX * extra, -dirY * extra)
+      nudgeEdgeLabel(b, dirX * extra, dirY * extra)
+    }
+  }
+}
+
+function nudgeEdgeLabel(
+  item: { el: Element, x: number, y: number },
+  nx: number,
+  ny: number,
+) {
+  item.x += nx
+  item.y += ny
+  const raw = item.el.getAttribute(`transform`) ?? ``
+  if (/translate\(/.test(raw)) {
+    item.el.setAttribute(
+      `transform`,
+      raw.replace(
+        /translate\(\s*([-\d.eE]+)(?:[\s,]+([-\d.eE]+))?\s*\)/,
+        `translate(${roundSvg(item.x)}, ${roundSvg(item.y)})`,
+      ),
+    )
+    return
+  }
+  item.el.setAttribute(
+    `transform`,
+    `translate(${roundSvg(item.x)}, ${roundSvg(item.y)})${raw ? ` ${raw}` : ``}`,
+  )
+}
+
+function roundSvg(n: number): number {
+  return Math.round(n * 10) / 10
+}
+
+/**
+ * WeChat drops / mis-paints HTML inside foreignObject (ER, requirement, flowchart).
+ * Convert labels to real SVG text so fill and font-size survive paste.
+ */
+function flattenMermaidHtmlLabels(svg: SVGSVGElement, mermaid = false) {
+  if (!isMermaidDiagramSvg(svg, mermaid))
+    return
+
+  svg.querySelectorAll(`foreignObject`).forEach((fo) => {
+    const lines = collectForeignObjectLines(fo)
+    if (lines.length === 0) {
+      fo.remove()
+      return
+    }
+
+    const x = Number.parseFloat(fo.getAttribute(`x`) ?? `0`) || 0
+    const y = Number.parseFloat(fo.getAttribute(`y`) ?? `0`) || 0
+    const width = Number.parseFloat(fo.getAttribute(`width`) ?? `0`) || 0
+    const height = Number.parseFloat(fo.getAttribute(`height`) ?? `0`) || 0
+    const styled = fo.querySelector(`[style], section, div, span, p`) ?? fo
+    const color = paintFromColorStyle(styled)
+      || paintFromStyle(styled, `fill`)
+      || window.getComputedStyle(styled).color
+      || `#333333`
+    const fontSize = parseCssNumber(
+      paintFromStyle(styled, `font-size`) || window.getComputedStyle(styled).fontSize || `16`,
+    )?.n ?? 16
+    const style = `${styled.getAttribute(`style`) ?? ``} ${window.getComputedStyle(styled).textAlign}`
+    const centered = /center/i.test(style) && width > 0
+    const inEdgeLabel = fo.closest(`.edgeLabel`) != null
+    const foTransform = fo.getAttribute(`transform`)
+
+    const text = document.createElementNS(SVG_NS, `text`)
+    const textX = centered ? x + width / 2 : x
+    // HTML in foreignObject is top-aligned; WeChat uses alphabetic baseline (no em dy).
+    const textY = y + (height > 0 ? Math.min(fontSize, height * 0.8) : fontSize * 0.8)
+    text.setAttribute(`x`, String(textX))
+    text.setAttribute(`y`, String(textY))
+    text.setAttribute(`fill`, isUsablePaint(color) ? color : `#333333`)
+    text.setAttribute(`stroke`, `none`)
+    text.setAttribute(`font-size`, String(fontSize))
+    text.setAttribute(`text-anchor`, centered ? `middle` : `start`)
+
+    if (lines.length === 1) {
+      text.textContent = lines[0]
+    }
+    else {
+      lines.forEach((line, index) => {
+        const tspan = document.createElementNS(SVG_NS, `tspan`)
+        tspan.setAttribute(`x`, String(textX))
+        tspan.setAttribute(`dy`, index === 0 ? `0` : `1.2em`)
+        tspan.setAttribute(`fill`, isUsablePaint(color) ? color : `#333333`)
+        tspan.textContent = line
+        text.appendChild(tspan)
+      })
+    }
+
+    const parent = fo.parentNode
+    if (!parent) {
+      fo.remove()
+      return
+    }
+
+    const needsBackdrop = inEdgeLabel && width > 0 && height > 0
+    if (!foTransform && !needsBackdrop) {
+      parent.replaceChild(text, fo)
+      return
+    }
+
+    const replacement = document.createElementNS(SVG_NS, `g`)
+    if (foTransform)
+      replacement.setAttribute(`transform`, foTransform)
+
+    if (needsBackdrop) {
+      const rect = document.createElementNS(SVG_NS, `rect`)
+      rect.setAttribute(`x`, String(x))
+      rect.setAttribute(`y`, String(y))
+      rect.setAttribute(`width`, String(width))
+      rect.setAttribute(`height`, String(height))
+      rect.setAttribute(`fill`, edgeLabelBackground(styled))
+      rect.setAttribute(`stroke`, `none`)
+      replacement.appendChild(rect)
+    }
+    replacement.appendChild(text)
+    parent.replaceChild(replacement, fo)
+  })
+
+  separateOverlappingMermaidEdgeLabels(svg)
+}
+
+/** Keep baked label sizes readable after WeChat shrinks a wide viewBox. */
+function clampMermaidFontSizes(svg: SVGSVGElement, mermaid = false) {
+  if (!isMermaidDiagramSvg(svg, mermaid))
+    return
+
+  svg.querySelectorAll(`text, tspan`).forEach((el) => {
+    const attr = el.getAttribute(`font-size`)
+    if (attr) {
+      const clamped = scaleFontSizeValue(attr, 1, 1)
+      if (clamped)
+        el.setAttribute(`font-size`, clamped)
+      return
+    }
+
+    const style = el.getAttribute(`style`)
+    if (style && /font-size/i.test(style))
+      el.setAttribute(`style`, scaleFontSizeInStyle(style, 1, 1))
+  })
+}
+
 function stripUnsupportedAttributes(svg: SVGSVGElement) {
   svg.querySelectorAll(`[clip-path], [clipPath]`).forEach((el) => {
     el.removeAttribute(`clip-path`)
@@ -667,6 +1309,7 @@ function stripUnsupportedAttributes(svg: SVGSVGElement) {
 
   svg.querySelectorAll(`style`).forEach(styleEl => styleEl.remove())
   svg.querySelectorAll(`defs`).forEach(defsEl => defsEl.remove())
+  svg.querySelectorAll(`linearGradient, radialGradient, filter, clipPath, mask, pattern, symbol`).forEach(el => el.remove())
 
   svg.querySelectorAll(`*`).forEach((el) => {
     el.removeAttribute(`id`)
@@ -679,6 +1322,58 @@ function stripUnsupportedAttributes(svg: SVGSVGElement) {
 export interface SanitizeSvgOptions {
   /** Keep natural width and wrap with horizontal scroll when wider than the article column. */
   plantuml?: boolean
+  /** Caller already knows this SVG came from `.mermaid-diagram` (may be detached). */
+  mermaid?: boolean
+}
+
+/**
+ * Attach SVGs to a hidden host so getComputedStyle works.
+ * Capture mermaid/plantuml before detach — closest() is null on the host.
+ */
+function forEachClipboardSvg(
+  root: ParentNode,
+  fn: (svg: SVGSVGElement, ctx: { mermaid: boolean, plantuml: boolean }) => void,
+) {
+  const svgs = Array.from(root.querySelectorAll<SVGSVGElement>(`svg`))
+  if (svgs.length === 0)
+    return
+
+  const host = document.createElement(`div`)
+  host.style.cssText = `position:fixed;left:-99999px;top:0;visibility:hidden;pointer-events:none;width:${WECHAT_MAX_WIDTH_PX}px;`
+  document.body.appendChild(host)
+
+  try {
+    for (const svg of svgs) {
+      if (isMathFormulaSvg(svg))
+        continue
+
+      const parent = svg.parentElement
+      const nextSibling = svg.nextSibling
+      const mermaid = isMermaidDiagramSvg(svg)
+      const plantuml = isPlantUmlDiagramSvg(svg)
+      host.appendChild(svg)
+      fn(svg, { mermaid, plantuml })
+      if (parent)
+        parent.insertBefore(svg, nextSibling)
+    }
+  }
+  finally {
+    host.remove()
+  }
+}
+
+/**
+ * Bake WeChat-unsafe paints (gradients, <use> icons) while the live SVG still has defs.
+ * Call before any innerHTML serialization / juice pass.
+ */
+export function prepareDiagramSvgsForWeChat(root: ParentNode) {
+  forEachClipboardSvg(root, (svg, { mermaid }) => {
+    expandUseElements(svg)
+    resolveUrlPaints(svg)
+    bakeHtmlLabelColors(svg)
+    flattenMermaidHtmlLabels(svg, mermaid)
+    convertDominantBaselineToDy(svg)
+  })
 }
 
 /**
@@ -686,16 +1381,32 @@ export interface SanitizeSvgOptions {
  */
 export function sanitizeSvgForWeChat(svg: SVGSVGElement, options?: SanitizeSvgOptions) {
   const isPlantuml = options?.plantuml ?? isPlantUmlDiagramSvg(svg)
+  const mermaid = options?.mermaid ?? isMermaidDiagramSvg(svg)
 
   expandMarkers(svg)
+  expandUseElements(svg)
+  resolveUrlPaints(svg)
+  bakeHtmlLabelColors(svg)
+  flattenMermaidHtmlLabels(svg, mermaid)
   inlinePresentationAttributes(svg)
   remapDiagramInkToCurrentColor(svg)
+  convertDominantBaselineToDy(svg)
+  svg.setAttribute(`overflow`, `visible`)
+  svg.querySelectorAll(`[style]`).forEach((el) => {
+    const style = el.getAttribute(`style`)
+    if (style && /overflow\s*:\s*hidden/i.test(style))
+      el.setAttribute(`style`, style.replace(/overflow\s*:\s*hidden/gi, `overflow: visible`))
+  })
 
   if (isPlantuml) {
     tightenPlantUmlViewBox(svg)
     const size = fixPlantUmlDimensions(svg)
     if (size.width <= WECHAT_MAX_WIDTH_PX)
       applyPlantUmlSvgDisplay(svg, size.width, size.height)
+  }
+  else if (mermaid) {
+    fixMermaidDimensions(svg)
+    clampMermaidFontSizes(svg, true)
   }
   else {
     fixSvgDimensions(svg)
@@ -708,36 +1419,17 @@ export function sanitizeSvgForWeChat(svg: SVGSVGElement, options?: SanitizeSvgOp
  * Process all SVG elements under `root` (attaches temporarily for getComputedStyle).
  */
 export function sanitizeSvgsForWeChat(root: ParentNode) {
-  const svgs = Array.from(root.querySelectorAll<SVGSVGElement>(`svg`))
-  if (svgs.length === 0)
-    return
+  const plantumlSvgs: SVGSVGElement[] = []
+  forEachClipboardSvg(root, (svg, { mermaid, plantuml }) => {
+    sanitizeSvgForWeChat(svg, { plantuml, mermaid })
+    if (plantuml)
+      plantumlSvgs.push(svg)
+  })
 
-  const host = document.createElement(`div`)
-  host.style.cssText = `position:fixed;left:-99999px;top:0;visibility:hidden;pointer-events:none;width:677px;`
-  document.body.appendChild(host)
-
-  try {
-    for (const node of svgs) {
-      const svg = node
-      if (isMathFormulaSvg(svg))
-        continue
-
-      const parent = svg.parentElement
-      const nextSibling = svg.nextSibling
-      const isPlantuml = isPlantUmlDiagramSvg(svg)
-      host.appendChild(svg)
-      sanitizeSvgForWeChat(svg, { plantuml: isPlantuml })
-      if (parent)
-        parent.insertBefore(svg, nextSibling)
-      if (isPlantuml) {
-        const container = svg.closest(`.plantuml-diagram`) as HTMLElement | null
-        if (container)
-          normalizePlantUmlContainer(container)
-        wrapWidePlantUmlSvg(svg)
-      }
-    }
-  }
-  finally {
-    host.remove()
+  for (const svg of plantumlSvgs) {
+    const container = svg.closest(`.plantuml-diagram`) as HTMLElement | null
+    if (container)
+      normalizePlantUmlContainer(container)
+    wrapWidePlantUmlSvg(svg)
   }
 }

--- a/apps/web/src/services/export/wechat-svg.ts
+++ b/apps/web/src/services/export/wechat-svg.ts
@@ -693,8 +693,9 @@ export function prepareMathFormulasForWeChat(root: ParentNode) {
 }
 
 /**
- * Remap dark fill/stroke on diagram SVGs to currentColor so Mermaid / PlantUML /
- * infographic ink stays readable when WeChat reader is in dark mode.
+ * Remap dark grayscale strokes/fills to currentColor for WeChat reader dark mode.
+ * Text is left as baked ink: labels often sit on light node/entity boxes, and
+ * currentColor would wash them out when the reader switches to light-on-dark.
  */
 function isDiagramTextNode(node: Element): boolean {
   return node.localName === `text`
@@ -1036,21 +1037,19 @@ function parseCssNumber(value: string): { n: number, unit: string } | null {
   return { n, unit: (match[2] || ``).toLowerCase() }
 }
 
-function scaleFontSizeValue(value: string, viewScale: number, labelScale: number): string | null {
+function clampFontSizeValue(value: string): string | null {
   const parsed = parseCssNumber(value)
+  // em/rem follow parent size; leave them so WeChat viewBox shrink cannot blow up labels.
   if (!parsed || parsed.unit === `%` || parsed.unit === `em` || parsed.unit === `rem`)
     return null
-  const scale = parsed.unit === `em` || parsed.unit === `rem`
-    ? labelScale
-    : viewScale * labelScale
-  const next = Math.max(MIN_DIAGRAM_FONT_PX, Math.round(parsed.n * scale * 10) / 10)
+  const next = Math.max(MIN_DIAGRAM_FONT_PX, Math.round(parsed.n * 10) / 10)
   return parsed.unit ? `${next}${parsed.unit}` : String(next)
 }
 
-function scaleFontSizeInStyle(style: string, viewScale: number, labelScale: number): string {
+function clampFontSizeInStyle(style: string): string {
   return style.replace(/(^|;)\s*font-size\s*:\s*([^;]*)/gi, (full, prefix: string, value: string) => {
-    const scaled = scaleFontSizeValue(value, viewScale, labelScale)
-    return scaled ? `${prefix} font-size: ${scaled}` : full
+    const clamped = clampFontSizeValue(value)
+    return clamped ? `${prefix} font-size: ${clamped}` : full
   })
 }
 
@@ -1289,7 +1288,7 @@ function clampMermaidFontSizes(svg: SVGSVGElement, mermaid = false) {
   svg.querySelectorAll(`text, tspan`).forEach((el) => {
     const attr = el.getAttribute(`font-size`)
     if (attr) {
-      const clamped = scaleFontSizeValue(attr, 1, 1)
+      const clamped = clampFontSizeValue(attr)
       if (clamped)
         el.setAttribute(`font-size`, clamped)
       return
@@ -1297,7 +1296,7 @@ function clampMermaidFontSizes(svg: SVGSVGElement, mermaid = false) {
 
     const style = el.getAttribute(`style`)
     if (style && /font-size/i.test(style))
-      el.setAttribute(`style`, scaleFontSizeInStyle(style, 1, 1))
+      el.setAttribute(`style`, clampFontSizeInStyle(style))
   })
 }
 


### PR DESCRIPTION
## Summary

- Sanitize Mermaid CSS that juice cannot parse (`style="undefined;"` and unquoted `Open Sans`) so copy no longer fails
- Flatten `foreignObject` labels to SVG `<text>`, bake paints/markers, and nudge overlapping bidirectional edge labels (e.g. state diagram「条件 2」/「返回」)
- Use `height: auto` on preview Mermaid SVGs so journey diagrams no longer leave a large blank band under the chart

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Maintenance / dependencies

## Test Procedure

- `pnpm test src/services/export/wechat-svg.test.ts src/services/export/clipboard.test.ts` in `@md/web` — 40 tests pass
- Copy a Mermaid gallery (flowchart, state, ER, requirement, journey, C4, sankey) into the WeChat editor and confirm styles, arrows, and labels survive
- Confirm state diagram bidirectional labels no longer overlap
- Confirm journey diagram preview no longer has excess bottom whitespace

## Pre-flight Checklist

- [x] Code follows the project style (lint passes)
- [x] Tests pass
- [x] Commit messages follow Conventional Commits
