### PR TITLE
chore(ci): unify GitHub Actions names and pin floating refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Run CI Checks
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cloudflare-preview-cleanup.yml
+++ b/.github/workflows/cloudflare-preview-cleanup.yml
@@ -1,4 +1,4 @@
-name: Cleanup Cloudflare Preview
+name: Cleanup Cloudflare Workers Preview
 
 on:
   pull_request:

--- a/.github/workflows/cloudflare-preview-deploy.yml
+++ b/.github/workflows/cloudflare-preview-deploy.yml
@@ -1,4 +1,4 @@
-name: Cloudflare Workers Preview
+name: Deploy Cloudflare Workers Preview
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: cloudflare-preview-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up pnpm
@@ -32,7 +33,7 @@ jobs:
           install: false
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build for Cloudflare Workers
         run: pnpm web build:h5-netlify

--- a/.github/workflows/deploy-gitee.yml
+++ b/.github/workflows/deploy-gitee.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-gitee-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0  # 获取完整历史，便于推送到新分支
 
       - name: Set up pnpm
@@ -28,7 +29,7 @@ jobs:
           install: false
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build project
         run: pnpm web build
@@ -46,7 +47,7 @@ jobs:
 
       - name: Sync to Gitee
         id: gitee-sync
-        uses: Yikun/hub-mirror-action@master
+        uses: Yikun/hub-mirror-action@ec47170fa9d126a4bee5a1ab9359845bb1395248 # v1.5
         continue-on-error: true
         with:
           src: github/doocs
@@ -61,7 +62,7 @@ jobs:
         id: gitee-deploy
         if: steps.gitee-sync.outcome == 'success'
         continue-on-error: true
