### PR TITLE
feat(theme): make link color and blockquote background configurable

### DIFF
--- a/apps/web/src/components/editor/CssEditor.vue
+++ b/apps/web/src/components/editor/CssEditor.vue
@@ -338,6 +338,8 @@ function exportCurrentTheme() {
       fontSize: themeStore.fontSize,
       lineHeight: themeStore.lineHeight,
       blockSpacing: themeStore.blockSpacing,
+      linkColor: themeStore.linkColor,
+      blockquoteBackground: themeStore.blockquoteBackground,
     },
     currentThemeName,
   )

--- a/apps/web/src/components/editor/RightSlider.vue
+++ b/apps/web/src/components/editor/RightSlider.vue
@@ -28,6 +28,8 @@ const {
   fontSize,
   lineHeight,
   blockSpacing,
+  linkColor,
+  blockquoteBackground,
   primaryColor,
   codeBlockTheme,
   legend,
@@ -103,6 +105,20 @@ function lineHeightChanged(value: string) {
 
 function blockSpacingChanged(value: string) {
   themeStore.blockSpacing = value
+
+  themeStore.applyCurrentTheme()
+  scheduleEditorRefresh()
+}
+
+function linkColorChanged(value: string) {
+  themeStore.linkColor = value
+
+  themeStore.applyCurrentTheme()
+  scheduleEditorRefresh()
+}
+
+function blockquoteBackgroundChanged(value: string) {
+  themeStore.blockquoteBackground = value
 
   themeStore.applyCurrentTheme()
   scheduleEditorRefresh()
@@ -352,6 +368,34 @@ const isThemeCompact = computed(() => themeGridWidth.value > 0 && themeGridWidth
             v-for="{ label, value, desc } in localizedStyleOptions.blockSpacingOptions" :key="value" variant="outline" class="h-auto w-full px-1 py-2 text-xs whitespace-nowrap" :title="desc" :class="{
               'bg-accent text-accent-foreground ring-1 ring-primary/20 border-primary': blockSpacing === value,
             }" @click="blockSpacingChanged(value)"
+          >
+            {{ label }}
+          </Button>
+        </div>
+      </div>
+      <div class="space-y-2">
+        <h2 class="text-sm font-medium">
+          {{ t('menu.linkColor') }}
+        </h2>
+        <div class="grid grid-cols-3 gap-1.5">
+          <Button
+            v-for="{ label, value, desc } in localizedStyleOptions.linkColorOptions" :key="value" variant="outline" class="h-auto w-full px-1 py-2 text-xs whitespace-nowrap" :title="desc" :class="{
+              'bg-accent text-accent-foreground ring-1 ring-primary/20 border-primary': linkColor === value,
+            }" @click="linkColorChanged(value)"
+          >
+            {{ label }}
+          </Button>
+        </div>
+      </div>
+      <div class="space-y-2">
+        <h2 class="text-sm font-medium">
+          {{ t('menu.blockquoteBackground') }}
+        </h2>
+        <div class="grid grid-cols-3 gap-1.5">
+          <Button
+            v-for="{ label, value, desc } in localizedStyleOptions.blockquoteBackgroundOptions" :key="value" variant="outline" class="h-auto w-full px-1 py-2 text-xs whitespace-nowrap" :title="desc" :class="{
+              'bg-accent text-accent-foreground ring-1 ring-primary/20 border-primary': blockquoteBackground === value,
+            }" @click="blockquoteBackgroundChanged(value)"
           >
             {{ label }}
           </Button>

--- a/apps/web/src/components/editor/editor-header/StyleDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/StyleDropdown.vue
@@ -3,7 +3,7 @@ import type {
   ThemeName,
 } from '@md/shared/configs'
 import type { Format } from 'vue-pick-colors'
-import { ALargeSmall, AlignVerticalSpaceAround, Code, Droplet, FileCode, ImageIcon, Palette, Pipette, RotateCcw, Rows3, SquareCode, Store, Type } from '@lucide/vue'
+import { ALargeSmall, AlignVerticalSpaceAround, Code, Droplet, FileCode, ImageIcon, Link, Palette, Pipette, Quote, RotateCcw, Rows3, SquareCode, Store, Type } from '@lucide/vue'
 import {
   codeBlockThemeOptions,
 } from '@md/shared/configs'
@@ -41,6 +41,8 @@ const {
   fontSize,
   lineHeight,
   blockSpacing,
+  linkColor,
+  blockquoteBackground,
   primaryColor,
   codeBlockTheme,
   legend,
@@ -78,6 +80,20 @@ function lineHeightChanged(value: string) {
 
 function blockSpacingChanged(value: string) {
   themeStore.blockSpacing = value
+
+  themeStore.applyCurrentTheme()
+  editorRefresh()
+}
+
+function linkColorChanged(value: string) {
+  themeStore.linkColor = value
+
+  themeStore.applyCurrentTheme()
+  editorRefresh()
+}
+
+function blockquoteBackgroundChanged(value: string) {
+  themeStore.blockquoteBackground = value
 
   themeStore.applyCurrentTheme()
   editorRefresh()
@@ -197,6 +213,22 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         :icon="Droplet"
       />
       <StyleOptionMenu
+        :title="t('menu.linkColor')"
+        style-key="linkColor"
+        :options="localizedStyleOptions.linkColorOptions"
+        :current="linkColor"
+        :change="linkColorChanged"
+        :icon="Link"
+      />
+      <StyleOptionMenu
+        :title="t('menu.blockquoteBackground')"
+        style-key="blockquoteBackground"
+        :options="localizedStyleOptions.blockquoteBackgroundOptions"
+        :current="blockquoteBackground"
+        :change="blockquoteBackgroundChanged"
+        :icon="Quote"
+      />
+      <StyleOptionMenu
         :title="t('menu.codeBlockTheme')"
         :options="codeBlockThemeOptions"
         :current="codeBlockTheme"
@@ -304,6 +336,22 @@ const formatOptions = ref<Format[]>([`rgb`, `hex`, `hsl`, `hsv`])
         :current="primaryColor"
         :change="colorChanged"
         :icon="Droplet"
+      />
+      <StyleOptionMenu
+        :title="t('menu.linkColor')"
+        style-key="linkColor"
+        :options="localizedStyleOptions.linkColorOptions"
+        :current="linkColor"
+        :change="linkColorChanged"
+        :icon="Link"
+      />
+      <StyleOptionMenu
+        :title="t('menu.blockquoteBackground')"
+        style-key="blockquoteBackground"
+        :options="localizedStyleOptions.blockquoteBackgroundOptions"
+        :current="blockquoteBackground"
+        :change="blockquoteBackgroundChanged"
+        :icon="Quote"
       />
       <StyleOptionMenu
         :title="t('menu.codeBlockTheme')"

--- a/apps/web/src/components/editor/editor-header/StyleOptionMenu.vue
+++ b/apps/web/src/components/editor/editor-header/StyleOptionMenu.vue
@@ -2,14 +2,22 @@
 import type { IConfigOption } from '@md/shared/types'
 import type { Component } from 'vue'
 
+type StyleKey = `font` | `fontSize` | `color` | `lineHeight` | `blockSpacing` | `linkColor` | `blockquoteBackground`
+
 const props = defineProps<{
   title: string
-  styleKey?: `font` | `fontSize` | `color` | `lineHeight` | `blockSpacing`
+  styleKey?: StyleKey
   options: IConfigOption[]
   current: string
   change: (val: any) => void
   icon?: Component
 }>()
+
+// Keys whose desc reads as a plain hint beside the label. `font` renders its desc
+// in the font itself, and `color` has no useful hint to show.
+const DESC_AS_HINT_KEYS: StyleKey[] = [`fontSize`, `lineHeight`, `blockSpacing`, `linkColor`, `blockquoteBackground`]
+
+const showDescHint = computed(() => !!props.styleKey && DESC_AS_HINT_KEYS.includes(props.styleKey))
 
 function setStyle(styleKey: typeof props.styleKey, value: string) {
   switch (styleKey) {
@@ -46,7 +54,7 @@ function setStyle(styleKey: typeof props.styleKey, value: string) {
             {{ desc }}
           </DropdownMenuShortcut>
           <DropdownMenuShortcut
-            v-else-if="(styleKey === 'fontSize' || styleKey === 'lineHeight' || styleKey === 'blockSpacing') && desc"
+            v-else-if="showDescHint && desc"
           >
             {{ desc }}
           </DropdownMenuShortcut>

--- a/apps/web/src/composables/useLocalizedStyleOptions.ts
+++ b/apps/web/src/composables/useLocalizedStyleOptions.ts
@@ -1,6 +1,7 @@
 import type { ThemeName } from '@md/shared/configs'
 import type { IConfigOption } from '@md/shared/types'
 import {
+  blockquoteBackgroundOptions,
   blockSpacingOptions,
   codeBlockThemeOptions,
   colorOptions,
@@ -10,6 +11,7 @@ import {
   headingStyleOptions,
   legendOptions,
   lineHeightOptions,
+  linkColorOptions,
   themeOptions,
 } from '@md/shared/configs'
 import { isMarketplaceThemeKey } from '@md/shared/types'
@@ -20,6 +22,8 @@ type Translate = (key: string) => string
 const FONT_FAMILY_KEYS = [`sansSerif`, `serif`, `monospace`] as const
 const FONT_SIZE_DESC_KEYS = [`smaller`, `slightlySmaller`, `recommended`, `slightlyLarger`, `larger`] as const
 const SPACING_DESC_KEYS = [`tight`, `slightlyTight`, `recommended`, `slightlyLoose`, `loose`] as const
+const LINK_COLOR_KEYS = [`wechatBlue`, `primary`, `body`] as const
+const BLOCKQUOTE_BACKGROUND_KEYS = [`theme`, `none`, `primary`] as const
 const COLOR_KEYS = [
   `classicBlue`,
   `emeraldGreen`,
@@ -82,6 +86,22 @@ function localizeBlockSpacingOptions(t: Translate): IConfigOption[] {
   }))
 }
 
+function localizeLinkColorOptions(t: Translate): IConfigOption[] {
+  return linkColorOptions.map((option, index) => ({
+    ...option,
+    label: t(`styleOptions.linkColor.${LINK_COLOR_KEYS[index]}.label`),
+    desc: t(`styleOptions.linkColor.${LINK_COLOR_KEYS[index]}.desc`),
+  }))
+}
+
+function localizeBlockquoteBackgroundOptions(t: Translate): IConfigOption[] {
+  return blockquoteBackgroundOptions.map((option, index) => ({
+    ...option,
+    label: t(`styleOptions.blockquoteBackground.${BLOCKQUOTE_BACKGROUND_KEYS[index]}.label`),
+    desc: t(`styleOptions.blockquoteBackground.${BLOCKQUOTE_BACKGROUND_KEYS[index]}.desc`),
+  }))
+}
+
 function localizeColorOptions(t: Translate): IConfigOption[] {
   return colorOptions.map((option, index) => ({
     ...option,
@@ -135,6 +155,8 @@ export function createLocalizedStyleOptions(
     fontSizeOptions: localizeFontSizeOptions(t),
     lineHeightOptions: localizeLineHeightOptions(t),
     blockSpacingOptions: localizeBlockSpacingOptions(t),
+    linkColorOptions: localizeLinkColorOptions(t),
+    blockquoteBackgroundOptions: localizeBlockquoteBackgroundOptions(t),
     colorOptions: localizeColorOptions(t),
     codeBlockThemeOptions,
     headingLevelOptions: localizeHeadingLevelOptions(t),

--- a/apps/web/src/i18n/messages/en-US/common.ts
+++ b/apps/web/src/i18n/messages/en-US/common.ts
@@ -151,6 +151,8 @@ export default {
     lineHeight: `Line height`,
     blockSpacing: `Block spacing`,
     primaryColor: `Color`,
+    linkColor: `Link color`,
+    blockquoteBackground: `Quote background`,
     codeBlockTheme: `Code theme`,
     legendFormat: `Caption`,
     customPrimaryColor: `Custom color`,
@@ -225,6 +227,16 @@ export default {
       recommended: `Recommended`,
       slightlyLoose: `Slightly loose`,
       loose: `Loose`,
+    },
+    linkColor: {
+      wechatBlue: { label: `WeChat blue`, desc: `Default` },
+      primary: { label: `Theme color`, desc: `Follows the theme color` },
+      body: { label: `Body color`, desc: `Same as body text` },
+    },
+    blockquoteBackground: {
+      theme: { label: `Theme default`, desc: `Default` },
+      none: { label: `None`, desc: `Transparent` },
+      primary: { label: `Theme color`, desc: `Tinted with the theme color` },
     },
     color: {
       classicBlue: { label: `Blue`, desc: `` },

--- a/apps/web/src/i18n/messages/ja-JP/common.ts
+++ b/apps/web/src/i18n/messages/ja-JP/common.ts
@@ -151,6 +151,8 @@ export default {
     lineHeight: `行間`,
     blockSpacing: `段落間隔`,
     primaryColor: `色`,
+    linkColor: `リンク色`,
+    blockquoteBackground: `引用の背景`,
     codeBlockTheme: `コードテーマ`,
     legendFormat: `キャプション`,
     customPrimaryColor: `カスタム色`,
@@ -225,6 +227,16 @@ export default {
       recommended: `推奨`,
       slightlyLoose: `やや広い`,
       loose: `広い`,
+    },
+    linkColor: {
+      wechatBlue: { label: `WeChat ブルー`, desc: `デフォルト` },
+      primary: { label: `テーマカラー`, desc: `テーマカラーに従う` },
+      body: { label: `本文の色`, desc: `本文と同じ` },
+    },
+    blockquoteBackground: {
+      theme: { label: `テーマに従う`, desc: `デフォルト` },
+      none: { label: `なし`, desc: `透明` },
+      primary: { label: `テーマカラー`, desc: `テーマカラーの淡い背景` },
     },
     color: {
       classicBlue: { label: `ブルー`, desc: `` },

--- a/apps/web/src/i18n/messages/zh-CN/common.ts
+++ b/apps/web/src/i18n/messages/zh-CN/common.ts
@@ -151,6 +151,8 @@ export default {
     lineHeight: `行距`,
     blockSpacing: `段间距`,
     primaryColor: `主题色`,
+    linkColor: `链接色`,
+    blockquoteBackground: `引用背景`,
     codeBlockTheme: `代码主题`,
     legendFormat: `图注`,
     customPrimaryColor: `自定义色`,
@@ -225,6 +227,16 @@ export default {
       recommended: `推荐`,
       slightlyLoose: `稍松`,
       loose: `宽松`,
+    },
+    linkColor: {
+      wechatBlue: { label: `微信蓝`, desc: `默认` },
+      primary: { label: `主题色`, desc: `跟随主题色` },
+      body: { label: `正文色`, desc: `与正文一致` },
+    },
+    blockquoteBackground: {
+      theme: { label: `跟随主题`, desc: `默认` },
+      none: { label: `无背景`, desc: `透明` },
+      primary: { label: `主题色`, desc: `主题色浅底` },
     },
     color: {
       classicBlue: { label: `经典蓝`, desc: `稳重冷静` },

--- a/apps/web/src/i18n/messages/zh-TW/common.ts
+++ b/apps/web/src/i18n/messages/zh-TW/common.ts
@@ -151,6 +151,8 @@ export default {
     lineHeight: `行距`,
     blockSpacing: `段間距`,
     primaryColor: `主題色`,
+    linkColor: `連結色`,
+    blockquoteBackground: `引用背景`,
     codeBlockTheme: `程式碼主題`,
     legendFormat: `圖注`,
     customPrimaryColor: `自訂色`,
@@ -225,6 +227,16 @@ export default {
       recommended: `推薦`,
       slightlyLoose: `稍鬆`,
       loose: `寬鬆`,
+    },
+    linkColor: {
+      wechatBlue: { label: `微信藍`, desc: `預設` },
+      primary: { label: `主題色`, desc: `跟隨主題色` },
+      body: { label: `正文色`, desc: `與正文一致` },
+    },
+    blockquoteBackground: {
+      theme: { label: `跟隨主題`, desc: `預設` },
+      none: { label: `無背景`, desc: `透明` },
+      primary: { label: `主題色`, desc: `主題色淺底` },
     },
     color: {
       classicBlue: { label: `經典藍`, desc: `穩重冷靜` },

--- a/apps/web/src/services/export/clipboard.ts
+++ b/apps/web/src/services/export/clipboard.ts
@@ -94,6 +94,8 @@ export async function processClipboardContent(primaryColor: string) {
       .replace(/--md-font-size:.+?;/g, ``)
       .replace(/--md-line-height:.+?;/g, ``)
       .replace(/--md-block-spacing:.+?;/g, ``)
+      .replace(/--md-link-color:.+?;/g, ``)
+      .replace(/--md-blockquote-background:.+?;/g, ``)
       .replace(
         /<span class="nodeLabel"([^>]*)><p[^>]*>(.*?)<\/p><\/span>/g,
         `<span class="nodeLabel"$1>$2</span>`,

--- a/apps/web/src/stores/theme.ts
+++ b/apps/web/src/stores/theme.ts
@@ -10,8 +10,8 @@ import { useCssEditorStore } from '@/stores/cssEditor'
  * Theme and style configuration.
  *
  * Each theme has its own settings (primaryColor, fontFamily, fontSize, lineHeight,
- * blockSpacing, codeBlockTheme, headingStyles, isShowLineNumber, isMacCodeBlock);
- * switching themes loads the matching config.
+ * blockSpacing, linkColor, blockquoteBackground, codeBlockTheme, headingStyles,
+ * isShowLineNumber, isMacCodeBlock); switching themes loads the matching config.
  */
 export const useThemeStore = defineStore(`theme`, () => {
   const theme = store.reactive<ThemeName>(addPrefix(`theme`), defaultStyleConfig.theme)
@@ -50,6 +50,16 @@ export const useThemeStore = defineStore(`theme`, () => {
   const blockSpacing = computed<string>({
     get: () => currentSettings.value.blockSpacing ?? defaultStyleConfig.blockSpacing,
     set: (v: string) => { setThemeField(`blockSpacing`, v) },
+  })
+
+  const linkColor = computed<string>({
+    get: () => currentSettings.value.linkColor ?? defaultStyleConfig.linkColor,
+    set: (v: string) => { setThemeField(`linkColor`, v) },
+  })
+
+  const blockquoteBackground = computed<string>({
+    get: () => currentSettings.value.blockquoteBackground ?? defaultStyleConfig.blockquoteBackground,
+    set: (v: string) => { setThemeField(`blockquoteBackground`, v) },
   })
 
   const codeBlockTheme = computed<string>({
@@ -162,6 +172,8 @@ export const useThemeStore = defineStore(`theme`, () => {
           fontSize: fontSize.value,
           lineHeight: lineHeight.value,
           blockSpacing: blockSpacing.value,
+          linkColor: linkColor.value,
+          blockquoteBackground: blockquoteBackground.value,
           isUseIndent: isUseIndent.value,
           isUseJustify: isUseJustify.value,
           headingStyles: headingStyles.value,
@@ -181,6 +193,8 @@ export const useThemeStore = defineStore(`theme`, () => {
     fontSizeNumber,
     lineHeight,
     blockSpacing,
+    linkColor,
+    blockquoteBackground,
     primaryColor,
     codeBlockTheme,
     legend,

--- a/packages/core/src/theme/cssVariables.test.ts
+++ b/packages/core/src/theme/cssVariables.test.ts
@@ -28,6 +28,68 @@ describe(`generateCSSVariables`, () => {
   })
 })
 
+describe(`link colour`, () => {
+  it(`emits the configured colour`, () => {
+    expect(generateCSSVariables({ ...baseConfig, linkColor: `inherit` }))
+      .toContain(`--md-link-color: inherit;`)
+  })
+
+  it(`defaults to the WeChat blue every theme used to hard-code`, () => {
+    expect(generateCSSVariables(baseConfig)).toContain(`--md-link-color: #576b95;`)
+  })
+
+  it(`resolves a var() reference down to the primary colour`, () => {
+    const variables = generateCSSVariables({ ...baseConfig, linkColor: `var(--md-primary-color)` })
+    const css = processCSS(`${variables}\n\na { color: var(--md-link-color); }`)
+
+    expect(css).toContain(`color: #0F4C81;`)
+    expect(css).not.toContain(`var(--md-link-color)`)
+  })
+})
+
+describe(`blockquote background`, () => {
+  const rule = `blockquote { background: var(--md-blockquote-background, var(--blockquote-background)); }`
+
+  it(`is left undeclared for the theme default`, () => {
+    expect(generateCSSVariables({ ...baseConfig, blockquoteBackground: `default` }))
+      .not
+      .toContain(`--md-blockquote-background`)
+  })
+
+  it(`falls through to the theme's own background when undeclared`, () => {
+    // The web shell and VSCode preview both define --blockquote-background per
+    // colour mode, so the fall-through has to survive processCSS untouched.
+    const css = processCSS(`${generateCSSVariables(baseConfig)}\n\n${rule}`)
+
+    expect(css).toContain(`background: var(--blockquote-background);`)
+  })
+
+  it(`overrides the theme background when set`, () => {
+    const variables = generateCSSVariables({ ...baseConfig, blockquoteBackground: `transparent` })
+    const css = processCSS(`${variables}\n\n${rule}`)
+
+    expect(css).toContain(`background: transparent;`)
+  })
+
+  it(`resolves a nested primary colour inside color-mix`, () => {
+    const variables = generateCSSVariables({
+      ...baseConfig,
+      blockquoteBackground: `color-mix(in srgb, var(--md-primary-color) 8%, transparent)`,
+    })
+    const css = processCSS(`${variables}\n\n${rule}`)
+
+    expect(css).toContain(`background: color-mix(in srgb, #0F4C81 8%, transparent);`)
+  })
+
+  it(`keeps the background-free themes background-free by default`, () => {
+    const css = processCSS(
+      `${generateCSSVariables(baseConfig)}\n\nblockquote { background: var(--md-blockquote-background, transparent); }`,
+    )
+
+    expect(css).toContain(`background: transparent;`)
+  })
+})
+
 describe(`block spacing resolution`, () => {
   // WeChat drops calc() and var(), so processCSS has to flatten both before juice
   // inlines the styles. These cases pin that the multiplier survives that pass.

--- a/packages/core/src/theme/cssVariables.ts
+++ b/packages/core/src/theme/cssVariables.ts
@@ -10,6 +10,10 @@ export interface CSSVariableConfig {
   lineHeight?: string
   /** Multiplier for the vertical block margins defined by the theme. */
   blockSpacing?: string
+  /** Link colour; accepts a colour or a var() reference such as var(--md-primary-color). */
+  linkColor?: string
+  /** Blockquote background; `default` leaves each theme's own background in place. */
+  blockquoteBackground?: string
   isUseIndent?: boolean
   isUseJustify?: boolean
   headingStyles?: HeadingStyles
@@ -18,8 +22,17 @@ export interface CSSVariableConfig {
 /** Kept in sync with defaultStyleConfig; optional so existing callers (VSCode preview, theme export) need no change. */
 const DEFAULT_LINE_HEIGHT = `1.75`
 const DEFAULT_BLOCK_SPACING = `1`
+const DEFAULT_LINK_COLOR = `#576b95`
+const THEME_BLOCKQUOTE_BACKGROUND = `default`
 
 export function generateCSSVariables(config: CSSVariableConfig): string {
+  // Left undeclared for `default` so the per-theme var() fallback wins: the
+  // default theme keeps its mode-aware grey while grace and simple stay
+  // background-free. Declaring it unconditionally would give them all a grey box.
+  const blockquoteBackground = config.blockquoteBackground && config.blockquoteBackground !== THEME_BLOCKQUOTE_BACKGROUND
+    ? `\n  --md-blockquote-background: ${config.blockquoteBackground};`
+    : ``
+
   return `
 :root {
   /* Theme config */
@@ -28,6 +41,7 @@ export function generateCSSVariables(config: CSSVariableConfig): string {
   --md-font-size: ${config.fontSize};
   --md-line-height: ${config.lineHeight || DEFAULT_LINE_HEIGHT};
   --md-block-spacing: ${config.blockSpacing || DEFAULT_BLOCK_SPACING};
+  --md-link-color: ${config.linkColor || DEFAULT_LINK_COLOR};${blockquoteBackground}
 }
 
 /* Paragraph indent & justify */

--- a/packages/mcp-server/src/config-options.ts
+++ b/packages/mcp-server/src/config-options.ts
@@ -69,6 +69,18 @@ export const blockSpacingOptions = [
   { label: `1.35×`, value: `1.35`, desc: `宽松` },
 ] as const
 
+export const linkColorOptions = [
+  { label: `微信蓝`, value: `#576b95`, desc: `默认` },
+  { label: `主题色`, value: `var(--md-primary-color)`, desc: `跟随主题色` },
+  { label: `正文色`, value: `inherit`, desc: `与正文一致` },
+] as const
+
+export const blockquoteBackgroundOptions = [
+  { label: `跟随主题`, value: `default`, desc: `默认` },
+  { label: `无背景`, value: `transparent`, desc: `透明` },
+  { label: `主题色`, value: `color-mix(in srgb, var(--md-primary-color) 8%, transparent)`, desc: `主题色浅底` },
+] as const
+
 export const legendOptions = [
   { label: `title 优先`, value: `title-alt`, desc: `` },
   { label: `alt 优先`, value: `alt-title`, desc: `` },
@@ -130,6 +142,8 @@ export const defaultRenderOptions = {
   fontSize: fontSizeOptions[2].value,
   lineHeight: lineHeightOptions[2].value,
   blockSpacing: blockSpacingOptions[2].value,
+  linkColor: linkColorOptions[0].value,
+  blockquoteBackground: blockquoteBackgroundOptions[0].value,
   legend: legendOptions[3].value as LegendValue,
   codeBlockTheme: codeBlockThemeOptions[0].value,
   isMacCodeBlock: false,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,6 +6,7 @@ import { McpServer } from '@modelcontextprotocol/server'
 import { StdioServerTransport } from '@modelcontextprotocol/server/stdio'
 import { z } from 'zod'
 import {
+  blockquoteBackgroundOptions,
   blockSpacingOptions,
   codeBlockThemeOptions,
   colorOptions,
@@ -14,6 +15,7 @@ import {
   headingStyleOptions,
   legendOptions,
   lineHeightOptions,
+  linkColorOptions,
   themeOptions,
 } from './config-options'
 
@@ -58,6 +60,17 @@ export const renderMarkdownInputSchema = z.object({
     .describe(
       `Multiplier for the theme's vertical block margins (e.g. 1.15 loosens by 15%). `
       + `Use list_spacing_options for presets.`,
+    ),
+  linkColor: z
+    .string()
+    .optional()
+    .describe(`Link colour. Use list_color_options for presets, including var(--md-primary-color).`),
+  blockquoteBackground: z
+    .string()
+    .optional()
+    .describe(
+      `Blockquote background. Use list_color_options for presets; `
+      + `"default" keeps each theme's own background.`,
     ),
   legend: z
     .enum([`title-alt`, `alt-title`, `title`, `alt`, `filename`, `none`])
@@ -260,6 +273,25 @@ server.registerTool(
 )
 
 server.registerTool(
+  `list_color_options`,
+  {
+    description: `List preset link colour and blockquote background options for render_markdown.`,
+  },
+  () => jsonText({
+    linkColors: linkColorOptions.map(o => ({
+      label: o.label,
+      value: o.value,
+      description: o.desc,
+    })),
+    blockquoteBackgrounds: blockquoteBackgroundOptions.map(o => ({
+      label: o.label,
+      value: o.value,
+      description: o.desc,
+    })),
+  }),
+)
+
+server.registerTool(
   `list_code_block_themes`,
   {
     description: `List highlight.js code block theme URLs for render_markdown.`,
@@ -381,6 +413,8 @@ server.registerTool(
       { name: `fontSize`, type: `string (px)`, default: `16px`, description: `Base font size. See list_font_sizes.` },
       { name: `lineHeight`, type: `string (unitless)`, default: `1.75`, description: `Body line height. See list_spacing_options.` },
       { name: `blockSpacing`, type: `string (unitless)`, default: `1`, description: `Multiplier for the theme's vertical block margins. See list_spacing_options.` },
+      { name: `linkColor`, type: `string (colour)`, default: `#576b95`, description: `Link colour. See list_color_options.` },
+      { name: `blockquoteBackground`, type: `string (colour)`, default: `default`, description: `Blockquote background; "default" keeps the theme's own. See list_color_options.` },
       { name: `legend`, type: `'title-alt' | 'alt-title' | 'title' | 'alt' | 'filename' | 'none'`, default: `alt`, description: `Image caption format.` },
       { name: `isMacCodeBlock`, type: `boolean`, default: false, description: `macOS-style code block title bar.` },
       { name: `isShowLineNumber`, type: `boolean`, default: false, description: `Line numbers in code blocks.` },

--- a/packages/mcp-server/src/render-article.ts
+++ b/packages/mcp-server/src/render-article.ts
@@ -22,6 +22,8 @@ export interface RenderMarkdownInput {
   fontSize?: string
   lineHeight?: string
   blockSpacing?: string
+  linkColor?: string
+  blockquoteBackground?: string
   legend?: LegendValue
   isMacCodeBlock?: boolean
   isShowLineNumber?: boolean
@@ -110,6 +112,8 @@ export async function buildRenderedOutput(input: RenderMarkdownInput) {
   const fontSize = input.fontSize ?? defaultRenderOptions.fontSize
   const lineHeight = input.lineHeight ?? defaultRenderOptions.lineHeight
   const blockSpacing = input.blockSpacing ?? defaultRenderOptions.blockSpacing
+  const linkColor = input.linkColor ?? defaultRenderOptions.linkColor
+  const blockquoteBackground = input.blockquoteBackground ?? defaultRenderOptions.blockquoteBackground
   const legend = input.legend ?? defaultRenderOptions.legend
   const codeBlockTheme = input.codeBlockTheme ?? defaultRenderOptions.codeBlockTheme
   const headingStyles = normalizeHeadingStyles(input.headingStyles)
@@ -133,6 +137,8 @@ export async function buildRenderedOutput(input: RenderMarkdownInput) {
     fontSize,
     lineHeight,
     blockSpacing,
+    linkColor,
+    blockquoteBackground,
     isUseIndent: input.isUseIndent ?? defaultRenderOptions.isUseIndent,
     isUseJustify: input.isUseJustify ?? defaultRenderOptions.isUseJustify,
     headingStyles,

--- a/packages/shared/src/configs/style.ts
+++ b/packages/shared/src/configs/style.ts
@@ -109,6 +109,51 @@ export const blockSpacingOptions: IConfigOption[] = [
   },
 ]
 
+/**
+ * Every built-in theme hard-coded the same WeChat blue for links, so a single
+ * always-emitted variable is enough here.
+ */
+export const linkColorOptions: IConfigOption[] = [
+  {
+    label: `微信蓝`,
+    value: `#576b95`,
+    desc: `默认`,
+  },
+  {
+    label: `主题色`,
+    value: `var(--md-primary-color)`,
+    desc: `跟随主题色`,
+  },
+  {
+    label: `正文色`,
+    value: `inherit`,
+    desc: `与正文一致`,
+  },
+]
+
+/**
+ * `default` keeps whatever background each theme already defines: the default
+ * theme uses a mode-aware grey, while grace and simple are deliberately
+ * background-free. Any other value overrides all of them.
+ */
+export const blockquoteBackgroundOptions: IConfigOption[] = [
+  {
+    label: `跟随主题`,
+    value: `default`,
+    desc: `默认`,
+  },
+  {
+    label: `无背景`,
+    value: `transparent`,
+    desc: `透明`,
+  },
+  {
+    label: `主题色`,
+    value: `color-mix(in srgb, var(--md-primary-color) 8%, transparent)`,
+    desc: `主题色浅底`,
+  },
+]
+
 export const colorOptions: IConfigOption[] = [
   {
     label: `经典蓝`,
@@ -333,6 +378,8 @@ export const defaultStyleConfig = {
   lineHeight: lineHeightOptions[2].value,
   blockSpacing: blockSpacingOptions[2].value,
   primaryColor: colorOptions[0].value,
+  linkColor: linkColorOptions[0].value,
+  blockquoteBackground: blockquoteBackgroundOptions[0].value,
   codeBlockTheme: codeBlockThemeOptions[23].value,
   legend: legendOptions[3].value,
   headingStyles: defaultHeadingStyles as HeadingStyles,
@@ -344,6 +391,8 @@ export interface PerThemeSettings {
   fontSize: string
   lineHeight: string
   blockSpacing: string
+  linkColor: string
+  blockquoteBackground: string
   codeBlockTheme: string
   headingStyles: HeadingStyles
   isShowLineNumber: boolean
@@ -357,6 +406,8 @@ export function defaultPerThemeSettings(): PerThemeSettings {
     fontSize: defaultStyleConfig.fontSize,
     lineHeight: defaultStyleConfig.lineHeight,
     blockSpacing: defaultStyleConfig.blockSpacing,
+    linkColor: defaultStyleConfig.linkColor,
+    blockquoteBackground: defaultStyleConfig.blockquoteBackground,
     codeBlockTheme: defaultStyleConfig.codeBlockTheme,
     headingStyles: { ...defaultStyleConfig.headingStyles },
     isShowLineNumber: defaultStyleConfig.isShowLineNumber,

--- a/packages/shared/src/configs/theme-css/default.css
+++ b/packages/shared/src/configs/theme-css/default.css
@@ -78,7 +78,7 @@ blockquote {
   border-left: 4px solid var(--md-primary-color);
   border-radius: 6px;
   color: hsl(var(--foreground));
-  background: var(--blockquote-background);
+  background: var(--md-blockquote-background, var(--blockquote-background));
   margin-bottom: calc(1em * var(--md-block-spacing));
 }
 
@@ -482,7 +482,7 @@ em {
 
 /* ==================== Links ==================== */
 a {
-  color: #576b95;
+  color: var(--md-link-color);
   text-decoration: none;
 }
 

--- a/packages/shared/src/configs/theme-css/grace.css
+++ b/packages/shared/src/configs/theme-css/grace.css
@@ -43,6 +43,7 @@ blockquote {
   border-left: 4px solid var(--md-primary-color);
   border-radius: 6px;
   color: rgba(0, 0, 0, 0.6);
+  background: var(--md-blockquote-background, transparent);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   margin-bottom: calc(1em * var(--md-block-spacing));
 }
@@ -130,6 +131,6 @@ em {
 
 /* Links */
 a {
-  color: #576b95;
+  color: var(--md-link-color);
   text-decoration: none;
 }

--- a/packages/shared/src/configs/theme-css/simple.css
+++ b/packages/shared/src/configs/theme-css/simple.css
@@ -48,6 +48,7 @@ blockquote {
   font-style: italic;
   padding: 1em 1em 1em 2em;
   color: rgba(0, 0, 0, 0.6);
+  background: var(--md-blockquote-background, transparent);
   border-bottom: 0.2px solid rgba(0, 0, 0, 0.04);
   border-top: 0.2px solid rgba(0, 0, 0, 0.04);
   border-right: 0.2px solid rgba(0, 0, 0, 0.04);
@@ -124,6 +125,6 @@ em {
 
 /* Links */
 a {
-  color: #576b95;
+  color: var(--md-link-color);
   text-decoration: none;
 }


### PR DESCRIPTION
> Stacked on #1938. Review that one first; this branch contains its commit.

## Summary

Two more hard-coded values in the theme CSS, both of which came up as things people override with custom CSS.

### Link colour

`a { color: #576b95 }` was copy-pasted identically into `default.css`, `grace.css` and `simple.css`. Since all three agreed, one always-emitted `--md-link-color` replaces all three, defaulting to the same WeChat blue so nothing changes visually.

Presets are deliberately not another 11-swatch grid — for links there are really only three useful answers: WeChat blue, the theme colour, or the body text colour. The theme-colour option is stored as the literal `var(--md-primary-color)`, which `processCSS` resolves through one extra iteration, so the link tracks the primary colour instead of freezing whatever it happened to be when picked.

### Blockquote background

This one could not use the same shape. Only `default.css` has a background (`var(--blockquote-background)`, a mode-aware grey injected separately by the web shell, the VSCode preview, the share page and the PNG capture path). `grace.css` uses a box shadow and `simple.css` uses thin borders — both are deliberately background-free.

So an unconditionally declared variable would have handed grace and simple a grey box they never had. Instead the variable is only declared when the user picks something other than `default`, and each theme keeps its own value as the `var()` fallback:

```css
/* default.css */
background: var(--md-blockquote-background, var(--blockquote-background));

/* grace.css, simple.css */
background: var(--md-blockquote-background, transparent);
```

Undeclared, every theme renders exactly as before, including the light/dark switch on the default theme. Declared, it overrides all three consistently.

This leans on `processCSS` handling a `var()` whose fallback is itself a `var()`, and on it leaving the unresolvable shell token alone rather than dropping the declaration. Neither was covered by tests, so both are pinned now, along with the nested resolution of `color-mix(in srgb, var(--md-primary-color) 8%, transparent)`.

### Scope note

No custom colour picker for either option — three presets each, with custom CSS remaining the escape hatch for arbitrary values. Easy to add later if it is wanted; I did not want to grow the style panel by two colour pickers in the same PR that introduces the plumbing.

`StyleOptionMenu`'s "show desc as a hint" condition was becoming a chain of `||` comparisons, so it is now a small keyed list.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

Eight new tests in `cssVariables.test.ts`: link colour default and override, the `var(--md-primary-color)` indirection resolving to a hex, the blockquote variable being omitted for `default`, the fall-through to both per-theme fallbacks, an explicit override, and nested `color-mix` resolution.

```bash
pnpm --filter @md/core --filter @md/shared exec vitest run   # 140 passed
pnpm run type-check
pnpm web build
npx eslint --fix apps/web/src packages/core/src packages/shared/src packages/mcp-server/src
```

Manual check worth doing on review: with quote background on `跟随主题`, switch between light and dark mode on the default theme and confirm the grey still flips; then switch to grace and simple and confirm neither gained a background. Set the link colour to `主题色`, change the primary colour, and confirm links follow. Finally copy to WeChat and confirm both survive the paste.

## Pre-flight Checklist

- [x] Code follows the project style and passes `pnpm run lint`
- [x] Type check passes
- [x] Unit tests added and passing
- [x] User-facing copy added to all four locales (zh-CN, zh-TW, en-US, ja-JP)
- [x] Existing themes render identically at the default settings
