### PR TITLE
docs: align contributing guides and agent PR workflow

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -7,6 +7,8 @@ description: Create a GitHub pull request following project conventions. Use whe
 
 This skill guides you through creating a well-structured GitHub pull request that follows project conventions and best practices.
 
+Do **not** assume Bash. On Windows PowerShell, avoid `&&`, `$(...)`, and POSIX tests; run git/`gh` commands as separate invocations and use `$env:TEMP` for the PR body file.
+
 ## Prerequisites Check
 
 Before proceeding, verify the following:
@@ -53,16 +55,15 @@ Ensure you're not on `main` or `master`. If so, ask the user to create or switch
 
 ### 2. Find the base branch
 
-Determine the default branch once and reuse it as `BASE_BRANCH` in all later commands:
+Resolve the default branch once and reuse it as `BASE_BRANCH`. Do **not** assume Bash (`$(...)`, `sed`, `[ -z ... ]` fail in PowerShell).
 
 ```bash
-BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-
-# Fallback when origin/HEAD is not configured
-if [ -z "$BASE_BRANCH" ]; then
-  BASE_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
-fi
+git symbolic-ref refs/remotes/origin/HEAD
 ```
+
+This prints `refs/remotes/origin/<branch>` (usually `main`). Use the last path segment.
+
+If that fails, run `git remote show origin` and parse the `HEAD branch:` line.
 
 This is typically `main` or `master`, but may differ per repo.
 
@@ -141,7 +142,7 @@ git push origin HEAD --force-with-lease
 
 ## Create the Pull Request
 
-Use `CONTRIBUTING.md` (Pull Request 流程) as the source of truth for PR content. If `.github/pull_request_template.md` exists, follow that template exactly. Otherwise, use this structure:
+Use `CONTRIBUTING.md` (Pull Request 流程) as the source of truth for PR content. Follow [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) exactly:
 
 - **Summary** — what changed and why
 - **Related Issue** — only when a real issue is linked (e.g. `Closes #123`); omit entirely if none
@@ -159,19 +160,23 @@ When filling out the PR body:
 
 **Use a temporary file for the PR body** to avoid shell escaping issues, newline problems, and other command-line flakiness:
 
-1. Write the PR body to a temporary file (e.g. `$env:TEMP/pr-body.md` on Windows, `/tmp/pr-body.md` on macOS/Linux).
+1. Write the PR body to a temporary file (`$env:TEMP/pr-body.md` on Windows PowerShell, `/tmp/pr-body.md` on macOS/Linux).
 
 2. Create the PR using the file:
+
    ```bash
+   # Bash / zsh
    gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base "$BASE_BRANCH"
+   ```
+
+   ```powershell
+   # PowerShell
+   gh pr create --title "PR_TITLE" --body-file "$env:TEMP/pr-body.md" --base $BASE_BRANCH
    ```
 
 3. Clean up the temporary file after the PR is created.
 
-For draft PRs:
-```bash
-gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base "$BASE_BRANCH" --draft
-```
+For draft PRs, add `--draft` to the same command.
 
 **Why use a file?** Passing complex markdown with newlines, special characters, and checkboxes directly via `--body` is error-prone. The `--body-file` flag handles all content reliably.
 

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -2,7 +2,6 @@
 name: git-commit
 description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Creating a feature branch when on main/master before committing, (3) Generating conventional commit messages from diff, (4) Interactive commit with optional type/scope/description overrides, (5) Intelligent file staging for logical grouping'
 license: MIT
-allowed-tools: Bash
 ---
 
 # Git Commit with Conventional Commits
@@ -48,6 +47,14 @@ feat: allow config to extend other configs
 
 BREAKING CHANGE: `extends` key behavior changed
 ```
+
+## Host shell
+
+Do **not** assume Bash. Cursor on Windows uses PowerShell, where `&&`, `$(cat <<'EOF')`, and POSIX `[ -z ... ]` fail.
+
+- Prefer **separate git invocations** over chained one-liners.
+- If you must chain: PowerShell uses `;` (or separate calls). Bash/zsh may use `&&`.
+- Examples below show Bash and PowerShell when the syntax differs.
 
 ## Workflow
 
@@ -128,11 +135,16 @@ Analyze the diff to determine:
 
 ### 5. Execute Commit
 
-```bash
-# Single line
-git commit -m "<type>[scope]: <description>"
+Single line (any shell):
 
