### PR TITLE
fix(core): render GFM task lists as static checkboxes

### DIFF
--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -347,15 +347,24 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       )
     },
 
+    checkbox({ checked }: Tokens.Checkbox): string {
+      // WeChat drops form controls, so task state is drawn with a styled span.
+      // The glyph is always emitted and hidden via `color: transparent` when
+      // unchecked, keeping the box non-empty and both states the same size.
+      const className = checked ? `task-checkbox task-checkbox-checked` : `task-checkbox`
+      return `<span class="${className}">✓</span> `
+    },
+
     listitem(token: Tokens.ListItem) {
       const ordered = listOrderedStack[listOrderedStack.length - 1]
       const idx = listCounters[listCounters.length - 1]!
 
       listCounters[listCounters.length - 1] = idx + 1
 
+      // Task items carry their own marker from checkbox(); a bullet would double up.
       const prefix = ordered
         ? `${idx}. `
-        : `• `
+        : token.task ? `` : `• `
 
       let content: string
       try {

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -352,7 +352,8 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       // The glyph is always emitted and hidden via `color: transparent` when
       // unchecked, keeping the box non-empty and both states the same size.
       const className = checked ? `task-checkbox task-checkbox-checked` : `task-checkbox`
-      return `<span class="${className}">✓</span> `
+      // nbsp so WeChat cannot split the marker from the label at a regular space.
+      return `<span class="${className}">✓</span>&nbsp;`
     },
 
     listitem(token: Tokens.ListItem) {

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -1,7 +1,7 @@
 import type { CollectedHeading, IOpts, RendererAPI } from '@md/shared/types'
 import type { FrontMatterData } from '@md/shared/types/front-matter'
 import type { ReadTimeResults } from '@md/shared/utils/readingTime'
-import type { RendererObject, Tokens } from 'marked'
+import type { RendererObject, Token, Tokens } from 'marked'
 import readingTime from '@md/shared/utils/readingTime'
 import { decodeHTML } from 'entities'
 import hljs from 'highlight.js/lib/core'
@@ -41,6 +41,27 @@ function stripInlineHtml(html: string): string {
   return decodeHTML(html.replace(HTML_TAG_REGEX, ``))
 }
 const PARAGRAPH_WRAPPER_REGEX = /^<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/
+
+function renderTaskCheckbox(checked: boolean): string {
+  const className = checked ? `task-checkbox task-checkbox-checked` : `task-checkbox`
+  return `<section class="${className}" style="display:table-cell;vertical-align:middle;">✓</section>`
+}
+
+/** Drop marked's checkbox tokens so listitem can emit a WeChat-safe marker itself. */
+function stripCheckboxTokens(tokens: Token[]): Token[] {
+  const result: Token[] = []
+  for (const token of tokens) {
+    if (token.type === `checkbox`)
+      continue
+    if (`tokens` in token && Array.isArray(token.tokens)) {
+      result.push({ ...token, tokens: stripCheckboxTokens(token.tokens) } as Token)
+    }
+    else {
+      result.push(token)
+    }
+  }
+  return result
+}
 const MP_WEIXIN_LINK_REGEX = /^https?:\/\/mp\.weixin\.qq\.com/
 /** Locale-neutral English fallbacks; Web injects localized strings via IOpts. */
 const DEFAULT_COUNT_SUMMARY = `{words} words, about {minutes} min read`
@@ -348,12 +369,9 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
     },
 
     checkbox({ checked }: Tokens.Checkbox): string {
-      // WeChat drops form controls, so task state is drawn with a styled span.
-      // The glyph is always emitted and hidden via `color: transparent` when
-      // unchecked, keeping the box non-empty and both states the same size.
-      const className = checked ? `task-checkbox task-checkbox-checked` : `task-checkbox`
-      // nbsp so WeChat cannot split the marker from the label at a regular space.
-      return `<span class="${className}">✓</span>&nbsp;`
+      // WeChat drops form controls and promotes bordered spans to block
+      // <section>s, so the marker is a table-cell section instead.
+      return renderTaskCheckbox(!!checked)
     },
 
     listitem(token: Tokens.ListItem) {
@@ -362,24 +380,41 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
       listCounters[listCounters.length - 1] = idx + 1
 
-      // Task items carry their own marker from checkbox(); a bullet would double up.
       const prefix = ordered
         ? `${idx}. `
         : token.task ? `` : `• `
 
+      const bodyTokens = token.task
+        ? stripCheckboxTokens(token.tokens)
+        : token.tokens
+      const nestedLists = token.task
+        ? bodyTokens.filter((item): item is Tokens.List => item.type === `list`)
+        : []
+      const rest = token.task
+        ? bodyTokens.filter(item => item.type !== `list`)
+        : bodyTokens
+
       let content: string
       try {
-        content = this.parser.parseInline(token.tokens)
+        content = this.parser.parseInline(rest)
       }
       catch {
         content = this.parser
-          .parse(token.tokens)
+          .parse(rest)
           .replace(PARAGRAPH_WRAPPER_REGEX, `$1`)
+      }
+
+      const nested = nestedLists.map(list => this.list(list)).join(``)
+
+      if (token.task) {
+        // display:table survives WeChat paste; inline-block / bordered spans do not.
+        const marker = renderTaskCheckbox(!!token.checked)
+        content = `<section class="task-item" style="display:table;width:100%;">${marker}<section class="task-item-text" style="display:table-cell;vertical-align:middle;">${prefix}${content}</section></section>`
       }
 
       return styledContent(
         `listitem`,
-        `${prefix}${content}`,
+        `${token.task ? `` : prefix}${content}${nested}`,
         `li`,
       )
     },

--- a/packages/core/src/renderer/renderer.test.ts
+++ b/packages/core/src/renderer/renderer.test.ts
@@ -103,15 +103,18 @@ $$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
     const { html } = renderMarkdown(`- [x] done\n- [ ] todo`, renderer)
 
     expect(html).not.toContain(`<input`)
+    expect(html).toContain(`display:table`)
     expect(html).toContain(`class="task-checkbox task-checkbox-checked"`)
     expect(html).toContain(`class="task-checkbox"`)
+    expect(html).toContain(`done`)
+    expect(html).toContain(`todo`)
   })
 
   it('omits the bullet prefix on task list items but keeps it on plain items', () => {
     const renderer = initRenderer({})
     const { html } = renderMarkdown(`- [ ] todo\n- plain`, renderer)
 
-    expect(html).toContain(`<li class="listitem"><span class="task-checkbox"`)
+    expect(html).toContain(`<section class="task-item"`)
     expect(html).toContain(`<li class="listitem">• plain</li>`)
   })
 
