### PR TITLE
perf(core): bound extension start() scans and memoize render output

### DIFF
--- a/packages/core/bench/fixture.ts
+++ b/packages/core/bench/fixture.ts
@@ -1,0 +1,145 @@
+/**
+ * Synthetic article fixtures for render benchmarks.
+ *
+ * Shapes mirror what long WeChat articles actually contain: many headings and
+ * paragraphs, a handful of fenced code blocks, inline/block math, tables and
+ * image figures. Content is deterministic so runs are comparable.
+ */
+
+interface ArticleShape {
+  sections: number
+  paragraphsPerSection: number
+  codeBlocks: number
+  inlineMathPerSection: number
+  blockMath: number
+  tables: number
+  images: number
+}
+
+const CJK_SENTENCES = [
+  `微信公众号的排版一直是内容创作里最消耗时间的环节之一。`,
+  `编辑器需要在保证渲染准确的同时，尽可能减少用户等待。`,
+  `当文章长度超过两万字时，任何一次全量重排都会被明显感知。`,
+  `因此增量渲染与缓存策略比单纯优化解析器更为关键。`,
+  `我们希望输入延迟稳定在一帧以内，而不是随文档长度线性增长。`,
+]
+
+const CODE_SAMPLE = `export function createRenderer(options: RenderOptions) {
+  const cache = new Map<string, string>()
+
+  return function render(source: string): string {
+    const key = hash(source)
+    const cached = cache.get(key)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const html = parse(source, options)
+    cache.set(key, html)
+    return html
+  }
+}`
+
+function paragraph(seed: number): string {
+  const a = CJK_SENTENCES[seed % CJK_SENTENCES.length]
+  const b = CJK_SENTENCES[(seed + 2) % CJK_SENTENCES.length]
+  return `${a}${b}这里补充一些**加粗**、*斜体*与\`inline code\` 的混合内容，并包含一个 [外部链接](https://example.com/article/${seed})。`
+}
+
+function table(seed: number): string {
+  return [
+    `| 配置项 | 默认值 | 说明 |`,
+    `| --- | --- | --- |`,
+    `| debounce | 300ms | 停止输入后的延迟 |`,
+    `| maxWait | 800ms | 连续输入下的强制刷新 |`,
+    `| cacheSize | ${50 + seed} | 缓存条目上限 |`,
+  ].join(`\n`)
+}
+
+export function buildArticle(shape: ArticleShape): string {
+  const parts: string[] = [`# 大文档渲染性能基准`, ``]
+  let codeLeft = shape.codeBlocks
+  let mathLeft = shape.blockMath
+  let tableLeft = shape.tables
+  let imageLeft = shape.images
+
+  for (let s = 0; s < shape.sections; s++) {
+    parts.push(`## 第 ${s + 1} 节 渲染管线剖析`, ``)
+
+    for (let p = 0; p < shape.paragraphsPerSection; p++) {
+      const seed = s * shape.paragraphsPerSection + p
+      let text = paragraph(seed)
+
+      for (let m = 0; m < shape.inlineMathPerSection; m++) {
+        text += ` 其中复杂度为 $O(n \\log n)$，常数项约为 $c_{${m}}$。`
+      }
+
+      parts.push(text, ``)
+    }
+
+    if (codeLeft > 0) {
+      parts.push(`\`\`\`typescript`, CODE_SAMPLE, `\`\`\``, ``)
+      codeLeft--
+    }
+
+    if (mathLeft > 0) {
+      parts.push(`$$`, `\\sum_{i=1}^{n} \\frac{x_i}{\\sqrt{n}} = \\mu + \\sigma \\cdot Z_{${s}}`, `$$`, ``)
+      mathLeft--
+    }
+
+    if (tableLeft > 0) {
+      parts.push(table(s), ``)
+      tableLeft--
+    }
+
+    if (imageLeft > 0) {
+      parts.push(`![渲染管线示意图|600x360](https://example.com/img/${s}.png "图 ${s + 1}")`, ``)
+      imageLeft--
+    }
+
+    parts.push(
+      `> [!NOTE]`,
+      `> 该小节的结论依赖于上面的基准数据。`,
+      ``,
+      `- 列表项 A：解析`,
+      `- 列表项 B：高亮`,
+      `- 列表项 C：净化`,
+      ``,
+    )
+  }
+
+  return parts.join(`\n`)
+}
+
+/** ~50k chars, code and math mixed in — the "long article" case. */
+export const LARGE_ARTICLE = buildArticle({
+  sections: 40,
+  paragraphsPerSection: 5,
+  codeBlocks: 15,
+  inlineMathPerSection: 1,
+  blockMath: 8,
+  tables: 6,
+  images: 10,
+})
+
+/** Math-dominant article: worst case for per-render MathJax typesetting. */
+export const MATH_HEAVY_ARTICLE = buildArticle({
+  sections: 20,
+  paragraphsPerSection: 6,
+  codeBlocks: 0,
+  inlineMathPerSection: 3,
+  blockMath: 20,
+  tables: 0,
+  images: 0,
+})
+
+/** Code-dominant article: worst case for highlight.js + post-formatting. */
+export const CODE_HEAVY_ARTICLE = buildArticle({
+  sections: 24,
+  paragraphsPerSection: 2,
+  codeBlocks: 24,
+  inlineMathPerSection: 0,
+  blockMath: 0,
+  tables: 4,
+  images: 0,
+})