-        uses: yanglbme/gitee-pages-action@main
+        uses: yanglbme/gitee-pages-action@b70eff28cd340913f899eab8d0f485b978d78d54 # v1.4.2
         with:
           gitee-username: ${{ secrets.GITEE_USERNAME }}
           gitee-password: ${{ secrets.GITEE_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
           install: false
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run lint
         run: pnpm run lint
@@ -76,6 +76,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/setup@v2
@@ -86,7 +88,7 @@ jobs:
           install: false
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build for Cloudflare Workers
         run: pnpm web build:h5-netlify

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,7 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -11,22 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'doocs/md'
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build and push multi-arch images
-      run: |
-        chmod +x scripts/build-multiarch.sh
-        bash scripts/build-multiarch.sh
+      - name: Build and push multi-arch images
+        run: |
+          chmod +x scripts/build-multiarch.sh
+          bash scripts/build-multiarch.sh

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   contents: write
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Extract Changelog for Tag
         id: changelog

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
-name: Stale Bot
+name: Close Stale Issues
 
 on:
   schedule:
-    - cron: "0 6 * * *" # 每天北京时间 14:00 运行
+    - cron: '0 6 * * *' # 每天北京时间 14:00 运行
 
 jobs:
   stale:
@@ -11,21 +11,22 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v11
+      - name: Mark stale issues
+        uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
           # Issue 设置
           days-before-stale: 60      # 超过 60 天无活动 -> 标记 stale
           days-before-close: 7       # 被标记后 7 天仍无活动 -> 关闭
-          stale-issue-message: "此 Issue 因长期无回复而被标记为过期，如果 7 天内无回复将自动关闭。"
-          close-issue-message: "此 Issue 已因无长期无回复自动关闭。"
+          stale-issue-message: '此 Issue 因长期无回复而被标记为过期，如果 7 天内无回复将自动关闭。'
+          close-issue-message: '此 Issue 已因无长期无回复自动关闭。'
 
           days-before-pr-stale: -1   # 不处理 PR
           days-before-pr-close: -1
 
           # 以下标签不会被标记为 stale
-          exempt-issue-labels: "help wanted, good first issue, never gets stale, enhancement, bug, issue: author provided repro"
+          exempt-issue-labels: 'help wanted, good first issue, never gets stale, enhancement, bug, issue: author provided repro'
 
   stale-needs-author-feedback:
     runs-on: ubuntu-latest
@@ -33,7 +34,8 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v11
+      - name: Close issues waiting for author
+        uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # 仅处理包含 "needs: author feedback" 标签的 Issue
@@ -42,11 +44,11 @@ jobs:
           # Issue 设置
           days-before-stale: 24
           days-before-close: 7
-          stale-issue-message: "此 Issue 已等待作者反馈 24 天，请提供所需信息，否则 7 天后将自动关闭。"
-          close-issue-message: "此 Issue 因作者未在 7 天内提供所需反馈而自动关闭。"
+          stale-issue-message: '此 Issue 已等待作者反馈 24 天，请提供所需信息，否则 7 天后将自动关闭。'
+          close-issue-message: '此 Issue 因作者未在 7 天内提供所需反馈而自动关闭。'
 
           days-before-pr-stale: -1   # 不处理 PR
           days-before-pr-close: -1
 
           # 以下标签不会被标记为 stale
-          exempt-issue-labels: "help wanted, good first issue, never gets stale, enhancement, bug, issue: author provided repro"
+          exempt-issue-labels: 'help wanted, good first issue, never gets stale, enhancement, bug, issue: author provided repro'

--- a/.github/workflows/starcharts.yml
+++ b/.github/workflows/starcharts.yml
@@ -2,7 +2,7 @@ name: Update Starcharts
 
 on:
   schedule:
-    - cron: "0 0/12 * * *"
+    - cron: '0 0/12 * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'doocs/md'
     steps:
       - name: Generate Starcharts
-        uses: MaoLongLong/actions-starcharts@main
+        uses: MaoLongLong/actions-starcharts@de0ebd5ddf5c5f19bf2b18e9a47b29c8cdfebc8d # v2.0.1
         with:
           github_token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
           svg_path: images/starcharts.svg

--- a/.github/workflows/surge-preview-build.yml
+++ b/.github/workflows/surge-preview-build.yml
@@ -1,8 +1,12 @@
-name: Surge Preview Build
+name: Build Surge Preview
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-preview:
@@ -12,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up pnpm
@@ -22,10 +27,11 @@ jobs:
           cache: true
           install: false
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Build
-        run: |
-          pnpm install
-          pnpm web build:h5-netlify
+        run: pnpm web build:h5-netlify
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/surge-preview-deploy.yml
+++ b/.github/workflows/surge-preview-deploy.yml
@@ -1,8 +1,8 @@
-name: Surge Preview Deploy
+name: Deploy Surge Preview
 
 on:
   workflow_run:
-    workflows: ["Surge Preview Build"]
+    workflows: ['Build Surge Preview']
     types:
       - completed
 
@@ -122,7 +122,7 @@ jobs:
               });
             }
 
-  failed:
+  notify-build-failure:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' && github.repository == 'doocs/md'
     steps:


### PR DESCRIPTION
## Summary

GitHub Actions filenames, workflow titles, and a few CI conventions were inconsistent. This PR only normalizes style and pins three floating third-party actions — job IDs used by required checks (`lint`, `type-check`, `test`) are unchanged.

- Rename `lint.yml` → `ci.yml`, `stale-bot.yml` → `stale.yml`, `cloudflare-preview.yml` → `cloudflare-preview-deploy.yml`
- Workflow titles use a verb + object phrase (e.g. `Run CI Checks`, `Deploy Surge Preview`)
- Update Surge `workflow_run` to listen for `Build Surge Preview`
- One concurrency group: `${{ github.workflow }}-${{ github.ref }}`
- Checkout steps set `persist-credentials: false`; `pnpm install` uses `--frozen-lockfile`
- Pin `hub-mirror-action` (v1.5), `gitee-pages-action` (v1.4.2), and `actions-starcharts` (v2.0.1) to commit SHAs

## Type of Change

- [x] Workflow / CI

## Test Procedure

- Review the workflow list in the Actions tab after merge: new titles should appear, old file names should disappear
- Confirm required status checks still resolve to the `lint` / `type-check` / `test` jobs
- Confirm a subsequent PR still triggers Build Surge Preview → Deploy Surge Preview

## Pre-flight Checklist

- [x] Code follows the project's ESLint / Prettier configuration
- [x] Self-reviewed the diff
- [x] No application code or user-facing copy changed
