### PR TITLE
docs: sync AGENTS.md and drop unused Related Issue from PR template

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -145,16 +145,15 @@ git push origin HEAD --force-with-lease
 Use `CONTRIBUTING.md` (Pull Request 流程) as the source of truth for PR content. Follow [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) exactly:
 
 - **Summary** — what changed and why
-- **Related Issue** — only when a real issue is linked (e.g. `Closes #123`); omit entirely if none
 - **Type of Change** — check applicable boxes
 - **Test Procedure** — how you verified the change
 - **Pre-flight Checklist** — mark items that apply
 
 When filling out the PR body:
-- Include **Related Issue** only when a real issue number is known (e.g. `Closes #123`). **Do not** add a Related Issue section or `#XXXX` placeholder when there is no linked issue.
-- Fill in all other sections with relevant information gathered from commits and context
+- Fill in all template sections with relevant information gathered from commits and context
 - Mark the appropriate "Type of Change" checkbox(es)
 - Complete the "Pre-flight Checklist" items that apply
+- **Related Issue is not in the template.** Add a `## Related Issue` section with `Closes #123` only when this PR actually fixes an issue. Never add `#XXXX` or an empty Related Issue heading.
 
 ### Create PR with gh CLI
 
@@ -214,7 +213,7 @@ Before finalizing, ensure:
 - [ ] Working directory is clean
 - [ ] All commits are pushed
 - [ ] Branch is up-to-date with base branch
-- [ ] Related Issue section included only when a real issue is linked (no `#XXXX` placeholder)
+- [ ] Related Issue included only when a real issue is linked (no empty heading, no `#XXXX` placeholder)
 - [ ] PR description follows the template or project conventions
 - [ ] Appropriate type of change is selected
 - [ ] Pre-flight checklist items are addressed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,6 @@
 
 <!-- What changed and why / 变更动机与实现要点 -->
 
-## Related Issue
-
-<!-- Optional. Use `Closes #123` when this PR fixes an issue. Delete this section if none. -->
-
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,17 @@
 
 ## Monorepo 结构
 
-| 工作区           | 路径                  | 说明                                                                 |
-| ---------------- | --------------------- | -------------------------------------------------------------------- |
-| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox）                    |
-| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID: `doocs.doocs-md`）       |
-| `@md/utools`     | `apps/utools`         | uTools 插件打包                                                      |
-| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）                        |
-| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置                                 |
-| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                                              |
-| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）                                 |
-| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                                       |
-| `@md/api`        | `apps/api`            | 后端 API：账户登录 + 云同步 + 计费（Cloudflare Workers + Hono + D1） |
+| 工作区           | 路径                  | 说明                                                                       |
+| ---------------- | --------------------- | -------------------------------------------------------------------------- |
+| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox）                          |
+| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID: `doocs.doocs-md`）             |
+| `@md/utools`     | `apps/utools`         | uTools 插件打包                                                            |
+| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）                              |
+| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置                                       |
+| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                                                    |
+| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）                                       |
+| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                                             |
+| `@md/api`        | `apps/api`            | 后端 API：账户、云同步、计费、分享与市场（Cloudflare Workers + Hono + D1） |
 
 独立示例（不在 workspace 内）：`docs/examples/wechat-openapi-worker/` — 微信公众号 OpenAPI 代理 Worker。
 
@@ -108,7 +108,7 @@ pnpm mcp dev          # MCP Server 监听模式
 Web 主应用与部分浏览器扩展 UI 支持 **zh-CN**、**zh-TW**、**en-US**、**ja-JP**；VS Code 扩展、uTools、CLI、MCP **未**国际化。
 
 - **库**：`vue-i18n`（composition API，`legacy: false`），在 `apps/web/vite.config.ts` 中通过 `unplugin-auto-import` 自动导入 `useI18n`
-- **文案**：`apps/web/src/i18n/messages/{zh-CN,zh-TW,en-US,ja-JP}/`（`common`、`editor`、`dialog`、`store`、`ai`、`upload`、`chrome`）
+- **文案**：`apps/web/src/i18n/messages/{zh-CN,zh-TW,en-US,ja-JP}/`（`common`、`editor`、`dialog`、`store`、`ai`、`upload`、`chrome`、`marketplace`、`notifications`）
 - **组件内**：`useI18n()` + `t('key')`；**Store / 工具函数**：`@/i18n/translate` 的 `t()` / `getLocale()` / `formatLocalDateTime()`
 - **语言状态**：`useLocaleStore`（持久化 key：`locale`）；用户可在 **偏好设置**（`Ctrl+,`）→ General 切换
 - **启动**：`await initStorage()` → `setupI18n(detectInitialLocale())` → Pinia → `useLocaleStore()`（见 `apps/web/src/bootstrap.ts`）；`index.html` 启动屏从 `localStorage` 读取 locale


### PR DESCRIPTION
﻿## Summary

- Update `AGENTS.md` so the `@md/api` blurb and i18n message modules match the repo (`marketplace`, `notifications`).
- Remove `Related Issue` from the GitHub PR template. Agents and contributors add `Closes #123` only when a PR actually fixes an issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor
- [x] Documentation / workflow update
- [ ] Test

## Test Procedure

- [x] Confirmed `AGENTS.md` lists `marketplace` and `notifications` and describes share/marketplace on `@md/api`
- [x] Confirmed `.github/pull_request_template.md` no longer includes a Related Issue heading
- [x] Confirmed `create-pr` skill tells agents to add Related Issue only for real issues
- [ ] CI lint passes on this PR

## Pre-flight Checklist

- [x] Self-review of the diff
- [x] `pnpm run lint` passes
- [x] Tests added or updated when behavior changes
- [x] User-facing copy updated in zh-CN, zh-TW, en-US, and ja-JP when UI text changes
- [x] Docs updated when public API or contributor workflow changes