--- a/packages/core/bench/render.bench.ts
+++ b/packages/core/bench/render.bench.ts
@@ -1,0 +1,73 @@
+import { bench, describe } from 'vitest'
+import { initRenderer } from '../src/renderer/renderer-impl'
+import { postProcessHtml, renderMarkdown, sanitizeHtml } from '../src/utils/markdownHelpers'
+import { CODE_HEAVY_ARTICLE, LARGE_ARTICLE, MATH_HEAVY_ARTICLE } from './fixture'
+
+/**
+ * DOMPurify runs on jsdom here, so absolute sanitize timings are far slower than
+ * a real browser. Treat these numbers as relative (before/after), not absolute.
+ */
+
+function makeRenderer() {
+  return initRenderer({
+    citeStatus: false,
+    legend: `alt`,
+    countStatus: true,
+    isMacCodeBlock: true,
+    isShowLineNumber: false,
+    themeMode: `light`,
+  })
+}
+
+function fullRender(markdown: string, renderer: ReturnType<typeof makeRenderer>) {
+  renderer.reset({})
+  const { html, readingTime } = renderMarkdown(markdown, renderer)
+  return postProcessHtml(html, readingTime, renderer)
+}
+
+describe(`full render pipeline`, () => {
+  const renderer = makeRenderer()
+
+  bench(`large article (~50k chars, mixed)`, () => {
+    fullRender(LARGE_ARTICLE, renderer)
+  })
+
+  bench(`code-heavy article`, () => {
+    fullRender(CODE_HEAVY_ARTICLE, renderer)
+  })
+
+  bench(`math-heavy article`, () => {
+    fullRender(MATH_HEAVY_ARTICLE, renderer)
+  })
+})
+
+describe(`pipeline phases (large article)`, () => {
+  const renderer = makeRenderer()
+
+  bench(`marked + highlight only`, () => {
+    renderer.reset({})
+    const { markdownContent } = renderer.parseFrontMatterAndContent(LARGE_ARTICLE)
+    renderer.renderMarkdownToHtml(markdownContent)
+  })
+
+  const renderedHtml = (() => {
+    renderer.reset({})
+    const { markdownContent } = renderer.parseFrontMatterAndContent(LARGE_ARTICLE)
+    return renderer.renderMarkdownToHtml(markdownContent)
+  })()
+
+  bench(`sanitize only`, () => {
+    sanitizeHtml(renderedHtml)
+  })
+})
+
+describe(`incremental typing (one paragraph edited)`, () => {
+  const renderer = makeRenderer()
+  let counter = 0
+
+  bench(`re-render after single-character edit`, () => {
+    counter++
+    const edited = LARGE_ARTICLE.replace(`# 大文档渲染性能基准`, `# 大文档渲染性能基准${counter}`)
+    fullRender(edited, renderer)
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench": "vitest bench --run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/core/src/extensions/alert.ts
+++ b/packages/core/src/extensions/alert.ts
@@ -121,7 +121,7 @@ export function markedAlert(options: AlertOptions = {}): MarkedExtension {
         name: `alertContainer`,
         level: `block`,
         start(src) {
-          return src.match(/^:::/)?.index
+          return src.startsWith(`:::`) ? 0 : undefined
         },
         tokenizer(src, _tokens) {
           // Name: any non-whitespace (incl. CJK); optional custom title on same line

--- a/packages/core/src/extensions/component.ts
+++ b/packages/core/src/extensions/component.ts
@@ -1,6 +1,7 @@
 import type { ComponentRegistry, CustomComponentDef } from '@md/shared/types'
 import type { MarkedExtension } from 'marked'
 import { escapeHtml, unescapeHtml } from '../utils/basicHelpers'
+import { blockScanLimit, indexOfWithin } from '../utils/scan'
 
 // Built-in components
 
@@ -383,29 +384,73 @@ export function markedComponent(
     return src.slice(from, findLineEnd(src, from)).trim() === ``
   }
 
+  /**
+   * Cheap rejection before the line walk below: a component tag always starts
+   * `<` immediately followed by an uppercase letter. marked calls `start()` at
+   * every block boundary with the whole remaining source, and most documents
+   * contain no component at all, so this native scan keeps the common case off
+   * the per-line path entirely.
+   */
+  function hasComponentCandidate(src: string, limit: number): boolean {
+    let from = 0
+    for (;;) {
+      const index = indexOfWithin(src, `<`, from, limit)
+      if (index === -1)
+        return false
+      const next = src.charCodeAt(index + 1)
+      if (next >= 65 && next <= 90)
+        return true
+      from = index + 1
+    }
+  }
+
+  /** Length of a leading ``` / ~~~ fence on the line at `lineStart`, else 0. */
+  function fenceRunLength(src: string, lineStart: number, lineEnd: number): { char: string, length: number } | null {
+    let i = lineStart
+    let indent = 0
+    while (i < lineEnd && src[i] === ` ` && indent < 3) {
+      i++
+      indent++
+    }
+    const char = src[i]
+    if (char !== `\`` && char !== `~`)
+      return null
+    let length = 0
+    while (i + length < lineEnd && src[i + length] === char)
+      length++
+    return length >= 3 ? { char, length } : null
+  }
+
   function findComponentStart(src: string): number | undefined {
-    let offset = 0
+    const limit = blockScanLimit(src)
+    if (!hasComponentCandidate(src, limit))
+      return undefined
+
     let fenceChar = ``
     let fenceLength = 0
+    let lineStart = 0
 
-    for (const line of src.split(`\n`)) {
-      const fenceMatch = line.match(/^ {0,3}([`~]{3,})/)
+    while (lineStart <= limit) {
+      const lineEnd = findLineEnd(src, lineStart)
+      const fence = fenceRunLength(src, lineStart, lineEnd)
 
       if (fenceChar) {
-        if (fenceMatch && fenceMatch[1][0] === fenceChar && fenceMatch[1].length >= fenceLength) {
+        if (fence && fence.char === fenceChar && fence.length >= fenceLength) {
           fenceChar = ``
           fenceLength = 0
         }
       }
-      else if (fenceMatch) {
-        fenceChar = fenceMatch[1][0]
-        fenceLength = fenceMatch[1].length
+      else if (fence) {
+        fenceChar = fence.char
+        fenceLength = fence.length
       }
-      else if (line[0] === `<` && line[1] >= `A` && line[1] <= `Z`) {
-        return offset
+      else {
+        const next = src.charCodeAt(lineStart + 1)
+        if (src[lineStart] === `<` && next >= 65 && next <= 90)
+          return lineStart
       }
 
-      offset += line.length + 1
+      lineStart = lineEnd + 1
     }
 
     return undefined

--- a/packages/core/src/extensions/extensions.test.ts
+++ b/packages/core/src/extensions/extensions.test.ts
@@ -127,6 +127,11 @@ describe(`markup extension`, () => {
     expect(render(`~ 文字 ~`)).not.toContain(`markup-wavyline`)
   })
 
+  it(`skips over longer delimiter runs and still pairs a later match`, () => {
+    expect(render(`前面 === 后面 ==高亮==`)).toContain(`class="markup-highlight"`)
+    expect(render(`+++ 然后 ++下划线++`)).toContain(`class="markup-underline"`)
+  })
+
   it(`still renders intraword CJK markup`, () => {
     const html = render(`把++重点++标出==高亮==和~波浪~`)
 

--- a/packages/core/src/extensions/footnotes.ts
+++ b/packages/core/src/extensions/footnotes.ts
@@ -28,7 +28,7 @@ export function markedFootnotes(): MarkedExtension {
         name: `footnoteDef`,
         level: `block`,
         start(src: string) {
-          return src.match(/^\[\^/)?.index
+          return src.startsWith(`[^`) ? 0 : undefined
         },
         tokenizer(src: string) {
           const match = src.match(/^\[\^(.*)\]:(.*)/)
@@ -67,7 +67,8 @@ export function markedFootnotes(): MarkedExtension {
         name: `footnoteRef`,
         level: `inline`,
         start(src: string) {
-          return src.match(/\[\^/)?.index
+          const index = src.indexOf(`[^`)
+          return index === -1 ? undefined : index
         },
         tokenizer(src: string) {
           const match = src.match(/^\[\^(.*?)\]/)

--- a/packages/core/src/extensions/infographic.ts
+++ b/packages/core/src/extensions/infographic.ts
@@ -11,6 +11,7 @@ import {
   resolveDiagramMessages,
 } from '../utils/asyncDiagramState'
 import { simpleHash } from '../utils/basicHelpers'
+import { blockScanLimit, findAtLineStart } from '../utils/scan'
 import { createSVGCache } from '../utils/svgCache'
 import { DIAGRAM_DARK_COLORS, DIAGRAM_LIGHT_COLORS, resolveDiagramThemeMode } from './diagram-theme'
 
@@ -25,7 +26,7 @@ const svgCache = createSVGCache(50)
 const pendingMeta = new Map<string, { code: string, options?: InfographicOptions }>()
 const inFlight = new Set<string>()
 
-const RE_INFOGRAPHIC_START = /^```infographic/m
+const INFOGRAPHIC_FENCE = '```infographic'
 const RE_INFOGRAPHIC_BLOCK = /^```infographic\r?\n([\s\S]*?)\r?\n```/
 const INFOGRAPHIC_ID_PREFIX = `infographic-`
 const OFFSCREEN_ROOT_ID = `md-infographic-offscreen-root`
@@ -236,7 +237,7 @@ export function markedInfographic(options?: InfographicOptionsSource): MarkedExt
         name: `infographic`,
         level: `block`,
         start(src: string) {
-          return src.match(RE_INFOGRAPHIC_START)?.index
+          return findAtLineStart(src, INFOGRAPHIC_FENCE, blockScanLimit(src))
         },
         tokenizer(src: string) {
           const match = RE_INFOGRAPHIC_BLOCK.exec(src)

--- a/packages/core/src/extensions/katex.ts
+++ b/packages/core/src/extensions/katex.ts
@@ -12,6 +12,8 @@ import {
   matchBlockKatex,
 } from '../utils/mathDetection'
 import { ensureMathJaxLoaded, isMathJaxReady } from '../utils/mathjax'
+import { blockScanLimit, findIndentedLineStart } from '../utils/scan'
+import { LRUMap } from '../utils/svgCache'
 
 export interface MarkedKatexOptions {
   nonStandard?: boolean
@@ -20,6 +22,20 @@ export interface MarkedKatexOptions {
 }
 
 const DEFAULT_KATEX_LOADING = `Loading formula…`
+
+/**
+ * tex2svg is a full synchronous typeset per formula. The preview re-renders the
+ * whole document on every keystroke batch, so a formula-heavy article would
+ * otherwise re-typeset every untouched formula each time. Only settled output is
+ * cached — pending placeholders must stay uncached so they resolve once MathJax
+ * finishes loading.
+ */
+const mathSvgCache = new LRUMap<string>(400)
+
+/** Drop memoized formula SVG (exported for tests and MathJax reloads). */
+export function clearMathSvgCache(): void {
+  mathSvgCache.clear()
+}
 
 let mathJaxLoadRequested = false
 
@@ -45,6 +61,12 @@ function createRenderer(
   return (token: KatexToken) => {
     const display = token.displayMode ?? defaultDisplay
     const rawAttr = escapeHtml(token.raw ?? token.text)
+    const cacheKey = `${display ? `1` : `0`}\u0000${withStyle ? `1` : `0`}\u0000${rawAttr}\u0000${token.text}`
+
+    const cached = mathSvgCache.get(cacheKey)
+    if (cached !== undefined) {
+      return cached
+    }
 
     if (typeof window === `undefined` || !isMathJaxReady()) {
       requestMathJaxLoad()
@@ -82,11 +104,12 @@ function createRenderer(
       firstG.setAttribute(`stroke`, `currentColor`)
     }
 
-    if (!display) {
-      return `<span class="katex-inline" data-math-display="false" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</span>`
-    }
+    const html = display
+      ? `<section class="katex-block" data-math-display="true" data-math-raw="${rawAttr}">${svg.outerHTML}</section>`
+      : `<span class="katex-inline" data-math-display="false" data-math-raw="${rawAttr}">${svg.outerHTML}</span>`
 
-    return `<section class="katex-block" data-math-display="true" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</section>`
+    mathSvgCache.set(cacheKey, html)
+    return html
   }
 }
 
@@ -119,8 +142,7 @@ function blockKatex(_options: MarkedKatexOptions | undefined, renderer: KatexRen
     name: `blockKatex`,
     level: `block` as const,
     start(src: string) {
-      const index = src.search(/^\s{0,3}\$\$/m)
-      return index === -1 ? undefined : index
+      return findIndentedLineStart(src, `$$`, 3, blockScanLimit(src))
     },
     tokenizer(src: string) {
       const match = matchBlockKatex(src)

--- a/packages/core/src/extensions/markup.ts
+++ b/packages/core/src/extensions/markup.ts
@@ -29,12 +29,28 @@ function followsWordChar(tokens: Token[] | undefined): boolean {
 // Regex lookbehind throws at parse time in JS engines without support (older
 // WebViews) and would take down the whole renderer, so boundaries are enforced
 // with plain scans/character classes instead of `(?<!...)`/`(?<=...)`.
-function boundaryStart(src: string, delimiter: RegExp): number | undefined {
-  const rule = new RegExp(delimiter.source, `g`)
-  for (let match = rule.exec(src); match !== null; match = rule.exec(src)) {
-    if (!WORD_CHAR.test(src.charAt(match.index - 1))) {
-      return match.index
+//
+// `start()` runs for every inline scan position, so the delimiter search uses
+// indexOf rather than a per-call `new RegExp`.
+function boundaryStart(src: string, delimiter: string): number | undefined {
+  let from = 0
+  for (;;) {
+    const index = src.indexOf(delimiter, from)
+    if (index === -1)
+      return undefined
+
+    // `==(?!=)` / `++(?!+)` / `~(?!~)`: the delimiter run must stop here.
+    // A failed lookahead only advances the scan by one, same as the regex engine.
+    if (src[index + delimiter.length] === delimiter[0]) {
+      from = index + 1
+      continue
     }
+
+    if (!WORD_CHAR.test(src.charAt(index - 1)))
+      return index
+
+    // Match consumed but rejected by the boundary rule: resume past it.
+    from = index + delimiter.length
   }
 }
 
@@ -46,7 +62,7 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_highlight`,
         level: `inline`,
         start(src: string) {
-          return boundaryStart(src, /==(?!=)/)
+          return boundaryStart(src, `==`)
         },
         tokenizer(src: string, tokens: Token[]) {
           if (followsWordChar(tokens)) {
@@ -71,7 +87,7 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_underline`,
         level: `inline`,
         start(src: string) {
-          return boundaryStart(src, /\+\+(?!\+)/)
+          return boundaryStart(src, `++`)
         },
         tokenizer(src: string, tokens: Token[]) {
           if (followsWordChar(tokens)) {
@@ -96,7 +112,7 @@ export function markedMarkup(): MarkedExtension {
         name: `markup_wavyline`,
         level: `inline`,
         start(src: string) {
-          return boundaryStart(src, /~(?!~)/)
+          return boundaryStart(src, `~`)
         },
         tokenizer(src: string, tokens: Token[]) {
           if (followsWordChar(tokens)) {

--- a/packages/core/src/extensions/mermaid.ts
+++ b/packages/core/src/extensions/mermaid.ts
@@ -11,6 +11,7 @@ import {
   resolveDiagramMessages,
 } from '../utils/asyncDiagramState'
 import { simpleHash } from '../utils/basicHelpers'
+import { blockScanLimit, findAtLineStart } from '../utils/scan'
 import { createSVGCache } from '../utils/svgCache'
 import { diagramCacheThemeSuffix, getMermaidThemeConfig } from './diagram-theme'
 
@@ -106,7 +107,7 @@ export function markedMermaid(options?: MermaidOptionsSource): MarkedExtension {
         name: 'mermaid',
         level: 'block',
         start(src: string) {
-          return src.match(/^```mermaid/m)?.index
+          return findAtLineStart(src, '```mermaid', blockScanLimit(src))
         },
         tokenizer(src: string) {
           const match = /^```mermaid\r?\n([\s\S]*?)\r?\n```/.exec(src)

--- a/packages/core/src/extensions/plantuml.ts
+++ b/packages/core/src/extensions/plantuml.ts
@@ -11,6 +11,7 @@ import {
   resolveDiagramMessages,
 } from '../utils/asyncDiagramState'
 import { simpleHash } from '../utils/basicHelpers'
+import { blockScanLimit, findAtLineStart } from '../utils/scan'
 import { createSVGCache } from '../utils/svgCache'
 import { diagramCacheThemeSuffix, injectPlantUmlTheme } from './diagram-theme'
 
@@ -261,7 +262,7 @@ export function markedPlantUML(options: PlantUMLOptions = {}): MarkedExtension {
         name: `plantuml`,
         level: `block`,
         start(src: string) {
-          return src.match(/^```plantuml/m)?.index
+          return findAtLineStart(src, '```plantuml', blockScanLimit(src))
         },
         tokenizer(src: string) {
           const match = /^```plantuml\r?\n([\s\S]*?)\r?\n```/.exec(src)

--- a/packages/core/src/extensions/render-memoization.test.ts
+++ b/packages/core/src/extensions/render-memoization.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initRenderer } from '../renderer/renderer-impl'
+import { clearHighlightCache } from '../utils/languages'
+import { clearMathSvgCache } from './katex'
+
+/**
+ * The preview re-renders the whole document on every keystroke batch, so
+ * formula typesetting and code highlighting must not be repeated for content
+ * that did not change.
+ */
+
+function makeRenderer() {
+  return initRenderer({ legend: `alt`, themeMode: `light` })
+}
+
+function render(renderer: ReturnType<typeof makeRenderer>, markdown: string) {
+  renderer.reset({})
+  const { markdownContent } = renderer.parseFrontMatterAndContent(markdown)
+  return renderer.renderMarkdownToHtml(markdownContent)
+}
+
+describe(`formula typesetting is memoized`, () => {
+  let tex2svgCalls = 0
+  const originalMathJax = window.MathJax
+
+  beforeEach(() => {
+    tex2svgCalls = 0
+    clearMathSvgCache()
+
+    window.MathJax = {
+      texReset() {},
+      tex2svg(tex: string) {
+        tex2svgCalls++
+        const container = document.createElement(`div`)
+        const svg = document.createElementNS(`http://www.w3.org/2000/svg`, `svg`)
+        svg.setAttribute(`width`, `10ex`)
+        svg.appendChild(document.createElementNS(`http://www.w3.org/2000/svg`, `g`))
+        svg.textContent = tex
+        container.appendChild(svg)
+        return container as unknown as ReturnType<MathJaxGlobal['tex2svg']>
+      },
+    }
+  })
+
+  afterEach(() => {
+    window.MathJax = originalMathJax
+    clearMathSvgCache()
+  })
+
+  it(`typesets each distinct formula once across repeated renders`, () => {
+    const renderer = makeRenderer()
+    const markdown = `Cost is $a + b$ and $c^2$ here.\n\n$$\nx = y\n$$\n`
+
+    render(renderer, markdown)
+    expect(tex2svgCalls).toBe(3)
+
+    render(renderer, markdown)
+    render(renderer, markdown)
+    expect(tex2svgCalls).toBe(3)
+  })
+
+  it(`typesets a newly added formula only`, () => {
+    const renderer = makeRenderer()
+
+    render(renderer, `$a + b$`)
+    expect(tex2svgCalls).toBe(1)
+
+    render(renderer, `$a + b$ and $z$`)
+    expect(tex2svgCalls).toBe(2)
+  })
+
+  it(`still produces identical output on a cache hit`, () => {
+    const renderer = makeRenderer()
+    const markdown = `inline $a + b$ done`
+
+    const first = render(renderer, markdown)
+    const second = render(renderer, markdown)
+    expect(second).toBe(first)
+  })
+
+  it(`does not cache the pending placeholder emitted before MathJax loads`, () => {
+    const renderer = makeRenderer()
+    const markdown = `inline $a + b$ done`
+
+    window.MathJax = undefined as unknown as MathJaxGlobal
+    const pending = render(renderer, markdown)
+    expect(pending).toContain(`katex-pending`)
+
+    window.MathJax = {
+      texReset() {},
+      tex2svg(tex: string) {
+        tex2svgCalls++
+        const container = document.createElement(`div`)
+        const svg = document.createElementNS(`http://www.w3.org/2000/svg`, `svg`)
+        svg.appendChild(document.createElementNS(`http://www.w3.org/2000/svg`, `g`))
+        svg.textContent = tex
+        container.appendChild(svg)
+        return container as unknown as ReturnType<MathJaxGlobal['tex2svg']>
+      },
+    }
+
+    const settled = render(renderer, markdown)
+    expect(settled).not.toContain(`katex-pending`)
+  })
+})
+
+describe(`code highlighting is memoized`, () => {
+  beforeEach(() => {
+    clearHighlightCache()
+  })
+
+  it(`returns identical markup for an unchanged block`, () => {
+    const renderer = makeRenderer()
+    const markdown = '```typescript\nconst a: number = 1\n```'
+
+    const first = render(renderer, markdown)
+    const second = render(renderer, markdown)
+
+    expect(second).toBe(first)
+    expect(first).toContain(`hljs`)
+  })
+
+  it(`keys on the line-number option`, () => {
+    const renderer = makeRenderer()
+    const markdown = '```typescript\nconst a: number = 1\n```'
+
+    renderer.reset({ isShowLineNumber: false })
+    const plain = renderer.renderMarkdownToHtml(markdown)
+
+    renderer.reset({ isShowLineNumber: true })
+    const numbered = renderer.renderMarkdownToHtml(markdown)
+
+    expect(numbered).not.toBe(plain)
+    expect(numbered).toContain(`line-numbers`)
+  })
+})

--- a/packages/core/src/extensions/ruby.ts
+++ b/packages/core/src/extensions/ruby.ts
@@ -17,7 +17,8 @@ export function markedRuby(): MarkedExtension {
         name: `ruby`,
         level: `inline`,
         start(src: string) {
-          return src.match(/\[/)?.index
+          const index = src.indexOf(`[`)
+          return index === -1 ? undefined : index
         },
         tokenizer(src: string) {
           const rule1 = /^\[([^\]]+)\]\{([^}]+)\}/

--- a/packages/core/src/extensions/slider.ts
+++ b/packages/core/src/extensions/slider.ts
@@ -11,7 +11,7 @@ export function markedSlider(): MarkedExtension {
         name: `horizontalSlider`,
         level: `block`,
         start(src: string) {
-          return src.match(/^<!\[/)?.index
+          return src.startsWith(`<![`) ? 0 : undefined
         },
         tokenizer(src: string) {
           const rule = /^<(!\[.*?\]\(.*?\)(?:,!\[.*?\]\(.*?\))*)>/

--- a/packages/core/src/extensions/toc.ts
+++ b/packages/core/src/extensions/toc.ts
@@ -1,4 +1,5 @@
 import type { MarkedExtension } from 'marked'
+import { blockScanLimit, findLineEquals } from '../utils/scan'
 
 /** marked extension: [TOC] syntax for nested table of contents */
 export function markedToc(): MarkedExtension {
@@ -25,8 +26,7 @@ export function markedToc(): MarkedExtension {
         level: `block`,
         start(src) {
           // Match [TOC] on its own line only
-          const match = src.match(/^\s*\[TOC\]\s*$/m)
-          return match ? match.index : undefined
+          return findLineEquals(src, `[TOC]`, blockScanLimit(src))
         },
         tokenizer(src) {
           const match = /^\[TOC\]/.exec(src)

--- a/packages/core/src/utils/languages.ts
+++ b/packages/core/src/utils/languages.ts
@@ -9,6 +9,7 @@ import python from 'highlight.js/lib/languages/python'
 import shell from 'highlight.js/lib/languages/shell'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
+import { LRUMap } from './svgCache'
 
 /**
  * Languages bundled with the renderer. Everything else loads from CDN on first use
@@ -130,8 +131,26 @@ function splitHighlightedHtmlByLines(html: string): string[] {
   return lines
 }
 
+/**
+ * Highlighting plus the span/whitespace post-processing below is pure, so the
+ * preview's full re-render on every keystroke batch would otherwise re-highlight
+ * every untouched code block.
+ *
+ * Entries hold generated HTML — several times the size of the source, and much
+ * more with line numbers, since every line becomes its own element. The cap only
+ * has to cover the code blocks of the documents in play, so it is kept well
+ * below the point where retained markup becomes noticeable.
+ */
+const highlightCache = new LRUMap<string>(128)
+
 /** Highlight code and format for display, optionally with line numbers. */
 export function highlightAndFormatCode(text: string, language: string, hljs: HLJSApi, showLineNumber: boolean): string {
+  const cacheKey = `${language}\u0000${showLineNumber ? `1` : `0`}\u0000${text}`
+  const cached = highlightCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+
   let highlighted = ``
 
   if (showLineNumber) {
@@ -164,7 +183,17 @@ export function highlightAndFormatCode(text: string, language: string, hljs: HLJ
     highlighted = `<span class="code-block__inner" style="display:block">${formatted}</span>`
   }
 
+  highlightCache.set(cacheKey, highlighted)
   return highlighted
+}
+
+/**
+ * Drop memoized highlight output. Not needed for grammar loading — a block
+ * highlighted before its grammar arrives is keyed under `plaintext`, so the
+ * later re-highlight under the real language name misses the cache anyway.
+ */
+export function clearHighlightCache(): void {
+  highlightCache.clear()
 }
 
 export function highlightCodeBlock(codeBlock: Element, language: string, hljs: HLJSApi): void {

--- a/packages/core/src/utils/mathDetection.ts
+++ b/packages/core/src/utils/mathDetection.ts
@@ -9,14 +9,42 @@ export function matchBlockKatex(src: string): RegExpMatchArray | null {
   return src.match(blockRuleMultiline) ?? src.match(blockRuleSingleLine)
 }
 
-function contentHasBlockKatex(content: string): boolean {
-  for (let i = 0; i <= content.length; i++) {
-    if (i > 0 && content[i - 1] !== '\n')
-      continue
-    if (matchBlockKatex(content.slice(i)))
-      return true
+/**
+ * Sticky twin of an `^`-anchored rule, so a position can be tested in place
+ * instead of slicing the source first. Keyed by rule identity; the rules are
+ * module constants, so this holds a couple of entries.
+ */
+const stickyRules = new Map<RegExp, RegExp>()
+
+function stickyRuleFor(rule: RegExp): RegExp {
+  let sticky = stickyRules.get(rule)
+  if (!sticky) {
+    sticky = new RegExp(rule.source.replace(/^\^/, ``), `${rule.flags.replace(/[gy]/g, ``)}y`)
+    stickyRules.set(rule, sticky)
   }
-  return false
+  return sticky
+}
+
+function matchesAt(rule: RegExp, src: string, index: number): boolean {
+  const sticky = stickyRuleFor(rule)
+  sticky.lastIndex = index
+  return sticky.test(src)
+}
+
+function contentHasBlockKatex(content: string): boolean {
+  if (!content.includes(`$`))
+    return false
+
+  let lineStart = 0
+  for (;;) {
+    if (matchesAt(blockRuleMultiline, content, lineStart) || matchesAt(blockRuleSingleLine, content, lineStart))
+      return true
+
+    const next = content.indexOf(`\n`, lineStart)
+    if (next === -1)
+      return false
+    lineStart = next + 1
+  }
 }
 
 export const inlineLatexRule = /^\\\(([^\\]*(?:\\.[^\\]*)*?)\\\)/
@@ -25,40 +53,48 @@ export const blockLatexRule = /^\\\[([^\\]*(?:\\.[^\\]*)*?)\\\]/
 const blockLatexAnywhere = /\\\[[^\\]*(?:\\.[^\\]*)*?\\\]/
 const inlineLatexAnywhere = /\\\([^\\]*(?:\\.[^\\]*)*?\\\)/
 
-function isAmountDollarSign(src: string, index: number): boolean {
-  if (index <= 0)
+const DOLLAR = 36
+
+/**
+ * `offset` is where the current scan region begins. The original implementation
+ * re-sliced the source after every `$`, so the "is this the region start" checks
+ * below stay relative to that region rather than to the absolute index.
+ */
+function isAmountDollarSign(src: string, index: number, offset: number): boolean {
+  if (index <= offset)
     return false
   const prev = src.charAt(index - 1)
   if (/[\d,.]/.test(prev))
     return true
-  return prev === ` ` && index >= 2 && /\d/.test(src.charAt(index - 2))
+  return prev === ` ` && index - offset >= 2 && /\d/.test(src.charAt(index - 2))
 }
 
-function isInlineKatexStart(src: string, index: number, nonStandard: boolean): boolean {
+function isInlineKatexStart(src: string, index: number, offset: number, nonStandard: boolean): boolean {
   if (nonStandard)
-    return !isAmountDollarSign(src, index)
-  return index === 0 || src.charAt(index - 1) === ` `
+    return !isAmountDollarSign(src, index, offset)
+  return index === offset || src.charAt(index - 1) === ` `
 }
 
 export function findInlineKatexStart(src: string, nonStandard: boolean, ruleReg: RegExp): number | undefined {
-  let indexSrc = src
   let offset = 0
 
-  while (indexSrc) {
-    const index = indexSrc.indexOf(`$`)
+  while (offset < src.length) {
+    const index = src.indexOf(`$`, offset)
     if (index === -1)
-      return
+      return undefined
 
-    if (isInlineKatexStart(indexSrc, index, nonStandard)) {
-      const possibleKatex = indexSrc.substring(index)
-      if (possibleKatex.match(ruleReg))
-        return offset + index
-    }
+    if (isInlineKatexStart(src, index, offset, nonStandard) && matchesAt(ruleReg, src, index))
+      return index
 
-    const next = indexSrc.substring(index + 1).replace(/^\$+/, ``)
-    offset += indexSrc.length - next.length
-    indexSrc = next
+    // Skip the delimiter plus any immediately adjacent `$`, matching the
+    // original `substring(index + 1).replace(/^\$+/, '')` step.
+    let next = index + 1
+    while (next < src.length && src.charCodeAt(next) === DOLLAR)
+      next++
+    offset = next
   }
+
+  return undefined
 }
 
 /** Whether content contains math recognized by MDKatex (default nonStandard=true, same as renderer-impl). */

--- a/packages/core/src/utils/scan.test.ts
+++ b/packages/core/src/utils/scan.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import {
+  blockScanLimit,
+  findAtLineStart,
+  findIndentedLineStart,
+  findLineEquals,
+  indexOfWithin,
+} from './scan'
+
+/**
+ * These helpers replaced whole-tail regex scans in extension `start()` hooks, so
+ * the cases below pin the anchoring rules of the patterns they stand in for.
+ */
+
+describe(`findAtLineStart`, () => {
+  const needle = '```mermaid'
+
+  it(`matches at the very start`, () => {
+    expect(findAtLineStart('```mermaid\ngraph TD', needle)).toBe(0)
+  })
+
+  it(`matches after a newline`, () => {
+    const src = 'text\n```mermaid\ngraph TD'
+    expect(findAtLineStart(src, needle)).toBe(5)
+  })
+
+  it(`ignores occurrences that do not start a line`, () => {
+    expect(findAtLineStart('inline ```mermaid stays text', needle)).toBeUndefined()
+  })
+
+  it(`skips a mid-line hit and finds the later line-start one`, () => {
+    const src = 'see ```mermaid here\n```mermaid\ngraph TD'
+    expect(findAtLineStart(src, needle)).toBe(20)
+  })
+
+  it(`handles CRLF line endings`, () => {
+    expect(findAtLineStart('text\r\n```mermaid', needle)).toBe(6)
+  })
+
+  it(`matches the old fence-at-line-start regex behaviour`, () => {
+    const samples = [
+      '```mermaid\na',
+      'x\n```mermaid',
+      'x ```mermaid',
+      'a\nb\n```mermaid\nc',
+      'no fence here',
+    ]
+    for (const sample of samples)
+      expect(findAtLineStart(sample, needle)).toBe(sample.match(/^```mermaid/m)?.index)
+  })
+
+  it(`respects the limit`, () => {
+    const src = 'para\n\n```mermaid\ngraph TD'
+    expect(findAtLineStart(src, needle)).toBe(6)
+    expect(findAtLineStart(src, needle, 4)).toBeUndefined()
+  })
+})
+
+describe(`findIndentedLineStart`, () => {
+  it(`returns the line start, not the delimiter position`, () => {
+    const src = 'text\n  $$\nx = 1\n$$'
+    expect(findIndentedLineStart(src, `$$`, 3)).toBe(5)
+  })
+
+  it(`allows up to three spaces of indent`, () => {
+    expect(findIndentedLineStart('   $$\na', `$$`, 3)).toBe(0)
+  })
+
+  it(`rejects four spaces of indent`, () => {
+    expect(findIndentedLineStart('    $$\na', `$$`, 3)).toBeUndefined()
+  })
+
+  it(`skips inline dollars and finds a later block`, () => {
+    const src = 'cost is $$5 today\n$$\nx\n$$'
+    expect(findIndentedLineStart(src, `$$`, 3)).toBe(18)
+  })
+
+  it(`matches the old indented-block regex behaviour for space indents`, () => {
+    const samples = ['$$\na', ' $$\na', '  $$', 'x\n $$', 'x $$ y', 'nothing']
+    for (const sample of samples)
+      expect(findIndentedLineStart(sample, `$$`, 3)).toBe(sample.search(/^\s{0,3}\$\$/m) === -1 ? undefined : sample.search(/^\s{0,3}\$\$/m))
+  })
+})
+
+describe(`findLineEquals`, () => {
+  it(`matches a bare marker line`, () => {
+    expect(findLineEquals('[TOC]\n# Title', `[TOC]`)).toBe(0)
+  })
+
+  it(`allows surrounding spaces`, () => {
+    const src = 'intro\n  [TOC]  \n# Title'
+    expect(findLineEquals(src, `[TOC]`)).toBe(6)
+  })
+
+  it(`ignores markers with other content on the line`, () => {
+    expect(findLineEquals('see [TOC] here', `[TOC]`)).toBeUndefined()
+  })
+
+  it(`finds a later standalone marker`, () => {
+    const src = 'see [TOC] here\n[TOC]\n'
+    expect(findLineEquals(src, `[TOC]`)).toBe(15)
+  })
+})
+
+describe(`blockScanLimit`, () => {
+  it(`stops at the first blank line`, () => {
+    const src = 'para one\nstill one\n\npara two'
+    expect(blockScanLimit(src)).toBe(18)
+  })
+
+  it(`treats whitespace-only lines as blank`, () => {
+    const src = 'para\n   \nnext'
+    expect(blockScanLimit(src)).toBe(4)
+  })
+
+  it(`returns the full length when there is no blank line`, () => {
+    const src = 'a\nb\nc'
+    expect(blockScanLimit(src)).toBe(src.length)
+  })
+
+  it(`keeps a directly adjacent fence in range`, () => {
+    const src = 'para text\n```mermaid\ngraph TD\n```\n\nafter'
+    const limit = blockScanLimit(src)
+    expect(findAtLineStart(src, '```mermaid', limit)).toBe(10)
+  })
+})
+
+describe(`indexOfWithin`, () => {
+  it(`finds within the limit`, () => {
+    expect(indexOfWithin(`ab<C`, `<`, 0, 10)).toBe(2)
+  })
+
+  it(`rejects past the limit`, () => {
+    expect(indexOfWithin(`ab<C`, `<`, 0, 1)).toBe(-1)
+  })
+
+  it(`matches indexOf when the limit covers the whole source`, () => {
+    const src = `alpha <Beta> gamma`
+    expect(indexOfWithin(src, `<`, 0, src.length)).toBe(src.indexOf(`<`))
+  })
+})

--- a/packages/core/src/utils/scan.ts
+++ b/packages/core/src/utils/scan.ts
@@ -1,0 +1,180 @@
+/**
+ * Fast source scanning helpers for marked extension `start()` hooks.
+ *
+ * marked calls `start()` for every registered extension at every block boundary,
+ * always passing the *remaining* source. A `/^.../m` regex — or a bare `indexOf`
+ * that finds nothing — therefore rescans the whole tail on every call, and a
+ * dozen extensions turn a long document into quadratic work.
+ *
+ * Two things keep that linear here: the search is bounded to the current block
+ * (see {@link blockScanLimit}), and the bounded search never allocates.
+ */
+
+const LF = 10
+const CR = 13
+const SPACE = 32
+const TAB = 9
+
+function isLineTerminator(code: number): boolean {
+  return code === LF || code === CR
+}
+
+/** True when `index` sits at the beginning of a line. */
+export function isAtLineStart(src: string, index: number): boolean {
+  return index === 0 || isLineTerminator(src.charCodeAt(index - 1))
+}
+
+/**
+ * How far a block-level `start()` needs to look.
+ *
+ * marked uses the returned index only to decide where the current paragraph is
+ * cut short. A paragraph always ends at a blank line, so anything past the first
+ * blank line belongs to a later block that marked tokenizes on its own pass.
+ */
+export function blockScanLimit(src: string): number {
+  let from = 0
+  for (;;) {
+    const newline = src.indexOf(`\n`, from)
+    if (newline === -1)
+      return src.length
+
+    let i = newline + 1
+    while (i < src.length) {
+      const code = src.charCodeAt(i)
+      if (code === LF)
+        return newline
+      if (code === SPACE || code === TAB || code === CR) {
+        i++
+        continue
+      }
+      break
+    }
+
+    if (i >= src.length)
+      return src.length
+
+    from = newline + 1
+  }
+}
+
+/**
+ * `indexOf` restricted to starts within `limit`.
+ *
+ * The native `indexOf` cannot be bounded, so it would scan the whole tail before
+ * the caller could reject an out-of-range hit. It stays faster on unbounded
+ * searches, so it is still used when the limit covers the entire source.
+ */
+function boundedIndexOf(src: string, needle: string, from: number, limit: number): number {
+  const maxStart = Math.min(limit, src.length - needle.length)
+  if (maxStart < from)
+    return -1
+
+  if (maxStart >= src.length - needle.length) {
+    const index = src.indexOf(needle, from)
+    return index > maxStart ? -1 : index
+  }
+
+  const firstCode = needle.charCodeAt(0)
+  const needleLength = needle.length
+
+  for (let i = from; i <= maxStart; i++) {
+    if (src.charCodeAt(i) !== firstCode)
+      continue
+    let j = 1
+    while (j < needleLength && src.charCodeAt(i + j) === needle.charCodeAt(j))
+      j++
+    if (j === needleLength)
+      return i
+  }
+
+  return -1
+}
+
+/** Index of the first `needle` occurrence that begins a line, if any. */
+export function findAtLineStart(src: string, needle: string, limit: number = src.length): number | undefined {
+  let from = 0
+  for (;;) {
+    const index = boundedIndexOf(src, needle, from, limit)
+    if (index === -1)
+      return undefined
+    if (isAtLineStart(src, index))
+      return index
+    from = index + 1
+  }
+}
+
+/**
+ * Index of the line start for the first `needle` preceded on its own line by at
+ * most `maxIndent` spaces/tabs. Mirrors `/^ {0,maxIndent}needle/m`, returning the
+ * line start (what `String.search` reports for that pattern) rather than the
+ * needle position.
+ */
+export function findIndentedLineStart(src: string, needle: string, maxIndent: number, limit: number = src.length): number | undefined {
+  let from = 0
+  for (;;) {
+    const index = boundedIndexOf(src, needle, from, limit)
+    if (index === -1)
+      return undefined
+
+    let lineStart = index
+    let indent = 0
+    while (lineStart > 0 && indent <= maxIndent) {
+      const code = src.charCodeAt(lineStart - 1)
+      if (code === SPACE || code === TAB) {
+        lineStart--
+        indent++
+        continue
+      }
+      break
+    }
+
+    if (indent <= maxIndent && isAtLineStart(src, lineStart))
+      return lineStart
+
+    from = index + 1
+  }
+}
+
+/** End index (exclusive) of the line containing `index`. */
+export function lineEndFrom(src: string, index: number): number {
+  const next = src.indexOf(`\n`, index)
+  return next === -1 ? src.length : next
+}
+
+/** True when `[from, to)` contains only spaces and tabs. */
+export function isBlankRange(src: string, from: number, to: number): boolean {
+  for (let i = from; i < to; i++) {
+    const code = src.charCodeAt(i)
+    if (code !== SPACE && code !== TAB && code !== CR)
+      return false
+  }
+  return true
+}
+
+/**
+ * Index of the line start for the first line whose only content is `needle`
+ * (surrounding spaces/tabs allowed). Mirrors `/^\s*needle\s*$/m`.
+ */
+export function findLineEquals(src: string, needle: string, limit: number = src.length): number | undefined {
+  let from = 0
+  for (;;) {
+    const index = boundedIndexOf(src, needle, from, limit)
+    if (index === -1)
+      return undefined
+
+    let lineStart = index
+    while (lineStart > 0 && !isLineTerminator(src.charCodeAt(lineStart - 1)))
+      lineStart--
+
+    const lineEnd = lineEndFrom(src, index)
+    if (isBlankRange(src, lineStart, index) && isBlankRange(src, index + needle.length, lineEnd))
+      return lineStart
+
+    from = index + 1
+  }
+}
+
+/** `indexOf` restricted to matches starting at or before `limit`. Returns -1 when absent. */
+export function indexOfWithin(src: string, needle: string, from: number, limit: number): number {
+  return boundedIndexOf(src, needle, from, limit)
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "src/**/*",
+    "bench/**/*",
     "../shared/src/global.d.ts"
   ],
   "exclude": [

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     environment: `jsdom`,
     include: [`src/**/*.test.ts`],
+    benchmark: {
+      include: [`bench/**/*.bench.ts`],
+    },
   },
 })


### PR DESCRIPTION
## Summary

Rendering a long article was quadratic in document length. marked calls every registered extension's `start()` hook at each block boundary and passes it the **whole remaining source**, so a `/^```mermaid/m`-style scan — one per extension, a dozen of them — rescanned the entire tail on every block.

This PR does two things:

1. **Bound the block-level scans.** marked uses the returned index only to decide where the current paragraph is cut short, and a paragraph always ends at a blank line, so anything past the first blank line belongs to a later block that marked tokenizes on its own pass. A new `utils/scan` module provides non-allocating `indexOf`-based helpers (`blockScanLimit`, `findAtLineStart`, `findIndentedLineStart`, `findLineEquals`, `indexOfWithin`) that replace the regex scans in `mermaid`, `plantuml`, `infographic`, `toc`, `alert`, `slider`, `footnotes`, `ruby`, `component`, `markup` and `katex`.
2. **Memoize the expensive pure work.** `highlight.js` highlighting and MathJax `tex2svg` typesetting are both pure and both re-run for every untouched block on each keystroke batch. Both are now LRU-memoized. Pending KaTeX placeholders are deliberately left uncached so they still resolve once MathJax finishes loading.

### Measured effect

Parse phase, synthetic articles of increasing size:

| Document size | Before | After | Speedup |
| ------------- | ------ | ----- | ------- |
| 5,795 chars | 7.16ms | 5.34ms | 1.34x |
| 23,109 chars | 25.58ms | 17.52ms | 1.46x |
| 92,784 chars | 287.59ms | 171.66ms | 1.68x |
| 185,765 chars | 927.82ms | 583.57ms | 1.59x |

The gain grows with document size, as expected for a scan-bounding change.

A reproducible benchmark harness is included under `packages/core/bench` (`pnpm --filter @md/core bench`).

### Known follow-up (not addressed here)

Per-hook timing shows the rewritten scans are now linear (growth exponent ≈ 1.00), but the pipeline as a whole is still superlinear (≈ 1.66) — the extension hooks together account for only ~42ms of the 578ms spent on a 186k-character document, so the dominant cost lies elsewhere and still needs profiling. One leftover unbounded hook was also identified, `blockLatexKatex.start()` (exponent 1.88, ~12ms), and is left for a follow-up so this PR stays limited to changes covered by the verification below.

## Type of Change

- [x] Performance improvement
- [x] Tests

## Test Procedure

- `pnpm --filter @md/core test` — 13 files, 125 tests passing
- `pnpm --filter @md/core exec tsc --noEmit` — clean
- `eslint` on `packages/core` — clean
- **Output parity**: rendered HTML for the four bundled example documents (`zh-CN`, `zh-TW`, `en-US`, `ja-JP`) is **byte-identical** to the previous implementation
- **Re-render stability**: rendering the same document three times in a row produces identical HTML, confirming the new caches introduce no drift
- New unit tests: `utils/scan.test.ts` checks each helper against the behaviour of the regex it replaces, including the scan limit; `extensions/render-memoization.test.ts` checks that highlighting and typesetting are memoized and that pending placeholders are not cached

## Pre-flight Checklist

- [x] Code follows the project's ESLint / Prettier configuration
- [x] Self-reviewed the diff
- [x] Added tests covering the new behaviour
- [x] All existing tests pass
- [x] No user-facing copy changed, so no i18n updates needed
