### PR TITLE
feat(core): add superscript syntax and theme strikethrough

### DIFF
--- a/apps/web/src/i18n/messages/en-US/dialog.ts
+++ b/apps/web/src/i18n/messages/en-US/dialog.ts
@@ -138,6 +138,7 @@ export default {
         { name: `Strikethrough`, syntax: `~~strikethrough~~`, example: `strikethrough` },
         { name: `Highlight`, syntax: `==highlighted text==`, example: `highlighted text` },
         { name: `Underline`, syntax: `++underline++`, example: `underline` },
+        { name: `Superscript`, syntax: `x^2^`, example: `x²`, tip: `Write it right after the text; the content cannot contain spaces` },
         { name: `Inline code`, syntax: `\`code\``, example: `code` },
         { name: `Unordered list`, syntax: `- Item 1\n- Item 2\n  - Nested item`, tip: `Use -, *, or + followed by a space` },
         { name: `Ordered list`, syntax: `1. Item 1\n2. Item 2`, tip: `Number followed by a period` },

--- a/apps/web/src/i18n/messages/ja-JP/dialog.ts
+++ b/apps/web/src/i18n/messages/ja-JP/dialog.ts
@@ -138,6 +138,7 @@ export default {
         { name: `取り消し線`, syntax: `~~取り消し線~~`, example: `取り消し線` },
         { name: `ハイライト`, syntax: `==ハイライトテキスト==`, example: `ハイライトテキスト` },
         { name: `下線`, syntax: `++下線++`, example: `下線` },
+        { name: `上付き文字`, syntax: `x^2^`, example: `x²`, tip: `文字の直後に書きます。内容に空白は使えません` },
         { name: `インラインコード`, syntax: `\`コード\``, example: `コード` },
         { name: `箇条書き`, syntax: `- 項目 1\n- 項目 2\n  - ネスト項目`, tip: `-、*、または + の後にスペース` },
         { name: `番号付きリスト`, syntax: `1. 項目 1\n2. 項目 2`, tip: `数字の後にピリオド` },

--- a/apps/web/src/i18n/messages/zh-CN/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-CN/dialog.ts
@@ -138,6 +138,7 @@ export default {
         { name: `删除线`, syntax: `~~删除线~~`, example: `删除线` },
         { name: `高亮`, syntax: `==高亮文本==`, example: `高亮文本` },
         { name: `下划线`, syntax: `++下划线++`, example: `下划线` },
+        { name: `上标`, syntax: `x^2^`, example: `x²`, tip: `紧跟在文字后面书写，内容中不能有空格` },
         { name: `行内代码`, syntax: `\`代码\``, example: `代码` },
         { name: `无序列表`, syntax: `- 项目 1\n- 项目 2\n  - 嵌套项目`, tip: `使用 -、* 或 + 加空格` },
         { name: `有序列表`, syntax: `1. 项目 1\n2. 项目 2`, tip: `数字加点号` },

--- a/apps/web/src/i18n/messages/zh-TW/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-TW/dialog.ts
@@ -138,6 +138,7 @@ export default {
         { name: `刪除線`, syntax: `~~刪除線~~`, example: `刪除線` },
         { name: `高亮`, syntax: `==高亮文本==`, example: `高亮文本` },
         { name: `下劃線`, syntax: `++下劃線++`, example: `下劃線` },
+        { name: `上標`, syntax: `x^2^`, example: `x²`, tip: `緊跟在文字後面書寫，內容中不能有空格` },
         { name: `行內程式碼`, syntax: `\`程式碼\``, example: `程式碼` },
         { name: `無序列表`, syntax: `- 專案 1\n- 專案 2\n  - 巢狀專案`, tip: `使用 -、* 或 + 加空格` },
         { name: `有序列表`, syntax: `1. 專案 1\n2. 專案 2`, tip: `數字加點號` },

--- a/packages/core/src/extensions/extensions.test.ts
+++ b/packages/core/src/extensions/extensions.test.ts
@@ -134,6 +134,42 @@ describe(`markup extension`, () => {
     expect(html).toContain(`class="markup-highlight"`)
     expect(html).toContain(`class="markup-wavyline"`)
   })
+
+  it(`renders superscript directly after a word char`, () => {
+    const html = render(`x^2^ + y^10^ = z`)
+
+    expect((html.match(/class="markup-superscript"/g) ?? []).length).toBe(2)
+    expect(html).toContain(`<sup class="markup-superscript">2</sup>`)
+    expect(html).toContain(`<sup class="markup-superscript">10</sup>`)
+  })
+
+  it(`keeps carets as literal text when superscript cannot pair`, () => {
+    expect(render(`a ^ b ^ c`)).not.toContain(`markup-superscript`)
+    expect(render(`2^10 is 1024`)).not.toContain(`markup-superscript`)
+    expect(render(`^ leading caret`)).not.toContain(`markup-superscript`)
+  })
+
+  it(`leaves ruby hat syntax to the ruby extension`, () => {
+    const html = render(`[汉字]^(han-zi)`)
+
+    expect(html).not.toContain(`markup-superscript`)
+    expect(html).toContain(`data-format="basic-hat"`)
+  })
+})
+
+describe(`strikethrough`, () => {
+  it(`renders del with a theme class`, () => {
+    const html = render(`~~gone~~`)
+
+    expect(html).toContain(`<del class="del">gone</del>`)
+  })
+
+  it(`keeps wavyline distinct from strikethrough`, () => {
+    const html = render(`~~gone~~ and ~wave~`)
+
+    expect(html).toContain(`<del class="del">gone</del>`)
+    expect(html).toContain(`class="markup-wavyline"`)
+  })
 })
 
 describe(`slider extension`, () => {

--- a/packages/core/src/extensions/markup.ts
+++ b/packages/core/src/extensions/markup.ts
@@ -1,5 +1,5 @@
 import type { MarkedExtension, Token } from 'marked'
-import type { MarkupHighlightToken, MarkupUnderlineToken, MarkupWavylineToken } from '../types/marked-tokens'
+import type { MarkupHighlightToken, MarkupSuperscriptToken, MarkupUnderlineToken, MarkupWavylineToken } from '../types/marked-tokens'
 import { asTextTokenRenderer } from '../types/marked-tokens'
 
 // ASCII-only on purpose: `C++`/`x==1`/`v1~2` must stay literal, while CJK
@@ -38,7 +38,7 @@ function boundaryStart(src: string, delimiter: RegExp): number | undefined {
   }
 }
 
-/** Extended markup: ==highlight==, ++underline++, ~wavyline~ */
+/** Extended markup: ==highlight==, ++underline++, ~wavyline~, ^superscript^ */
 export function markedMarkup(): MarkedExtension {
   return {
     extensions: [
@@ -114,6 +114,33 @@ export function markedMarkup(): MarkedExtension {
         },
         renderer: asTextTokenRenderer((token: MarkupWavylineToken) => {
           return `<span class="markup-wavyline">${token.text}</span>`
+        }),
+      },
+
+      {
+        name: `markup_superscript`,
+        level: `inline`,
+        start(src: string) {
+          // Superscript is the one delimiter meant to sit right after a word
+          // char (`x^2^`), so the shared word-boundary filtering is skipped.
+          const index = src.indexOf(`^`)
+          return index === -1 ? undefined : index
+        },
+        tokenizer(src: string) {
+          // Content must be whitespace-free, so prose like `a ^ b` and dangling
+          // carets such as `2^10` stay literal.
+          const rule = /^\^([^\s^]+)\^/
+          const match = rule.exec(src)
+          if (match) {
+            return {
+              type: `markup_superscript`,
+              raw: match[0],
+              text: match[1],
+            }
+          }
+        },
+        renderer: asTextTokenRenderer((token: MarkupSuperscriptToken) => {
+          return `<sup class="markup-superscript">${token.text}</sup>`
         }),
       },
     ],

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -415,6 +415,10 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       return styledContent(`em`, this.parser.parseInline(tokens))
     },
 
+    del({ tokens }: Tokens.Del): string {
+      return styledContent(`del`, this.parser.parseInline(tokens))
+    },
+
     table({ header, rows }: Tokens.Table): string {
       const headerRow = header
         .map((cell) => {

--- a/packages/core/src/theme/selectorMapping.ts
+++ b/packages/core/src/theme/selectorMapping.ts
@@ -99,6 +99,7 @@ export const SELECTOR_MAPPING: Record<string, string> = {
   markup_highlight: `markup-highlight`,
   markup_underline: `markup-underline`,
   markup_wavyline: `markup-wavyline`,
+  markup_superscript: `markup-superscript`,
 
   listitem: `listitem`,
 }

--- a/packages/core/src/types/marked-tokens.ts
+++ b/packages/core/src/types/marked-tokens.ts
@@ -31,6 +31,10 @@ export interface MarkupWavylineToken extends TextToken {
   type: 'markup_wavyline'
 }
 
+export interface MarkupSuperscriptToken extends TextToken {
+  type: 'markup_superscript'
+}
+
 export interface RubyToken extends TextToken {
   type: 'ruby'
   ruby: string

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -315,8 +315,8 @@ server.registerTool(
       },
       {
         name: `Markup Highlighting`,
-        description: `Inline ==highlighted== text.`,
-        example: `==highlighted text==`,
+        description: `Inline markup: ==highlight==, ++underline++, ~wavy line~ and ^superscript^.`,
+        example: `==highlighted text== ++underlined++ ~wavy~ x^2^`,
       },
       {
         name: `Slider`,

--- a/packages/shared/src/configs/theme-css/default.css
+++ b/packages/shared/src/configs/theme-css/default.css
@@ -491,6 +491,12 @@ strong {
   font-size: inherit;
 }
 
+/* ==================== Strikethrough ==================== */
+.del {
+  color: color-mix(in srgb, hsl(var(--foreground)) 55%, transparent);
+  text-decoration: line-through;
+}
+
 /* ==================== Tables ==================== */
 table {
   color: hsl(var(--foreground));
@@ -562,4 +568,11 @@ td {
   text-decoration: underline wavy;
   text-decoration-color: var(--md-primary-color);
   text-decoration-thickness: 2px;
+}
+
+/* line-height: 0 keeps the raised glyph from stretching the line box */
+.markup-superscript {
+  font-size: 0.75em;
+  line-height: 0;
+  vertical-align: super;
 }


### PR DESCRIPTION
## Summary

Two related gaps in inline rendering.

**Superscript had no syntax.** `x^2^` leaked through as literal text, so footnote markers, units and simple math in prose had to fall back to KaTeX or a raw `<sup>` tag. This adds a `markup_superscript` inline extension alongside the existing `==highlight==` / `++underline++` / `~wavy~` family.

It renders semantic `<sup>`:

```html
x<sup class="markup-superscript">2</sup>
```

Using the real element rather than a styled `<span>` means it still reads correctly wherever the theme CSS does not reach, and `<sup>` is already proven to survive a WeChat paste — the external-link citation feature emits one.

Two tokenizer details worth flagging for review:

- Superscript is the one delimiter in this family that is *supposed* to sit directly after a word character (`x^2^`), so it deliberately opts out of the shared `followsWordChar` / `boundaryStart` filtering that exists to keep `C++` literal. Instead it requires whitespace-free content, which keeps prose like `a ^ b ^ c` and dangling carets like `2^10` literal.
- Ruby's `[text]^(annotation)` form is unaffected. `markedRuby` is registered after `markedMarkup`, and marked `unshift`s each extension's tokenizer, so ruby is tried first. There is a test pinning this.

**Subscript is deliberately not included.** Pandoc-style `H~2~O` needs the single `~` delimiter that the wavy-line extension already owns, so adding it would silently change how existing documents render. Left out rather than guessed at.

**Strikethrough is now themeable.** `<del>` was emitted without a class, so it was the only inline element that could not be styled by a theme and relied purely on the browser default. It now goes through `styledContent`, producing `<del class="del">`, with a muted colour in `default.css`.

Docs updated alongside the code: the Markdown help dialog gains a superscript entry in all four locales, `SELECTOR_MAPPING` gains the new class so custom CSS can target it, and the MCP `explain_extensions` entry now lists the full markup family instead of only highlight.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

Added five extension tests: superscript pairing after a word char, three non-pairing cases that must stay literal, ruby-hat precedence, and two strikethrough cases covering the new class and its coexistence with the wavy-line extension.

```bash
pnpm --filter @md/core exec vitest run   # 74 passed
pnpm --filter @md/core run type-check
npx eslint --fix packages/core/src packages/mcp-server/src apps/web/src/i18n/messages
```

Manual check: render `x^2^`, `~~gone~~`, `[汉字]^(han-zi)` and `C++17` in the preview, confirm the first two pick up the new styles, the third still renders ruby, and the fourth stays literal. Then copy to WeChat and confirm `<sup>` and `<del>` survive the paste.

## Pre-flight Checklist

- [x] Code follows the project style and passes `pnpm run lint`
- [x] Type check passes
- [x] Unit tests added and passing
- [x] User-facing copy added to all four locales (zh-CN, zh-TW, en-US, ja-JP)