-# Multi-line with body/footer
+```bash
+git commit -m "<type>[scope]: <description>"
+```
+
+Multi-line with body/footer:
+
+```bash
+# Bash / zsh
 git commit -m "$(cat <<'EOF'
 <type>[scope]: <description>
 
@@ -141,6 +153,17 @@ git commit -m "$(cat <<'EOF'
 <optional footer>
 EOF
 )"
+```
+
+```powershell
+# PowerShell
+git commit -m @"
+<type>[scope]: <description>
+
+<optional body>
+
+<optional footer>
+"@
 ```
 
 ## Best Practices
@@ -161,6 +184,6 @@ EOF
 
 ## Project Notes (doocs/md)
 
-- Commit messages must be in **English** (see `AGENTS.md`)
+- Commit messages and PR titles must be in **English** (see `AGENTS.md` and `CONTRIBUTING.md`)
 - Branch naming: `feat/`, `fix/`, `docs/` per `CONTRIBUTING.md`; for other commit types use `<type>/` prefix; never commit on `main`/`master` — create a branch first (step 2)
 - Pre-commit runs `eslint --fix` via lint-staged; if the hook modifies files, fix and create a new commit instead of amending

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,57 +1,98 @@
 # Copilot Instructions
 
-This repository is a pnpm monorepo containing a Vue 3 web application, a VSCode extension, and a core markdown rendering library.
+This repository is a pnpm monorepo for **doocs/md**, a WeChat Markdown editor. Canonical agent guidance lives in [AGENTS.md](../AGENTS.md); keep this file aligned with it.
+
+- **Node:** `>=22.22.2` (`.nvmrc`: v22.22.2)
+- **Package manager:** pnpm (`packageManager` in the root `package.json`)
+- **npm registry:** https://registry.npmmirror.com (`.npmrc`)
 
 ## Build, Test, and Lint
 
 ### Global Commands
-- **Install Dependencies:** `pnpm install`
+
+- **Install:** `pnpm install`
 - **Lint (ESLint + Prettier):** `pnpm run lint`
-- **Type Check (Vue/TS):** `pnpm run type-check`
+- **Type Check:** `pnpm run type-check`
+- **Tests:** `pnpm run test` (`@md/shared`, `@md/core`, `@md/web`, `@md/api`)
 
-### Web App (@md/web)
+### Web App (`@md/web`)
+
 - **Development Server:** `pnpm web dev`
-- **Build for Production:** `pnpm web build`
-- **Build Browser Extension:** `pnpm web ext:zip` (uses WXT)
+- **Production Build:** `pnpm web build`
+- **Browser Extension:** `pnpm web ext:zip` (WXT; Chrome) / `pnpm web firefox:zip`
 
-### VSCode Extension (@md/vscode)
-- **Development:** `pnpm vscode`
+### Other Workspaces
 
-### CLI (@doocs/md-cli)
-- **Build CLI:** `pnpm run build:cli`
+- **API (`@md/api`):** `pnpm api dev` / `pnpm api test`
+- **VS Code (`doocs-md`):** `pnpm vscode compile` / `pnpm vscode package`
+- **CLI (`@doocs/md-cli`):** `pnpm run build:cli`
+- **MCP (`@md/mcp-server`):** `pnpm mcp dev`
+- **uTools (`@md/utools`):** `pnpm utools:package`
 
 ## High-Level Architecture
 
 ### Monorepo Structure
-- **apps/web**: The main application. Built with Vue 3, Vite, Pinia, and Tailwind CSS. It functions as both a web app and a browser extension (via WXT).
-- **packages/core**: The markdown rendering engine. It wraps `marked` and implements custom extensions (Mermaid, PlantUML, Ruby, etc.) and theme injection.
-- **packages/shared**: Shared utilities and configurations.
-- **packages/md-cli**: A CLI wrapper that serves the built web application.
+
+- **`apps/web`**: Vue 3 + Vite + Pinia + Tailwind CSS 4. Web app and browser extension (WXT).
+- **`apps/api`**: Cloudflare Workers + Hono + D1 (auth, cloud sync, billing, upload, share, marketplace, emoji).
+- **`apps/vscode`**: VS Code extension (webpack). Marketplace ID: `doocs.doocs-md`.
+- **`apps/utools`**: uTools plugin packaging shell (artifacts from `@md/web`).
+- **`packages/core`**: Markdown renderer (`marked` + custom extensions, theme CSS variables).
+- **`packages/shared`**: Shared config, types, CodeMirror wrapper, theme CSS.
+- **`packages/config`**: Shared TypeScript config.
+- **`packages/md-cli`**: Published npm CLI that serves the built web app.
+- **`packages/mcp-server`**: MCP tools (`render_markdown`, `list_themes`, `list_colors`).
+- **`docs/examples/wechat-openapi-worker/`**: standalone WeChat OpenAPI proxy (not in the pnpm workspace).
+
+Details: [docs/architecture.md](../docs/architecture.md).
 
 ### Key Technologies
