### PR TITLE
feat(export): add segmented long-image PNG export

### DIFF
--- a/apps/web/src/components/editor/EditorContextMenu.vue
+++ b/apps/web/src/components/editor/EditorContextMenu.vue
@@ -35,6 +35,7 @@ import { useEditorDocumentActions } from '@/composables/useEditorDocumentActions
 import { useEditorFormat } from '@/composables/useEditorFormat'
 import { copyPlain, readPlainFromClipboard } from '@/lib/browser/clipboard'
 import { normalizeFormulaInput } from '@/lib/markdown/formula'
+import { PNG_SEGMENT_HEIGHTS } from '@/services/export'
 import { useConfirmStore } from '@/stores/confirm'
 import { useCssEditorStore } from '@/stores/cssEditor'
 import { useEditorStore } from '@/stores/editor'
@@ -159,6 +160,10 @@ function exportEditorContent2MD() {
 
 function downloadAsCardImage() {
   exportStore.downloadAsCardImage()
+}
+
+function downloadAsSegmentedImages(maxSegmentHeight: number) {
+  exportStore.downloadAsSegmentedImages(maxSegmentHeight)
 }
 </script>
 
@@ -316,6 +321,21 @@ function downloadAsCardImage() {
             <FileImage class="mr-2 h-4 w-4" />
             {{ t('contextMenu.exportPng') }}
           </ContextMenuItem>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <FileImage class="mr-2 h-4 w-4" />
+              {{ t('contextMenu.exportPngSegments') }}
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent class="w-48">
+              <ContextMenuItem
+                v-for="height in PNG_SEGMENT_HEIGHTS"
+                :key="height"
+                @click="downloadAsSegmentedImages(height)"
+              >
+                {{ t('menu.exportPngSegmentHeight', { height }) }}
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
         </ContextMenuSubContent>
       </ContextMenuSub>
 

--- a/apps/web/src/components/editor/editor-header/FileDropdown.vue
+++ b/apps/web/src/components/editor/editor-header/FileDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Cloud, Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Settings, Share2, Upload } from '@lucide/vue'
+import { Cloud, Download, FileCode, FileCog, FileText, FolderKanban, FolderOpen, Package, Rows3, Settings, Share2, Upload } from '@lucide/vue'
+import { PNG_SEGMENT_HEIGHTS } from '@/services/export'
 import { isShareUiEnabled } from '@/services/share/client'
 import { isSyncUiEnabled } from '@/services/sync/client'
 import { useEditorStore } from '@/stores/editor'
@@ -50,6 +51,10 @@ function exportEditorContent2MD() {
 
 function downloadAsCardImage() {
   exportStore.downloadAsCardImage()
+}
+
+function downloadAsSegmentedImages(maxSegmentHeight: number) {
+  exportStore.downloadAsSegmentedImages(maxSegmentHeight)
 }
 
 function exportEditorContent2PDF() {
@@ -111,6 +116,21 @@ function exportEditorContent2PDF() {
             <Download class="mr-2 size-4" />
             {{ t('menu.exportPng') }}
           </MenubarItem>
+          <MenubarSub>
+            <MenubarSubTrigger>
+              <Rows3 class="mr-2 size-4" />
+              {{ t('menu.exportPngSegments') }}
+            </MenubarSubTrigger>
+            <MenubarSubContent class="min-w-48">
+              <MenubarItem
+                v-for="height in PNG_SEGMENT_HEIGHTS"
+                :key="height"
+                @click="downloadAsSegmentedImages(height)"
+              >
+                {{ t('menu.exportPngSegmentHeight', { height }) }}
+              </MenubarItem>
+            </MenubarSubContent>
+          </MenubarSub>
         </MenubarSubContent>
       </MenubarSub>
 
@@ -205,6 +225,21 @@ function exportEditorContent2PDF() {
             <Download class="mr-2 size-4" />
             {{ t('menu.exportPng') }}
           </MenubarItem>
+          <MenubarSub>
+            <MenubarSubTrigger>
+              <Rows3 class="mr-2 size-4" />
+              {{ t('menu.exportPngSegments') }}
+            </MenubarSubTrigger>
+            <MenubarSubContent class="min-w-48">
+              <MenubarItem
+                v-for="height in PNG_SEGMENT_HEIGHTS"
+                :key="height"
+                @click="downloadAsSegmentedImages(height)"
+              >
+                {{ t('menu.exportPngSegmentHeight', { height }) }}
+              </MenubarItem>
+            </MenubarSubContent>
+          </MenubarSub>
         </MenubarSubContent>
       </MenubarSub>
 

--- a/apps/web/src/i18n/messages/en-US/chrome.ts
+++ b/apps/web/src/i18n/messages/en-US/chrome.ts
@@ -50,6 +50,7 @@ export default {
     exportHtml: `Export .html`,
     exportPdf: `Export .pdf`,
     exportPng: `Export .png`,
+    exportPngSegments: `Export split .png`,
   },
   search: {
     toggleReplace: `Toggle replace`,

--- a/apps/web/src/i18n/messages/en-US/common.ts
+++ b/apps/web/src/i18n/messages/en-US/common.ts
@@ -105,6 +105,8 @@ export default {
     exportHtmlNoStyle: `HTML (plain)`,
     exportPdf: `PDF`,
     exportPng: `PNG`,
+    exportPngSegments: `PNG (split)`,
+    exportPngSegmentHeight: `~{height}px per image`,
     templateManage: `Templates`,
     marketplace: `Community Themes`,
     contentManage: `Content`,

--- a/apps/web/src/i18n/messages/en-US/store.ts
+++ b/apps/web/src/i18n/messages/en-US/store.ts
@@ -78,6 +78,13 @@ export default {
       pageFooter: `Page " counter(page) " of " counter(pages) "`,
       pageFooterN: `" counter(page) "`,
     },
+    png: {
+      segmentsStart: `Preparing long images…`,
+      segmentsProgress: `Exporting image {done} of {total}…`,
+      segmentsDone: `Exported {count} images`,
+      segmentsEmpty: `Nothing to export`,
+      segmentsFailed: `Long image export failed: {message}`,
+    },
     relativeTime: {
       justNow: `Just now`,
       secondsAgo: `{seconds}s ago`,

--- a/apps/web/src/i18n/messages/ja-JP/chrome.ts
+++ b/apps/web/src/i18n/messages/ja-JP/chrome.ts
@@ -50,6 +50,7 @@ export default {
     exportHtml: `.html をエクスポート`,
     exportPdf: `.pdf をエクスポート`,
     exportPng: `.png をエクスポート`,
+    exportPngSegments: `分割 .png をエクスポート`,
   },
   search: {
     toggleReplace: `置換の切替`,

--- a/apps/web/src/i18n/messages/ja-JP/common.ts
+++ b/apps/web/src/i18n/messages/ja-JP/common.ts
@@ -105,6 +105,8 @@ export default {
     exportHtmlNoStyle: `HTML（プレーン）`,
     exportPdf: `PDF`,
     exportPng: `PNG`,
+    exportPngSegments: `PNG（分割）`,
+    exportPngSegmentHeight: `1 枚あたり約 {height}px`,
     templateManage: `テンプレート`,
     marketplace: `コミュニティテーマ`,
     contentManage: `コンテンツ`,

--- a/apps/web/src/i18n/messages/ja-JP/store.ts
+++ b/apps/web/src/i18n/messages/ja-JP/store.ts
@@ -78,6 +78,13 @@ export default {
       pageFooter: `" counter(page) " / " counter(pages) " ページ`,
       pageFooterN: `" counter(page) "`,
     },
+    png: {
+      segmentsStart: `長い画像を準備中…`,
+      segmentsProgress: `{total} 枚中 {done} 枚目を書き出し中…`,
+      segmentsDone: `{count} 枚の画像を書き出しました`,
+      segmentsEmpty: `書き出す内容がありません`,
+      segmentsFailed: `長い画像の書き出しに失敗しました: {message}`,
+    },
     relativeTime: {
       justNow: `たった今`,
       secondsAgo: `{seconds}秒前`,

--- a/apps/web/src/i18n/messages/zh-CN/chrome.ts
+++ b/apps/web/src/i18n/messages/zh-CN/chrome.ts
@@ -50,6 +50,7 @@ export default {
     exportHtml: `导出 .html`,
     exportPdf: `导出 .pdf`,
     exportPng: `导出 .png`,
+    exportPngSegments: `导出分段长图`,
   },
   search: {
     toggleReplace: `切换替换`,

--- a/apps/web/src/i18n/messages/zh-CN/common.ts
+++ b/apps/web/src/i18n/messages/zh-CN/common.ts
@@ -105,6 +105,8 @@ export default {
     exportHtmlNoStyle: `HTML（纯）`,
     exportPdf: `PDF 文档`,
     exportPng: `PNG 图片`,
+    exportPngSegments: `PNG 分段长图`,
+    exportPngSegmentHeight: `每段约 {height}px`,
     templateManage: `模板管理`,
     marketplace: `社区主题`,
     contentManage: `内容管理`,

--- a/apps/web/src/i18n/messages/zh-CN/store.ts
+++ b/apps/web/src/i18n/messages/zh-CN/store.ts
@@ -78,6 +78,13 @@ export default {
       pageFooter: `第 " counter(page) " 页，共 " counter(pages) " 页`,
       pageFooterN: `" counter(page) "`,
     },
+    png: {
+      segmentsStart: `正在准备长图…`,
+      segmentsProgress: `正在导出第 {done} / {total} 张…`,
+      segmentsDone: `已导出 {count} 张长图`,
+      segmentsEmpty: `没有可导出的内容`,
+      segmentsFailed: `长图导出失败：{message}`,
+    },
     relativeTime: {
       justNow: `刚刚`,
       secondsAgo: `{seconds} 秒前`,

--- a/apps/web/src/i18n/messages/zh-TW/chrome.ts
+++ b/apps/web/src/i18n/messages/zh-TW/chrome.ts
@@ -50,6 +50,7 @@ export default {
     exportHtml: `匯出 .html`,
     exportPdf: `匯出 .pdf`,
     exportPng: `匯出 .png`,
+    exportPngSegments: `匯出分段長圖`,
   },
   search: {
     toggleReplace: `切換替換`,

--- a/apps/web/src/i18n/messages/zh-TW/common.ts
+++ b/apps/web/src/i18n/messages/zh-TW/common.ts
@@ -105,6 +105,8 @@ export default {
     exportHtmlNoStyle: `HTML（純）`,
     exportPdf: `PDF 文件`,
     exportPng: `PNG 圖片`,
+    exportPngSegments: `PNG 分段長圖`,
+    exportPngSegmentHeight: `每段約 {height}px`,
     templateManage: `範本管理`,
     marketplace: `社群主題`,
     contentManage: `內容管理`,

--- a/apps/web/src/i18n/messages/zh-TW/store.ts
+++ b/apps/web/src/i18n/messages/zh-TW/store.ts
@@ -78,6 +78,13 @@ export default {
       pageFooter: `第 " counter(page) " 頁，共 " counter(pages) " 頁`,
       pageFooterN: `" counter(page) "`,
     },
+    png: {
+      segmentsStart: `正在準備長圖…`,
+      segmentsProgress: `正在匯出第 {done} / {total} 張…`,
+      segmentsDone: `已匯出 {count} 張長圖`,
+      segmentsEmpty: `沒有可匯出的內容`,
+      segmentsFailed: `長圖匯出失敗：{message}`,
+    },
     relativeTime: {
       justNow: `剛剛`,
       secondsAgo: `{seconds} 秒前`,

--- a/apps/web/src/services/export/index.ts
+++ b/apps/web/src/services/export/index.ts
@@ -15,4 +15,9 @@ export {
   resolvePdfSiteFooterUrl,
 } from './pdf'
 export { exportPNG } from './png'
+export {
+  DEFAULT_PNG_SEGMENT_HEIGHT,
+  exportPNGSegments,
+  PNG_SEGMENT_HEIGHTS,
+} from './png-segments'
 export { getExportStyles, getShareExportStyles } from './share-styles'

--- a/apps/web/src/services/export/png-capture.ts
+++ b/apps/web/src/services/export/png-capture.ts
@@ -1,0 +1,79 @@
+import { stripUnresolvedAsyncPlaceholders } from '@/lib/preview/preview-ready'
+import {
+  applyExportLayout,
+  getPngCaptureBackgroundColor,
+  getPngCaptureStyles,
+  PNG_CAPTURE_ROOT_CLASS,
+} from './apply-export-layout'
+
+export type PreviewDevice = `desktop` | `mobile`
+
+export interface OffScreenPreview {
+  /** The `.preview` shell handed to html-to-image; includes the export padding. */
+  el: HTMLElement
+  /** The cloned `#output` root. Its direct children are the atomic content blocks. */
+  content: HTMLElement
+  cleanup: () => void
+}
+
+/**
+ * Clone the live preview into a fixed-width off-screen host.
+ *
+ * Capturing a clone rather than the live preview keeps the on-screen editor
+ * untouched while the export rewrites scroll containers and drops unresolved
+ * async placeholders.
+ */
+export async function createOffScreenPreview(
+  previewDevice: PreviewDevice,
+): Promise<OffScreenPreview | null> {
+  const output = document.getElementById(`output`)
+  if (!output)
+    return null
+
+  const isDarkApp = document.documentElement.classList.contains(`dark`)
+  const useNightPreview = isDarkApp
+    && document.getElementById(`output-wrapper`)?.classList.contains(`output_night`)
+  const width = previewDevice === `mobile` ? `375px` : `750px`
+
+  const host = document.createElement(`div`)
+  host.setAttribute(`data-png-export-host`, ``)
+  host.style.cssText = `position:fixed;left:-99999px;top:0;z-index:-1;visibility:visible;pointer-events:none;`
+  host.innerHTML = await getPngCaptureStyles()
+
+  const wrapper = document.createElement(`div`)
+  wrapper.className = useNightPreview ? `output_night` : ``
+  wrapper.style.width = width
+
+  const preview = document.createElement(`div`)
+  preview.className = `preview border-x shadow-xl mx-auto`
+  preview.style.width = width
+  preview.style.margin = `0`
+
+  const content = output.cloneNode(true) as HTMLElement
+  content.removeAttribute(`id`)
+  content.classList.add(PNG_CAPTURE_ROOT_CLASS)
+  content.style.width = `100%`
+  content.querySelectorAll(`.diagram-download-bar`).forEach(el => el.remove())
+  stripUnresolvedAsyncPlaceholders(content)
+  applyExportLayout(content)
+
+  preview.appendChild(content)
+  wrapper.appendChild(preview)
+  host.appendChild(wrapper)
+  document.body.appendChild(host)
+
+  return {
+    el: preview,
+    content,
+    cleanup: () => host.remove(),
+  }
+}
+
+export function getPngCaptureOptions() {
+  return {
+    backgroundColor: getPngCaptureBackgroundColor(),
+    skipFonts: true,
+    pixelRatio: Math.max(window.devicePixelRatio || 1, 2),
+    style: { margin: `0` },
+  }
+}

--- a/apps/web/src/services/export/png-segments.test.ts
+++ b/apps/web/src/services/export/png-segments.test.ts
@@ -1,0 +1,56 @@
+import type { BlockBounds } from './png-segments'
+import { describe, expect, it } from 'vitest'
+import { planSegments } from './png-segments'
+
+/** Build bounds for consecutive blocks of the given heights, separated by `gap`. */
+function stack(heights: number[], gap = 0): BlockBounds[] {
+  let top = 0
+  return heights.map((height) => {
+    const bounds = { top, bottom: top + height }
+    top = bounds.bottom + gap
+    return bounds
+  })
+}
+
+describe(`planSegments`, () => {
+  it(`returns nothing for an empty document`, () => {
+    expect(planSegments([], 1000)).toEqual([])
+  })
+
+  it(`keeps everything in one segment when it fits`, () => {
+    expect(planSegments(stack([100, 200, 300]), 1000)).toEqual([[0, 1, 2]])
+  })
+
+  it(`splits on a block boundary once the ceiling is passed`, () => {
+    expect(planSegments(stack([400, 400, 400, 400]), 1000)).toEqual([[0, 1], [2, 3]])
+  })
+
+  it(`measures from the segment top so earlier segments do not shrink later ones`, () => {
+    // Without re-basing on each segment's own top, the second segment would be
+    // measured from the document top and get split far too eagerly.
+    expect(planSegments(stack([600, 600, 600, 600]), 1000)).toEqual([[0], [1], [2], [3]])
+  })
+
+  it(`counts the gaps between blocks toward the segment height`, () => {
+    const noGap = planSegments(stack([300, 300, 300]), 1000)
+    const withGap = planSegments(stack([300, 300, 300], 100), 1000)
+
+    expect(noGap).toEqual([[0, 1, 2]])
+    expect(withGap).toEqual([[0, 1], [2]])
+  })
+
+  it(`never splits a block that is taller than the ceiling`, () => {
+    expect(planSegments(stack([5000]), 1000)).toEqual([[0]])
+  })
+
+  it(`gives an oversized block its own segment without swallowing neighbours`, () => {
+    expect(planSegments(stack([200, 5000, 200]), 1000)).toEqual([[0], [1], [2]])
+  })
+
+  it(`covers every block exactly once and preserves order`, () => {
+    const bounds = stack([120, 480, 90, 2200, 300, 640, 150], 24)
+    const segments = planSegments(bounds, 1000)
+
+    expect(segments.flat()).toEqual(bounds.map((_, index) => index))
+  })
+})

--- a/apps/web/src/services/export/png-segments.ts
+++ b/apps/web/src/services/export/png-segments.ts
@@ -1,0 +1,202 @@
+import type { PreviewDevice } from './png-capture'
+import { sanitizeTitle } from '@md/shared/utils/basicHelpers'
+import { downloadFile } from '@md/shared/utils/fileHelpers'
+import { delay } from '@/lib/delay'
+import { waitForPreviewReady } from '@/lib/preview/preview-ready'
+import { createOffScreenPreview, getPngCaptureOptions } from './png-capture'
+
+/** Presets offered in the export menu, in CSS pixels. */
+export const PNG_SEGMENT_HEIGHTS = [2000, 4000, 6000, 8000] as const
+
+export const DEFAULT_PNG_SEGMENT_HEIGHT = 4000
+
+export interface BlockBounds {
+  top: number
+  bottom: number
+}
+
+export interface ExportPNGSegmentsOptions {
+  previewDevice: PreviewDevice
+  /** Soft ceiling in CSS pixels; a single block taller than this is not split. */
+  maxSegmentHeight: number
+  onProgress?: (done: number, total: number) => void
+}
+
+/**
+ * Group block indices into segments that stay under `maxSegmentHeight`.
+ *
+ * Bounds are absolute viewport offsets, so a segment's height is measured from
+ * the first block's top to the last block's bottom. That accounts for the
+ * margins between blocks, which summing `offsetHeight` would miss.
+ *
+ * Kept free of DOM access so it can be tested without a layout engine.
+ */
+export function planSegments(bounds: BlockBounds[], maxSegmentHeight: number): number[][] {
+  if (bounds.length === 0)
+    return []
+
+  const segments: number[][] = []
+  let current: number[] = []
+  let segmentTop = bounds[0].top
+
+  for (let i = 0; i < bounds.length; i++) {
+    const wouldOverflow = bounds[i].bottom - segmentTop > maxSegmentHeight
+
+    // A block taller than the ceiling on its own still gets a whole segment:
+    // splitting it is exactly what this export exists to avoid.
+    if (wouldOverflow && current.length > 0) {
+      segments.push(current)
+      current = []
+      segmentTop = bounds[i].top
+    }
+
+    current.push(i)
+  }
+
+  if (current.length > 0)
+    segments.push(current)
+
+  return segments
+}
+
+function measureBlocks(blocks: HTMLElement[]): BlockBounds[] {
+  return blocks.map((block) => {
+    const rect = block.getBoundingClientRect()
+    return { top: rect.top, bottom: rect.bottom }
+  })
+}
+
+/**
+ * Descend past wrapper elements to the level whose children are the article's
+ * blocks.
+ *
+ * The renderer wraps the whole document in a single `<section>`, so the clone's
+ * own children are one wrapper rather than the headings and paragraphs we want
+ * to split on.
+ */
+function resolveBlockContainer(root: HTMLElement): HTMLElement {
+  let container = root
+  while (container.children.length === 1) {
+    const child = container.firstElementChild as HTMLElement
+    if (child.tagName !== `SECTION` && child.tagName !== `DIV`)
+      break
+    container = child
+  }
+  return container
+}
+
+/**
+ * Blocks that can be hidden per segment, in document order.
+ *
+ * `<style>` tags and other non-rendered children are left out: they carry the
+ * theme CSS for every segment and must never be touched.
+ */
+function collectBlocks(container: HTMLElement): HTMLElement[] {
+  return (Array.from(container.children) as HTMLElement[]).filter((child) => {
+    const rect = child.getBoundingClientRect()
+    return rect.width > 0 || rect.height > 0
+  })
+}
+
+async function downloadSegmentsAsZip(segments: Blob[], baseName: string) {
+  const { zip } = await import(`fflate`)
+
+  const files: Record<string, Uint8Array> = {}
+  const pad = String(segments.length).length
+  for (let i = 0; i < segments.length; i++) {
+    const index = String(i + 1).padStart(pad, `0`)
+    files[`${baseName}-${index}.png`] = new Uint8Array(await segments[i].arrayBuffer())
+  }
+
+  const archive = await new Promise<Uint8Array<ArrayBuffer>>((resolve, reject) =>
+    zip(files, (err, out) => (err ? reject(err) : resolve(out as Uint8Array<ArrayBuffer>))))
+
+  const url = URL.createObjectURL(new Blob([archive], { type: `application/zip` }))
+  try {
+    downloadFile(url, `${baseName}.zip`, `application/zip`)
+  }
+  finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+function downloadSingleSegment(segment: Blob, baseName: string) {
+  const url = URL.createObjectURL(segment)
+  try {
+    downloadFile(url, `${baseName}.png`, `image/png`)
+  }
+  finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+/**
+ * Export the preview as several PNGs split on block boundaries.
+ *
+ * Each segment is captured separately rather than slicing one tall canvas,
+ * because a full-length capture is what hits the browser's canvas size limit on
+ * long articles — the very case this export is for.
+ *
+ * @returns the number of images produced, or 0 if there was nothing to export.
+ */
+export async function exportPNGSegments(
+  title: string = `untitled`,
+  options: ExportPNGSegmentsOptions,
+): Promise<number> {
+  await waitForPreviewReady()
+
+  const offScreen = await createOffScreenPreview(options.previewDevice)
+  if (!offScreen)
+    return 0
+
+  try {
+    await delay(100)
+
+    const blocks = collectBlocks(resolveBlockContainer(offScreen.content))
+    if (blocks.length === 0)
+      return 0
+
+    const segments = planSegments(measureBlocks(blocks), options.maxSegmentHeight)
+    const captureOptions = getPngCaptureOptions()
+    const { toBlob } = await import(`html-to-image`)
+
+    // Inline display values come from the renderer (code blocks use flex), so
+    // the originals are restored rather than cleared.
+    const originalDisplay = blocks.map(block => block.style.display)
+    const images: Blob[] = []
+
+    try {
+      for (let i = 0; i < segments.length; i++) {
+        const visible = new Set(segments[i])
+        blocks.forEach((block, index) => {
+          block.style.display = visible.has(index) ? originalDisplay[index] : `none`
+        })
+
+        const blob = await toBlob(offScreen.el, captureOptions)
+        if (blob)
+          images.push(blob)
+
+        options.onProgress?.(i + 1, segments.length)
+      }
+    }
+    finally {
+      blocks.forEach((block, index) => {
+        block.style.display = originalDisplay[index]
+      })
+    }
+
+    if (images.length === 0)
+      return 0
+
+    const baseName = sanitizeTitle(title)
+    if (images.length === 1)
+      downloadSingleSegment(images[0], baseName)
+    else
+      await downloadSegmentsAsZip(images, baseName)
+
+    return images.length
+  }
+  finally {
+    offScreen.cleanup()
+  }
+}

--- a/apps/web/src/services/export/png.ts
+++ b/apps/web/src/services/export/png.ts
@@ -1,79 +1,25 @@
+import type { PreviewDevice } from './png-capture'
 import { sanitizeTitle } from '@md/shared/utils/basicHelpers'
 import { downloadFile } from '@md/shared/utils/fileHelpers'
 import { delay } from '@/lib/delay'
-import { stripUnresolvedAsyncPlaceholders, waitForPreviewReady } from '@/lib/preview/preview-ready'
-import {
-  applyExportLayout,
-  getPngCaptureBackgroundColor,
-  getPngCaptureStyles,
-  PNG_CAPTURE_ROOT_CLASS,
-} from './apply-export-layout'
-
-async function createOffScreenPreviewElement(
-  previewDevice: `desktop` | `mobile`,
-): Promise<{ el: HTMLElement, cleanup: () => void } | null> {
-  const output = document.getElementById(`output`)
-  if (!output)
-    return null
-
-  const isDarkApp = document.documentElement.classList.contains(`dark`)
-  const useNightPreview = isDarkApp
-    && document.getElementById(`output-wrapper`)?.classList.contains(`output_night`)
-  const width = previewDevice === `mobile` ? `375px` : `750px`
-
-  const host = document.createElement(`div`)
-  host.setAttribute(`data-png-export-host`, ``)
-  host.style.cssText = `position:fixed;left:-99999px;top:0;z-index:-1;visibility:visible;pointer-events:none;`
-  host.innerHTML = await getPngCaptureStyles()
-
-  const wrapper = document.createElement(`div`)
-  wrapper.className = useNightPreview ? `output_night` : ``
-  wrapper.style.width = width
-
-  const preview = document.createElement(`div`)
-  preview.className = `preview border-x shadow-xl mx-auto`
-  preview.style.width = width
-  preview.style.margin = `0`
-
-  const content = output.cloneNode(true) as HTMLElement
-  content.removeAttribute(`id`)
-  content.classList.add(PNG_CAPTURE_ROOT_CLASS)
-  content.style.width = `100%`
-  content.querySelectorAll(`.diagram-download-bar`).forEach(el => el.remove())
-  stripUnresolvedAsyncPlaceholders(content)
-  applyExportLayout(content)
-
-  preview.appendChild(content)
-  wrapper.appendChild(preview)
-  host.appendChild(wrapper)
-  document.body.appendChild(host)
-
-  return {
-    el: preview,
-    cleanup: () => host.remove(),
-  }
-}
+import { waitForPreviewReady } from '@/lib/preview/preview-ready'
+import { createOffScreenPreview, getPngCaptureOptions } from './png-capture'
 
 /** Export PNG card image. */
 export async function exportPNG(
   title: string = `untitled`,
-  options: { previewDevice: `desktop` | `mobile` },
+  options: { previewDevice: PreviewDevice },
 ) {
   await waitForPreviewReady()
 
-  const offScreen = await createOffScreenPreviewElement(options.previewDevice)
+  const offScreen = await createOffScreenPreview(options.previewDevice)
   if (!offScreen)
     return
 
   try {
     await delay(100)
     const { toPng } = await import(`html-to-image`)
-    const url = await toPng(offScreen.el, {
-      backgroundColor: getPngCaptureBackgroundColor(),
-      skipFonts: true,
-      pixelRatio: Math.max(window.devicePixelRatio || 1, 2),
-      style: { margin: `0` },
-    })
+    const url = await toPng(offScreen.el, getPngCaptureOptions())
     downloadFile(url, `${sanitizeTitle(title)}.png`, `image/png`)
   }
   finally {

--- a/apps/web/src/stores/export.ts
+++ b/apps/web/src/stores/export.ts
@@ -1,9 +1,12 @@
 import type { PdfExportOptions } from '@/services/export'
+import { t } from '@/i18n/translate'
 import {
+  DEFAULT_PNG_SEGMENT_HEIGHT,
   downloadMD,
   exportHTML,
   exportPDF,
   exportPNG,
+  exportPNGSegments,
   exportPureHTML,
   getHtmlContent,
 } from '@/services/export'
@@ -43,6 +46,32 @@ export const useExportStore = defineStore(`export`, () => {
     })
   }
 
+  const downloadAsSegmentedImages = async (maxSegmentHeight = DEFAULT_PNG_SEGMENT_HEIGHT) => {
+    const currentPost = postStore.currentPost
+    if (!currentPost)
+      return
+
+    const toastId = toast.loading(t(`store.png.segmentsStart`))
+    try {
+      const count = await exportPNGSegments(currentPost.title, {
+        previewDevice: uiStore.previewDevice,
+        maxSegmentHeight,
+        onProgress: (done, total) => {
+          toast.loading(t(`store.png.segmentsProgress`, { done, total }), { id: toastId })
+        },
+      })
+
+      if (count === 0)
+        toast.error(t(`store.png.segmentsEmpty`), { id: toastId })
+      else
+        toast.success(t(`store.png.segmentsDone`, { count }), { id: toastId })
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      toast.error(t(`store.png.segmentsFailed`, { message }), { id: toastId })
+    }
+  }
+
   const exportEditorContent2PDF = async (options?: Partial<PdfExportOptions>) => {
     const currentPost = postStore.currentPost
     if (!currentPost)
@@ -64,6 +93,7 @@ export const useExportStore = defineStore(`export`, () => {
     exportEditorContent2HTML,
     exportEditorContent2PureHTML,
     downloadAsCardImage,
+    downloadAsSegmentedImages,
     exportEditorContent2PDF,
     exportEditorContent2MD,
   }


### PR DESCRIPTION
## Summary

`导出 PNG` renders the whole article into one image. That is fine for a card but it is the wrong shape for a long post: browsers cap canvas dimensions (Chrome around 65k px, Safari lower and it fails silently by returning a blank or truncated image), and even when the capture succeeds a 20k px tall PNG is awkward to send anywhere.

This adds a second entry, `PNG 分段长图`, which produces several images instead. The point of the feature is not just "make it shorter" — it is that the cuts land in sensible places.

### Splitting on blocks, not pixels

The obvious implementation is to capture the full height once and slice the canvas every N pixels. That reproduces the exact problem being avoided (the tall capture still has to succeed first) and it cuts through the middle of paragraphs, headings and code blocks.

Instead the planner works on the article's top-level blocks and groups them greedily into segments, then each segment is captured on its own. `planSegments` takes the measured bounds and returns index groups:

```ts
const wouldOverflow = bounds[i].bottom - segmentTop > maxSegmentHeight
if (wouldOverflow && current.length > 0) { /* start a new segment */ }
```

Two details worth reviewing:

- Heights are measured from the segment's own first block's `top`, not from the document top. Measuring from the document top makes every segment after the first look oversized and splits far too eagerly.
- Bounds come from `getBoundingClientRect`, so the gaps between blocks are counted. Summing `offsetHeight` would ignore margins, which are exactly what `--md-block-spacing` (#1938) makes user-controllable, so the segments would drift over the ceiling.
- `maxSegmentHeight` is a soft ceiling. A single block taller than it — a long code block, a tall Mermaid diagram — gets a whole segment to itself rather than being split, since not splitting it is the entire point.

The planner is pure, so it is unit-tested without a layout engine. Eight cases in `png-segments.test.ts`, including the two failure modes above and an invariant that every block appears exactly once in document order.

### Finding the blocks

`#output`'s children are not the blocks. `createContainer` wraps the whole document in one `<section class="container">`, so the clone has exactly one child. `resolveBlockContainer` descends through single-child `section`/`div` wrappers to the level that actually holds the headings and paragraphs.

`collectBlocks` then drops children with a zero-size rect. This is load-bearing: `postProcessHtml` appends `<style>` tags to the output, and those would otherwise be treated as blocks with `top === bottom === 0`, which resets the planner's baseline mid-document. Leaving them out also guarantees the per-segment `display` toggling never touches the nodes carrying the theme CSS.

### Capture

Segments are rendered by hiding the other blocks with `display: none` and calling `toBlob` on the same off-screen host. The original inline `display` values are saved and restored rather than cleared, because the renderer sets them (code blocks use `flex`). One image downloads directly; several are zipped with `fflate`, matching `exportPostsAsZip`.

The off-screen preview construction is shared with the existing single-image export — `png.ts`'s private `createOffScreenPreviewElement` moved to `png-capture.ts` unchanged and both paths now call it, so the two exports cannot drift in theme scoping, night-mode handling or placeholder stripping.

### Scope note

Fixed presets (2000 / 4000 / 6000 / 8000 px) in a submenu rather than a dialog with a numeric input. There is no obviously right number here and the presets cover the range; a dialog can come later if people want an exact value. Progress is a single updating toast, since a 10-segment export takes a few seconds.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation
- [ ] Workflow

## Test Procedure

```bash
pnpm --filter @md/web exec vitest run src/services/export/   # 67 passed
pnpm run type-check
pnpm web build
npx eslint --fix apps/web/src
```

Manual checks worth doing on review:

1. Open a long document (the default content repeated a few times works), pick `文件 → 导出 → PNG 分段长图 → 每段约 2000px`, and confirm the ZIP contains sequentially numbered images with no block cut in half at any boundary.
2. Do the same on a document containing a code block taller than the chosen ceiling, and confirm it lands whole in its own image instead of being split.
3. Switch the preview to mobile width and re-export; the segments should be 375px wide.
4. Toggle dark mode with night preview on and confirm the segments keep the dark background.
5. Export a short document and confirm you get one plain `.png`, not a ZIP with one entry.
6. Run the existing single-image `PNG 图片` export before and after this branch and confirm the output is unchanged (the shared-helper extraction should be behaviour-preserving).

## Pre-flight Checklist

- [x] Code follows the project style and passes `pnpm run lint`
- [x] Type check passes
- [x] Unit tests added and passing
- [x] User-facing copy added to all four locales (zh-CN, zh-TW, en-US, ja-JP)
- [x] Existing single-image PNG export unchanged
