### PR TITLE
fix(editor): gate SidebarAIToolbar by showAIToolbox preference

### DIFF
--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -62,7 +62,7 @@ function onWrapperContextMenuCapture(e: MouseEvent) {
 }
 
 const { editor } = storeToRefs(editorStore)
-const { isDark } = storeToRefs(uiStore)
+const { isDark, showAIToolbox } = storeToRefs(uiStore)
 const { posts, currentPostIndex, currentPost } = storeToRefs(postStore)
 const {
   isMobile,
@@ -698,6 +698,7 @@ defineExpose({
       @close="closeSlashMenu()"
     />
     <SidebarAIToolbar
+      v-if="showAIToolbox"
       :is-mobile="isMobile"
       :show-editor="showEditor"
     />

--- a/apps/web/src/i18n/messages/en-US/dialog.ts
+++ b/apps/web/src/i18n/messages/en-US/dialog.ts
@@ -243,8 +243,8 @@ export default {
       hint: `Sync editor and preview scrolling`,
     },
     showAIToolbox: {
-      label: `AI toolbox`,
-      hint: `Show floating AI tools when text is selected`,
+      label: `AI toolbar`,
+      hint: `Show the AI assistant, image generator, and toolbox on the editor edge`,
     },
     imageReupload: {
       label: `Image re-upload`,

--- a/apps/web/src/i18n/messages/en-US/editor.ts
+++ b/apps/web/src/i18n/messages/en-US/editor.ts
@@ -118,7 +118,7 @@ export default {
       isUseJustify: `Justify text`,
       isOpenRightSlider: `Right slider open`,
       isOpenPostSlider: `Post slider open`,
-      showAIToolbox: `AI toolbox`,
+      showAIToolbox: `AI toolbar`,
       theme: `Theme`,
       fontFamily: `Font family`,
       fontSize: `Font size`,

--- a/apps/web/src/i18n/messages/ja-JP/dialog.ts
+++ b/apps/web/src/i18n/messages/ja-JP/dialog.ts
@@ -243,8 +243,8 @@ export default {
       hint: `エディターとプレビューのスクロールを同期`,
     },
     showAIToolbox: {
-      label: `AI ツールボックス`,
-      hint: `テキスト選択時にフローティング AI ツールを表示`,
+      label: `AI ツールバー`,
+      hint: `エディター右側に AI アシスタント、画像生成、ツールボックスを表示`,
     },
     imageReupload: {
       label: `画像の再アップロード`,

--- a/apps/web/src/i18n/messages/ja-JP/editor.ts
+++ b/apps/web/src/i18n/messages/ja-JP/editor.ts
@@ -118,7 +118,7 @@ export default {
       isUseJustify: `両端揃え`,
       isOpenRightSlider: `右スライダーを開く`,
       isOpenPostSlider: `投稿スライダーを開く`,
-      showAIToolbox: `AI ツールボックス`,
+      showAIToolbox: `AI ツールバー`,
       theme: `テーマ`,
       fontFamily: `フォントファミリー`,
       fontSize: `フォントサイズ`,

--- a/apps/web/src/i18n/messages/zh-CN/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-CN/dialog.ts
@@ -243,8 +243,8 @@ export default {
       hint: `编辑区与预览区滚动联动`,
     },
     showAIToolbox: {
-      label: `AI 工具箱`,
-      hint: `选中文本时显示浮动 AI 工具`,
+      label: `AI 工具栏`,
+      hint: `在编辑区右侧显示 AI 助手、生图和工具箱`,
     },
     imageReupload: {
       label: `图片转存`,

--- a/apps/web/src/i18n/messages/zh-CN/editor.ts
+++ b/apps/web/src/i18n/messages/zh-CN/editor.ts
@@ -118,7 +118,7 @@ export default {
       isUseJustify: `使用两端对齐`,
       isOpenRightSlider: `开启右侧滑块`,
       isOpenPostSlider: `开启右侧发布滑块`,
-      showAIToolbox: `AI 工具箱状态`,
+      showAIToolbox: `AI 工具栏状态`,
       theme: `主题`,
       fontFamily: `字体`,
       fontSize: `字体大小`,

--- a/apps/web/src/i18n/messages/zh-TW/dialog.ts
+++ b/apps/web/src/i18n/messages/zh-TW/dialog.ts
@@ -243,8 +243,8 @@ export default {
       hint: `編輯區與預覽區滾動聯動`,
     },
     showAIToolbox: {
-      label: `AI 工具箱`,
-      hint: `選中文本時顯示浮動 AI 工具`,
+      label: `AI 工具列`,
+      hint: `在編輯區右側顯示 AI 助手、生圖和工具箱`,
     },
     imageReupload: {
       label: `圖片轉存`,

--- a/apps/web/src/i18n/messages/zh-TW/editor.ts
+++ b/apps/web/src/i18n/messages/zh-TW/editor.ts
@@ -118,7 +118,7 @@ export default {
       isUseJustify: `使用兩端對齊`,
       isOpenRightSlider: `開啟右側滑塊`,
       isOpenPostSlider: `開啟右側釋出滑塊`,
-      showAIToolbox: `AI 工具箱狀態`,
+      showAIToolbox: `AI 工具列狀態`,
       theme: `主題`,
       fontFamily: `字型`,
       fontSize: `字型大小`,


### PR DESCRIPTION
The SidebarAIToolbar was always rendered regardless of the "AI toolbox" preference in the settings dialog, so users who turned the floating toolbar off still saw it. Tie the render to the existing 'showAIToolbox' reactive flag in the UI store.