-- **Frontend Framework:** Vue 3 (Composition API)
-- **Build System:** Vite
-- **State Management:** Pinia
-- **Styling:** Tailwind CSS + Custom CSS Variables for themes.
-- **Markdown Parsing:** `marked` (in `@md/core`)
-- **Editor Component:** CodeMirror 6
-- **Extension Framework:** WXT (Web Extension Tools)
+
+- **Frontend:** Vue 3 (Composition API), Pinia, Tailwind CSS 4 + PostCSS
+- **Editor:** CodeMirror 6
+- **Markdown:** `marked` in `@md/core`; `juice` inlines CSS for WeChat paste; `isomorphic-dompurify` sanitizes output
+- **Web build:** Vite 8; extension build: WXT
+- **API:** Hono on Cloudflare Workers, D1
+- **i18n (web only):** `vue-i18n` — zh-CN, zh-TW, en-US, ja-JP
 
 ## Key Conventions
 
 ### Development Patterns
-- **Direct TypeScript Imports:** The `@md/core` and `@md/shared` packages export TypeScript source files directly (`src/index.ts`). Do not attempt to build these packages separately; they are compiled by the consumer's build tool (Vite).
-- **UI Components:** The project uses Shadcn-Vue style components located in `apps/web/src/components/ui`. Prefer using these over raw HTML/CSS.
-- **Store Structure:** State is divided into domain-specific Pinia stores (e.g., `useEditorStore`, `useThemeStore`, `useUiStore`) located in `apps/web/src/stores`.
+
+- **`@md/core` and `@md/shared` export TypeScript source** (`src/index.ts`). Do not pre-build them; consumers (Vite/webpack) compile them.
+- **UI:** Shadcn-Vue components in `apps/web/src/components/ui`. Prefer these over raw HTML/CSS.
+- **Stores:** Domain Pinia stores in `apps/web/src/stores` (`useEditorStore`, `useThemeStore`, `useUiStore`, `useLocaleStore`, …).
+- **Comments:** English only. Explain non-obvious why / constraints; do not narrate the next line. Do not rewrite user-facing i18n copy unless asked.
+
+### Internationalization (`@md/web`)
+
+- Messages: `apps/web/src/i18n/messages/{zh-CN,zh-TW,en-US,ja-JP}/`
+- Components: `useI18n()` + `t('key')`. Stores/utils: `@/i18n/translate`.
+- New user-visible strings must be added in all four locales. VS Code, uTools, CLI, and MCP are not localized.
 
 ### Styling & Theming
-- **Theme Injection:** Theming is handled by `@md/core/src/theme`. Themes are applied by injecting CSS variables into the DOM.
-- **CSS processing:** Uses PostCSS and Tailwind. Global styles are in `apps/web/src/assets`.
+
+- Theme injection: `@md/core/src/theme` (CSS variables).
+- Theme CSS sources: `packages/shared/src/configs/theme-css/` (`default.css`, `grace.css`, `simple.css`).
 
 ### Markdown Extensions
-- **Implementation:** New markdown features should be implemented as extensions in `@md/core/src/extensions`.
-- **Registration:** Extensions must be registered in the renderer configuration.
+
+- Implement new Markdown features as extensions in `packages/core/src/extensions`.
+- Register them in the renderer configuration.
+
+### Dependencies
+
+- Shared toolchain versions live in `pnpm-workspace.yaml` `catalog`; workspace packages use `"catalog:"`.
+- Root `package.json` is publishable (`private: false`) — use plain semver there, not `catalog:`.
+- Prettier is pinned to **2.8.8**. Do not remove security `overrides` unless upstream fixed the CVE.
+- If a patched dependency is upgraded, update the matching file in `patches/` and `patchedDependencies`.
 
 ### Git Conventions