@@ -119,8 +122,11 @@ $$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
     const renderer = initRenderer({})
     const { html } = renderMarkdown(`1. [x] first\n2. [ ] second`, renderer)
 
-    expect(html).toContain(`<li class="listitem">1. <span class="task-checkbox task-checkbox-checked"`)
-    expect(html).toContain(`<li class="listitem">2. <span class="task-checkbox"`)
+    expect(html).toContain(`class="task-item-text"`)
+    expect(html).toContain(`1. first`)
+    expect(html).toContain(`2. second`)
+    expect(html).toContain(`class="task-checkbox task-checkbox-checked"`)
+    expect(html).toContain(`class="task-checkbox"`)
   })
 
   it('renders checkboxes in nested task lists', () => {

--- a/packages/core/src/renderer/renderer.test.ts
+++ b/packages/core/src/renderer/renderer.test.ts
@@ -98,6 +98,48 @@ $$ITE_{i}=Y_{i,1}-Y_{i,0} \\tag{1}$$`
     expect(html).not.toMatch(/<p[^>]*>\s*<section class="katex-block"/)
   })
 
+  it('renders task list items with a styled checkbox instead of an input', () => {
+    const renderer = initRenderer({})
+    const { html } = renderMarkdown(`- [x] done\n- [ ] todo`, renderer)
+
+    expect(html).not.toContain(`<input`)
+    expect(html).toContain(`class="task-checkbox task-checkbox-checked"`)
+    expect(html).toContain(`class="task-checkbox"`)
+  })
+
+  it('omits the bullet prefix on task list items but keeps it on plain items', () => {
+    const renderer = initRenderer({})
+    const { html } = renderMarkdown(`- [ ] todo\n- plain`, renderer)
+
+    expect(html).toContain(`<li class="listitem"><span class="task-checkbox"`)
+    expect(html).toContain(`<li class="listitem">• plain</li>`)
+  })
+
+  it('keeps the number prefix on ordered task list items', () => {
+    const renderer = initRenderer({})
+    const { html } = renderMarkdown(`1. [x] first\n2. [ ] second`, renderer)
+
+    expect(html).toContain(`<li class="listitem">1. <span class="task-checkbox task-checkbox-checked"`)
+    expect(html).toContain(`<li class="listitem">2. <span class="task-checkbox"`)
+  })
+
+  it('renders checkboxes in nested task lists', () => {
+    const renderer = initRenderer({})
+    const { html } = renderMarkdown(`- [ ] parent\n  - [x] child`, renderer)
+
+    expect(html).not.toContain(`<input`)
+    expect(html.match(/class="task-checkbox/g)).toHaveLength(2)
+    expect(html).toContain(`task-checkbox-checked`)
+  })
+
+  it('renders checkboxes in loose task lists', () => {
+    const renderer = initRenderer({})
+    const { html } = renderMarkdown(`- [x] first\n\n- [ ] second`, renderer)
+
+    expect(html).not.toContain(`<input`)
+    expect(html.match(/class="task-checkbox/g)).toHaveLength(2)
+  })
+
   it('collects headings in document order with plain text', () => {
     const renderer = initRenderer({})
     renderMarkdown(`# Title\n\n## Sub \`code\` & **bold**\n\nBody\n\n### Third`, renderer)

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -53,21 +53,39 @@ section table {
  * Lives in base (not theme CSS) so the marker survives every consumer:
  * scoped web preview, unscoped VSCode preview, exported HTML and share pages.
  * Avoids --foreground, which only the web shell injects.
+ *
+ * WeChat paste promotes bordered <span>s to block <section>s, which puts the
+ * label on the next line. A table + table-cell pair is the layout WeChat
+ * already uses for headings, so the marker and label stay on one row.
  */
+.task-item {
+  display: table;
+  width: 100%;
+}
+
 .task-checkbox {
-  /*
-   * Must stay `inline` (the span default). `inline-block` + width/height makes
-   * WeChat treat the marker as a replaced box on paste, wrap the following
-   * label in a block, and put the text on the next line.
-   */
+  display: table-cell;
+  width: 1.35em;
   border: 1px solid var(--md-primary-color);
   border-radius: 3px;
-  padding: 0 0.15em;
-  margin-right: 0.35em;
   color: transparent;
   font-size: 0.8em;
   line-height: 1.2;
+  text-align: center;
+  vertical-align: middle;
   white-space: nowrap;
+}
+
+.task-checkbox-checked {
+  border-color: var(--md-primary-color);
+  background: var(--md-primary-color);
+  color: #fff;
+}
+
+.task-item-text {
+  display: table-cell;
+  padding-left: 0.45em;
+  vertical-align: middle;
 }
 
 .task-checkbox-checked {

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -47,3 +47,29 @@ section table {
   color: unset !important;
   letter-spacing: unset !important;
 }
+
+/*
+ * ==================== Task lists ====================
+ * Lives in base (not theme CSS) so the marker survives every consumer:
+ * scoped web preview, unscoped VSCode preview, exported HTML and share pages.
+ * Avoids --foreground, which only the web shell injects.
+ */
+.task-checkbox {
+  display: inline-block;
+  box-sizing: border-box;
+  width: 1em;
+  height: 1em;
+  border: 1px solid color-mix(in srgb, var(--md-primary-color) 45%, transparent);
+  border-radius: 3px;
+  color: transparent;
+  font-size: 0.85em;
+  line-height: 1;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.task-checkbox-checked {
+  border-color: var(--md-primary-color);
+  background: var(--md-primary-color);
+  color: #fff;
+}

--- a/packages/shared/src/configs/theme-css/base.css
+++ b/packages/shared/src/configs/theme-css/base.css
@@ -55,17 +55,19 @@ section table {
  * Avoids --foreground, which only the web shell injects.
  */
 .task-checkbox {
-  display: inline-block;
-  box-sizing: border-box;
-  width: 1em;
-  height: 1em;
-  border: 1px solid color-mix(in srgb, var(--md-primary-color) 45%, transparent);
+  /*
+   * Must stay `inline` (the span default). `inline-block` + width/height makes
+   * WeChat treat the marker as a replaced box on paste, wrap the following
+   * label in a block, and put the text on the next line.
+   */
+  border: 1px solid var(--md-primary-color);
   border-radius: 3px;
+  padding: 0 0.15em;
+  margin-right: 0.35em;
   color: transparent;
-  font-size: 0.85em;
-  line-height: 1;
-  text-align: center;
-  vertical-align: middle;
+  font-size: 0.8em;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .task-checkbox-checked {


### PR DESCRIPTION
## Summary

GFM task lists were rendered incorrectly. `listitem` unconditionally prefixed unordered items with `•` and never looked at marked's `task` / `checked` flags, so `- [x] done` came out as a bullet followed by marked's default `<input type="checkbox">`:

```html
<li class="listitem">• <input checked="" disabled="" type="checkbox"> done</li>
```

Two problems with that:

- The bullet and the checkbox stack up, which looks broken in the preview.
- WeChat strips form controls, so after pasting there is no visible task state at all — checked and unchecked items become indistinguishable.

This PR overrides marked's `checkbox` renderer to emit a themed span drawn with CSS, and skips the bullet prefix on task items (ordered task lists keep their number). Output is now:

```html
<li class="listitem"><span class="task-checkbox task-checkbox-checked">✓</span> done</li>
```

The checkmark glyph is always emitted and hidden with `color: transparent` when unchecked, so both states keep identical box metrics and the element never renders empty.

Styles live in `base.css` rather than a theme file for two reasons: base CSS is injected unscoped, so the marker also works in the VSCode preview (which has no `#output` wrapper), exported HTML and share pages; and it applies to every theme instead of only the ones layered on `default.css`. The colors derive from `--md-primary-color`, which `generateCSSVariables` always defines — `--foreground` was deliberately avoided since only the web shell injects it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

Added five renderer tests covering checked/unchecked markers, bullet suppression on task items while plain items keep `•`, number retention on ordered task lists, nested task lists, and loose task lists (where marked nests the checkbox token inside a paragraph, exercising the `parseInline` fallback path).

```bash
pnpm --filter @md/core --filter @md/shared exec vitest run   # 131 passed
pnpm --filter @md/core run type-check
npx eslint --fix packages/core/src/renderer packages/shared/src/configs/theme-css/base.css
```

Manual check: render `- [x] done` / `- [ ] todo` in the preview, confirm a single themed box per item, then copy to WeChat and confirm the state survives the paste.

## Pre-flight Checklist

- [x] Code follows the project style and passes `pnpm run lint`
- [x] Type check passes
- [x] Unit tests added and passing
- [x] No user-facing copy changed, so no i18n updates needed
