### PR TITLE
fix(web): keep editor font stack when copying to WeChat

### DIFF
--- a/apps/web/src/services/export/clipboard-dom.ts
+++ b/apps/web/src/services/export/clipboard-dom.ts
@@ -11,21 +11,6 @@ function isUndefinedCssValue(value: string): boolean {
   return !normalized || /^undefined$/i.test(normalized) || /\bundefined\b/i.test(normalized)
 }
 
-/** Multi-word fonts that juice/PostCSS reject when unquoted. WeChat does not ship them anyway. */
-const FONT_FAMILY_REPLACEMENTS: Array<[RegExp, string]> = [
-  [/^open sans$/i, `sans-serif`],
-  [/^trebuchet ms$/i, `sans-serif`],
-  [/^segoe ui$/i, `sans-serif`],
-  [/^helvetica neue$/i, `sans-serif`],
-  [/^noto sans$/i, `sans-serif`],
-  [/^pingfang sc$/i, `sans-serif`],
-  [/^microsoft yahei$/i, `sans-serif`],
-  [/^微软雅黑$/, `sans-serif`],
-  [/^operator mono$/i, `monospace`],
-  [/^fira code$/i, `monospace`],
-  [/^courier new$/i, `monospace`],
-]
-
 function mapFontFamilyName(family: string): string {
   const unquoted = family.replace(/["']/g, ``).trim()
   if (!unquoted)
@@ -34,10 +19,9 @@ function mapFontFamilyName(family: string): string {
     return family
   if (GENERIC_FONT_FAMILIES.test(unquoted))
     return unquoted
-  for (const [pattern, replacement] of FONT_FAMILY_REPLACEMENTS) {
-    if (pattern.test(unquoted))
-      return replacement
-  }
+  // Quote multi-word / CJK names so juice/PostCSS can parse them.
+  // Do not rewrite them to generic families: a mid-stack `sans-serif`
+  // would make later serif fonts unreachable (WeChat copy of the serif preset).
   if (/\s/.test(unquoted) || unquoted.split(``).some(ch => ch.charCodeAt(0) > 127))
     return `'${unquoted}'`
   return unquoted

--- a/apps/web/src/services/export/clipboard.test.ts
+++ b/apps/web/src/services/export/clipboard.test.ts
@@ -111,8 +111,9 @@ describe(`stripInvalidCssForJuice`, () => {
 
     stripInvalidCssForJuice(root)
 
-    expect(root.querySelector(`path`)?.getAttribute(`style`)).toContain(`sans-serif`)
-    expect(root.querySelector(`path`)?.getAttribute(`style`)).not.toMatch(/Open Sans/)
+    const style = root.querySelector(`path`)?.getAttribute(`style`) ?? ``
+    expect(style).toContain(`sans-serif`)
+    expect(style).toMatch(/['"]Open Sans['"]/)
     expect(() => juice(sanitizeHtmlCssForJuice(root.innerHTML), {
       inlinePseudoElements: true,
       preserveImportant: true,
@@ -120,13 +121,13 @@ describe(`stripInvalidCssForJuice`, () => {
     })).not.toThrow()
   })
 
-  it(`rewrites Open Sans in the HTML string after browsers drop style quotes`, async () => {
+  it(`quotes Open Sans in the HTML string after browsers drop style quotes`, async () => {
     const { default: juice } = await import(`juice`)
     const html = `<svg><path style="fill: #1168BD;stroke: #0B4884;color: #FFFFFF;font-family:Open Sans, sans-serif"></path></svg>`
 
     const sanitized = sanitizeHtmlCssForJuice(html)
     expect(sanitized).toContain(`sans-serif`)
-    expect(sanitized).not.toMatch(/Open Sans/)
+    expect(sanitized).toMatch(/['"]Open Sans['"]/)
     expect(() => juice(sanitized, {
       inlinePseudoElements: true,
       preserveImportant: true,
@@ -134,17 +135,48 @@ describe(`stripInvalidCssForJuice`, () => {
     })).not.toThrow()
   })
 
-  it(`rewrites sequence/C4 text styles that juice reports at column 43`, async () => {
+  it(`quotes sequence/C4 text styles that juice reports at column 43`, async () => {
     const { default: juice } = await import(`juice`)
     const html = `<svg><text style="dominant-baseline:central;font-family:Open Sans,sans-serif" font-family="Open Sans, sans-serif">A</text></svg>`
 
     const sanitized = sanitizeHtmlCssForJuice(html)
-    expect(sanitized).not.toMatch(/Open Sans/)
+    expect(sanitized).toMatch(/['"]Open Sans['"]/)
     expect(() => juice(sanitized, {
       inlinePseudoElements: true,
       preserveImportant: true,
       resolveCSSVariables: false,
     })).not.toThrow()
+  })
+
+  it(`keeps editor serif stack so WeChat copy does not fall back to sans-serif`, async () => {
+    const { default: juice } = await import(`juice`)
+    const serif = `Optima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif`
+    const html = `<style>p{font-family:${serif}}</style><p>hello</p>`
+
+    const sanitized = sanitizeHtmlCssForJuice(html)
+    expect(sanitized).toMatch(/PingFang SC/)
+    expect(sanitized).toMatch(/\bserif\b/)
+    expect(sanitized).not.toMatch(/sans-serif/)
+
+    const inlined = juice(sanitized, {
+      inlinePseudoElements: true,
+      preserveImportant: true,
+      resolveCSSVariables: false,
+    })
+    expect(inlined).toMatch(/PingFang SC/)
+    expect(inlined).toMatch(/\bserif\b/)
+    expect(inlined).not.toMatch(/sans-serif/)
+  })
+
+  it(`quotes editor sans-serif stack without dropping PingFang / YaHei`, () => {
+    const sans = `-apple-system-font,BlinkMacSystemFont, Helvetica Neue, PingFang SC, Hiragino Sans GB , Microsoft YaHei UI , Microsoft YaHei ,Arial,sans-serif`
+    const html = `<style>p{font-family:${sans}}</style><p>hello</p>`
+
+    const sanitized = sanitizeHtmlCssForJuice(html)
+    expect(sanitized).toMatch(/['"]PingFang SC['"]/)
+    expect(sanitized).toMatch(/['"]Microsoft YaHei['"]/)
+    expect(sanitized).toMatch(/['"]Helvetica Neue['"]/)
+    expect(sanitized).toMatch(/sans-serif/)
   })
 })
 

--- a/apps/web/src/services/export/clipboard.ts
+++ b/apps/web/src/services/export/clipboard.ts
@@ -1,6 +1,7 @@
 import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from '@/lib/preview/preview-ready'
 import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
+import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 import { createEmptyNode, modifyHtmlStructure, promoteSvgHtmlLabels, sanitizeHtmlCssForJuice, solveWeChatImage, stripFontFamilyForJuiceFallback, stripInvalidCssForJuice } from './clipboard-dom'
 import { getStylesToAdd } from './share-styles'
@@ -52,6 +53,7 @@ export async function processClipboardContent(primaryColor: string) {
 
   const renderStore = useRenderStore()
   const editorStore = useEditorStore()
+  const themeStore = useThemeStore()
   const uiStore = useUIStore()
   const content = editorStore.getContent()
   const wechatThemeMode = `light` as const
@@ -83,6 +85,8 @@ export async function processClipboardContent(primaryColor: string) {
       .replace(/hsl\(var\(--foreground\)\)/g, `#3f3f3f`)
       .replace(/var\(--blockquote-background\)/g, `#f7f7f7`)
       .replace(/var\(--md-primary-color\)/g, primaryColor)
+      .replace(/var\(--md-font-family\)/g, themeStore.fontFamily)
+      .replace(/var\(--md-font-size\)/g, themeStore.fontSize)
       .replace(/--md-primary-color:.+?;/g, ``)
       .replace(/--md-font-family:.+?;/g, ``)
       .replace(/--md-font-size:.+?;/g, ``)


### PR DESCRIPTION
## Summary

- Keep the editor font stack when copying to WeChat. Juice sanitization used to rewrite multi-word fonts such as `PingFang SC` to `sans-serif`, so a mid-stack generic family made later serif fonts unreachable after paste.
- Quote multi-word / CJK font names instead of replacing them, so juice can still parse Mermaid `Open Sans` without breaking the 衬线 / 无衬线 presets.
- Substitute leftover `var(--md-font-family)` / `var(--md-font-size)` after inlining, the same way primary color is handled.

## Related Issue

Closes #1916

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Procedure

- [x] `pnpm --filter @md/web test -- src/services/export/clipboard.test.ts`
- [ ] Switch preview font to 衬线, copy, paste into the WeChat official account editor, and confirm serif fonts are kept
- [ ] Repeat with 无衬线 and 等宽
- [ ] Copy an article that contains a Mermaid diagram and confirm juice still succeeds

## Pre-flight Checklist

- [x] Change is focused on one issue
- [x] Commit follows Conventional Commits
- [x] Related unit tests updated
- [ ] CI is green