-- **Commit Messages:** Follow Conventional Commits (`feat`, `fix`, `docs`, `chore`, etc.).
-- **Branch Naming:** `feat/description`, `fix/description`.
+
+- **Commit messages and PR titles:** Conventional Commits, **English** (`feat`, `fix`, `docs`, `chore`, …).
+- **Branches:** `feat/description`, `fix/description`, `docs/description`; other types use `<type>/`.
+- Never commit on `main`. Follow `.github/pull_request_template.md` when opening a PR.
+
+### Agent Skills
+
+Canonical workflows: `.agents/skills/` (`git-commit`, `create-pr`, `wechat-svg`). Claude Code discovers them via git symlinks under `.claude/skills/`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What changed and why / 变更动机与实现要点 -->
+
+## Related Issue
+
+<!-- Optional. Use `Closes #123` when this PR fixes an issue. Delete this section if none. -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor
+- [ ] Documentation / workflow update
+- [ ] Test
+
+## Test Procedure
+
+<!-- How you verified the change / 如何验证 -->
+
+- [ ]
+
+## Pre-flight Checklist
+
+- [ ] Self-review of the diff
+- [ ] `pnpm run lint` passes
+- [ ] Tests added or updated when behavior changes
+- [ ] User-facing copy updated in zh-CN, zh-TW, en-US, and ja-JP when UI text changes
+- [ ] Docs updated when public API or contributor workflow changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,9 @@ Web 主应用与部分浏览器扩展 UI 支持 **zh-CN**、**zh-TW**、**en-US*
 
 ## Git 规范
 
-- **提交信息:** 遵循 Conventional Commits（`feat`、`fix`、`docs`、`style`、`refactor`、`perf`、`test`、`build`、`chore`），**一律使用英文**
-- **分支命名:** `feat/description`、`fix/description`
+- **提交信息 / PR 标题:** 遵循 Conventional Commits（`feat`、`fix`、`docs`、`style`、`refactor`、`perf`、`test`、`build`、`chore`），**一律使用英文**（见 `CONTRIBUTING.md`）
+- **分支命名:** `feat/description`、`fix/description`、`docs/description`；其他类型用 `<type>/`
+- **PR 说明:** 按 [`.github/pull_request_template.md`](./.github/pull_request_template.md) 填写；无关联 Issue 时不要写 Related Issue 占位符
 
 ## Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,26 +20,28 @@
 
 ## 前置条件
 
-- **Node.js ≥ 22**
+- **Node.js ≥ 22.22.2**（见 `.nvmrc`）
 - **pnpm ≥ 10**
 
 ## 快速开始
 
-该项目为 pnpm monorepo 项目，使用 pnpm 管理依赖。
+该项目为 pnpm monorepo 项目，使用 pnpm 管理依赖。完整架构见 [docs/architecture.md](./docs/architecture.md)。
 
 项目结构如下：
 
-```shell
-- apps
-  - web           # 网页及浏览器插件
-  - vscode        # VSCode 插件
-- packages
-  - config        # 项目级别配置
-  - core          # 核心 markdown 渲染器
-  - shared        # 共享的配置、常量、类型和工具函数
-  - example       # 公众号 openapi 接口代理服务示例
-  - md-cli        # 命令行工具
-```
+| 工作区           | 路径                  | 说明                               |
+| ---------------- | --------------------- | ---------------------------------- |
+| `@md/web`        | `apps/web`            | Vue 3 主应用与浏览器扩展（WXT）    |
+| `doocs-md`       | `apps/vscode`         | VS Code 扩展                       |
+| `@md/utools`     | `apps/utools`         | uTools 插件打包                    |
+| `@md/api`        | `apps/api`            | 账户、云同步、计费、分享与市场 API |
+| `@md/core`       | `packages/core`       | Markdown 渲染引擎                  |
+| `@md/shared`     | `packages/shared`     | 共享配置、类型与工具               |
+| `@md/config`     | `packages/config`     | 共享 TypeScript 配置               |
+| `@doocs/md-cli`  | `packages/md-cli`     | CLI（托管构建产物）                |
+| `@md/mcp-server` | `packages/mcp-server` | MCP 服务                           |
+
+独立示例（不在 pnpm workspace 内）：`docs/examples/wechat-openapi-worker/`。
 
 以开发 `@md/web` 为例：
 
@@ -79,7 +81,7 @@ pnpm web dev
    ```bash
    pnpm run lint        # ESLint + Prettier
    pnpm run type-check  # TypeScript 类型检查
-   pnpm run web build       # 产物验证
+   pnpm web build       # 产物验证
    ```
 
 5. 提交并推送：
@@ -90,7 +92,7 @@ pnpm web dev
    git push origin feat/awesome-feature
    ```
 
-6. 在 GitHub 页面发起 **Pull Request**。
+6. 在 GitHub 页面发起 **Pull Request**，并按 [`.github/pull_request_template.md`](./.github/pull_request_template.md) 填写说明。
 
 > [!TIP]
 > 开发时可在 `apps/web` 目录下新建 `.env.local` 文件，配置 `VITE_LAUNCH_EDITOR` 为 `code` （默认值）或其他 [支持的编辑器](https://github.com/yyx990803/launch-editor?tab=readme-ov-file#supported-editors)，方便调试。
@@ -107,8 +109,11 @@ pnpm web dev
 - 所有提交必须通过 `pnpm run lint` 检查，无警告、无错误。
 - 推荐在 IDE 中启用 **ESLint** 与 **Prettier** 自动修复。
 - **代码注释统一使用英文。** 只写非显而易见的 why / 约束 / 坑；删除复述代码的噪音注释。用户可见文案（i18n）不受此限制。
+- Web 主应用新增用户可见文案须同时维护 **zh-CN**、**zh-TW**、**en-US**、**ja-JP**。
 
 ## 提交规范
+
+提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/)，**标题与描述一律使用英文**（与 `AGENTS.md` 一致）。
 
 | 类型     | 说明                       |
 | -------- | -------------------------- |
@@ -125,22 +130,24 @@ pnpm web dev
 ### Branch 命名
 
 ```
-feat/<简要描述>
-fix/<简要描述>
-docs/<简要描述>
+feat/<short-description>
+fix/<short-description>
+docs/<short-description>
 ```
+
+其他类型使用对应前缀，例如 `chore/<short-description>`、`test/<short-description>`。
 
 ### Pull Request 标题
 
-保持与首条 commit message 一致，建议附带影响范围（Scope）与简要描述，例如：
+保持与首条 commit message 一致，使用英文 Conventional Commit 格式，建议附带影响范围（Scope），例如：
 
 ```
-feat(editor): 支持自定义快捷键
+feat(editor): add custom keyboard shortcuts
 ```
 
 ## Pull Request 流程
 
-1. **描述清晰**：在 PR 模板中说明变更动机、相关 Issue、实现方案及影响范围。
+1. **描述清晰**：在 [PR 模板](./.github/pull_request_template.md) 中说明变更动机、实现方案及影响范围。仅在确实修复某个 Issue 时填写 Related Issue（如 `Closes #123`），不要留占位符。
 2. **保持小而聚焦**：一个 PR 只做一件事，方便审阅。
 3. **确保测试**：新增/变更功能需自测，确保没问题。
 4. **更新文档**：公共 API 或行为变更必须同步更新文档。

--- a/apps/api/src/marketplace.test.ts
+++ b/apps/api/src/marketplace.test.ts
@@ -1,0 +1,67 @@
+import type { Env } from './types'
+import { describe, expect, it } from 'vitest'
+import app from './index'
+
+function stubD1(options?: { first?: unknown, results?: unknown[] }) {
+  const stmt = {
+    bind: (..._args: unknown[]) => stmt,
+    first: async () => options?.first ?? null,
+    all: async () => ({ results: options?.results ?? [] }),
+    run: async () => ({ meta: { changes: 0 } }),
+  }
+  return {
+    prepare: () => stmt,
+  } as unknown as D1Database
+}
+
+describe(`marketplace authentication`, () => {
+  const env = {
+    JWT_SECRET: `test-secret`,
+  } as Env
+
+  it.each([
+    [`GET`, `/marketplace/me`],
+    [`POST`, `/marketplace/themes`],
+    [`POST`, `/marketplace/components`],
+    [`PATCH`, `/marketplace/item-id`],
+    [`DELETE`, `/marketplace/item-id`],
+    [`GET`, `/marketplace/admin/pending`],
+    [`POST`, `/marketplace/admin/item-id/approve`],
+    [`POST`, `/marketplace/admin/item-id/reject`],
+  ])(`requires auth for %s %s`, async (method, path) => {
+    const response = await app.request(`https://api.example${path}`, { method }, env)
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: `unauthorized` })
+  })
+})
+
+describe(`marketplace public browse`, () => {
+  const env = {
+    JWT_SECRET: `test-secret`,
+    DB: stubD1({ first: { total: 0 }, results: [] }),
+  } as Env
+
+  it.each([
+    `/marketplace/themes`,
+    `/marketplace/components`,
+  ])(`lists an empty catalog for %s`, async (path) => {
+    const response = await app.request(`https://api.example${path}`, {}, env)
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    })
+  })
+
+  it(`returns 404 for a missing item`, async () => {
+    const missing = {
+      JWT_SECRET: `test-secret`,
+      DB: stubD1(),
+    } as Env
+    const response = await app.request(`https://api.example/marketplace/missing-id`, {}, missing)
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: `not_found` })
+  })
+})

--- a/apps/api/src/share.test.ts
+++ b/apps/api/src/share.test.ts
@@ -1,0 +1,53 @@
+import type { Env } from './types'
+import { describe, expect, it } from 'vitest'
+import app from './index'
+
+function stubD1(options?: { first?: unknown, results?: unknown[] }) {
+  const stmt = {
+    bind: (..._args: unknown[]) => stmt,
+    first: async () => options?.first ?? null,
+    all: async () => ({ results: options?.results ?? [] }),
+    run: async () => ({ meta: { changes: 0 } }),
+  }
+  return {
+    prepare: () => stmt,
+  } as unknown as D1Database
+}
+
+describe(`share manage authentication`, () => {
+  const env = {
+    JWT_SECRET: `test-secret`,
+  } as Env
+
+  it.each([
+    [`GET`, `/share`],
+    [`POST`, `/share`],
+    [`DELETE`, `/share/aaaaaaaaaaaa`],
+  ])(`requires auth for %s %s`, async (method, path) => {
+    const response = await app.request(`https://api.example${path}`, { method }, env)
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: `unauthorized` })
+  })
+})
+
+describe(`share public routes`, () => {
+  const env = {
+    JWT_SECRET: `test-secret`,
+    DB: stubD1(),
+  } as Env
+
+  it.each([
+    [`GET`, `/s/not-a-share-id`],
+    [`POST`, `/s/not-a-share-id/unlock`],
+  ])(`rejects malformed share ids for %s %s`, async (method, path) => {
+    const response = await app.request(`https://api.example${path}`, { method }, env)
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe(`Not Found`)
+  })
+
+  it(`returns 404 when a well-formed share id does not exist`, async () => {
+    const response = await app.request(`https://api.example/s/aaaaaaaaaaaa`, {}, env)
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe(`Not Found`)
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@
 ### 依赖关系
 
 ```
-apps (web / vscode / mcp-server)
+apps/web, apps/vscode, packages/mcp-server
   └── @md/core
         └── @md/shared
               └── @md/config (dev)


### PR DESCRIPTION
﻿## Summary

- Add `.github/pull_request_template.md` and point `CONTRIBUTING.md`, `AGENTS.md`, and the `create-pr` skill at it.
- Refresh the contributor/Copilot docs: current monorepo map, English conventional-commit titles, `pnpm web build`, and i18n locale requirements.
- Make `git-commit` / `create-pr` skills shell-neutral for PowerShell, and add share/marketplace API route tests (401 and public 404/empty catalog).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor
- [x] Documentation / workflow update
- [x] Test

## Test Procedure

- [x] `@md/api` Vitest: 13 files, 85 tests passed
- [x] Confirmed `CONTRIBUTING.md` uses `pnpm web build` and English PR title examples
- [x] Confirmed `git-commit` and `create-pr` skills include PowerShell examples
- [ ] CI lint, type-check, and tests pass on this PR

## Pre-flight Checklist

- [x] Self-review of the diff
- [x] `pnpm run lint` passes
- [x] Tests added or updated when behavior changes
- [x] User-facing copy updated in zh-CN, zh-TW, en-US, and ja-JP when UI text changes
- [x] Docs updated when public API or contributor workflow changes
