### PR TITLE
docs: correct leftover contributor and agent skill guidance

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -63,6 +63,11 @@ git symbolic-ref refs/remotes/origin/HEAD
 
 This prints `refs/remotes/origin/<branch>` (usually `main`). Use the last path segment.
 
+```powershell
+# PowerShell
+$BASE_BRANCH = (git symbolic-ref refs/remotes/origin/HEAD).Split('/')[-1]
+```
+
 If that fails, run `git remote show origin` and parse the `HEAD branch:` line.
 
 This is typically `main` or `master`, but may differ per repo.
@@ -70,7 +75,13 @@ This is typically `main` or `master`, but may differ per repo.
 ### 3. Analyze recent commits relevant to this PR
 
 ```bash
+# Bash / zsh
 git log "origin/${BASE_BRANCH}..HEAD" --oneline --no-decorate
+```
+
+```powershell
+# PowerShell
+git log "origin/$BASE_BRANCH..HEAD" --oneline --no-decorate
 ```
 
 Review these commits to understand:
@@ -81,7 +92,13 @@ Review these commits to understand:
 ### 4. Review the diff
 
 ```bash
+# Bash / zsh
 git diff "origin/${BASE_BRANCH}..HEAD" --stat
+```
+
+```powershell
+# PowerShell
+git diff "origin/$BASE_BRANCH..HEAD" --stat
 ```
 
 This shows which files changed and helps identify the type of change.
@@ -121,12 +138,9 @@ Before creating the PR, consider these best practices:
    git fetch origin
    git rebase "origin/${BASE_BRANCH}"
    ```
+   In PowerShell, use `"origin/$BASE_BRANCH"`.
 
-2. **Squash if appropriate**: If there are many small "WIP" commits, consider interactive rebase:
-   ```bash
-   git rebase -i "origin/${BASE_BRANCH}"
-   ```
-   Only suggest this if commits appear messy and the user is comfortable with rebasing.
+2. **Squash if appropriate**: If history is messy, ask the user whether they want commits squashed. Do **not** run `git rebase -i` (interactive; agents cannot complete it).
 
 ### Push Changes
 

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -118,10 +118,9 @@ git add path/to/file1 path/to/file2
 # Stage by pattern
 git add *.test.*
 git add src/components/*
-
-# Interactive staging
-git add -p
 ```
+
+Do **not** run `git add -p` (interactive; agents cannot complete it). Stage explicit paths instead.
 
 **Never commit secrets** (.env, credentials.json, private keys).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## 项目概览
 
-**doocs/md** — 一款微信 Markdown 编辑器，将 Markdown 渲染为微信公众号文章格式。支持自定义主题样式、多图床、AI 助手、浏览器扩展、**简体中文 / English 界面**等特性。
+**doocs/md** — 一款微信 Markdown 编辑器，将 Markdown 渲染为微信公众号文章格式。支持自定义主题样式、多图床、AI 助手、浏览器扩展、**zh-CN / zh-TW / en-US / ja-JP 界面**等特性。
 
 - **在线地址:** https://md.doocs.org
 - **Node 版本:** >= 22.22.2（`.nvmrc`: v22.22.2）
@@ -13,17 +13,17 @@
 
 ## Monorepo 结构
 
-| 工作区           | 路径                  | 说明                                                                       |
-| ---------------- | --------------------- | -------------------------------------------------------------------------- |
-| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox）                          |
-| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID: `doocs.doocs-md`）             |
-| `@md/utools`     | `apps/utools`         | uTools 插件打包                                                            |
-| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）                              |
-| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置                                       |
-| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                                                    |
-| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）                                       |
-| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                                             |
-| `@md/api`        | `apps/api`            | 后端 API：账户、云同步、计费、分享与市场（Cloudflare Workers + Hono + D1） |
+| 工作区           | 路径                  | 说明                                                                                                  |
+| ---------------- | --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox）                                                     |
+| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID: `doocs.doocs-md`）                                        |
+| `@md/utools`     | `apps/utools`         | uTools 插件打包                                                                                       |
+| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）                                                         |
+| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置                                                                  |
+| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                                                                               |
+| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）                                                                  |
+| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                                                                        |
+| `@md/api`        | `apps/api`            | 后端 API：账户、云同步、计费、上传代理、分享、主题/组件市场、表情包（Cloudflare Workers + Hono + D1） |
 
 独立示例（不在 workspace 内）：`docs/examples/wechat-openapi-worker/` — 微信公众号 OpenAPI 代理 Worker。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,17 +29,17 @@
 
 项目结构如下：
 
-| 工作区           | 路径                  | 说明                               |
-| ---------------- | --------------------- | ---------------------------------- |
-| `@md/web`        | `apps/web`            | Vue 3 主应用与浏览器扩展（WXT）    |
-| `doocs-md`       | `apps/vscode`         | VS Code 扩展                       |
-| `@md/utools`     | `apps/utools`         | uTools 插件打包                    |
-| `@md/api`        | `apps/api`            | 账户、云同步、计费、分享与市场 API |
-| `@md/core`       | `packages/core`       | Markdown 渲染引擎                  |
-| `@md/shared`     | `packages/shared`     | 共享配置、类型与工具               |
-| `@md/config`     | `packages/config`     | 共享 TypeScript 配置               |
-| `@doocs/md-cli`  | `packages/md-cli`     | CLI（托管构建产物）                |
-| `@md/mcp-server` | `packages/mcp-server` | MCP 服务                           |
+| 工作区           | 路径                  | 说明                                                 |
+| ---------------- | --------------------- | ---------------------------------------------------- |
+| `@md/web`        | `apps/web`            | Vue 3 主应用与浏览器扩展（WXT）                      |
+| `doocs-md`       | `apps/vscode`         | VS Code 扩展                                         |
+| `@md/utools`     | `apps/utools`         | uTools 插件打包                                      |
+| `@md/api`        | `apps/api`            | 账户、云同步、计费、上传代理、分享、市场与表情包 API |
+| `@md/core`       | `packages/core`       | Markdown 渲染引擎                                    |
+| `@md/shared`     | `packages/shared`     | 共享配置、类型与工具                                 |
+| `@md/config`     | `packages/config`     | 共享 TypeScript 配置                                 |
+| `@doocs/md-cli`  | `packages/md-cli`     | CLI（托管构建产物）                                  |
+| `@md/mcp-server` | `packages/mcp-server` | MCP 服务                                             |
 
 独立示例（不在 pnpm workspace 内）：`docs/examples/wechat-openapi-worker/`。
 
@@ -105,7 +105,7 @@ pnpm web dev
 
 ## 代码规范
 
-- 遵循项目自带的 **ESLint**、**Prettier** 与 **Stylelint** 配置。
+- 遵循项目自带的 **ESLint** 与 **Prettier** 配置。
 - 所有提交必须通过 `pnpm run lint` 检查，无警告、无错误。
 - 推荐在 IDE 中启用 **ESLint** 与 **Prettier** 自动修复。
 - **代码注释统一使用英文。** 只写非显而易见的 why / 约束 / 坑；删除复述代码的噪音注释。用户可见文案（i18n）不受此限制。
@@ -147,7 +147,7 @@ feat(editor): add custom keyboard shortcuts
 
 ## Pull Request 流程
 
-1. **描述清晰**：在 [PR 模板](./.github/pull_request_template.md) 中说明变更动机、实现方案及影响范围。仅在确实修复某个 Issue 时填写 Related Issue（如 `Closes #123`），不要留占位符。
+1. **描述清晰**：按 [PR 模板](./.github/pull_request_template.md) 填写 Summary、Type of Change、Test Procedure 与 Checklist。仅当本 PR 确实修复某个 Issue 时，在模板之外增加 `## Related Issue`（如 `Closes #123`），不要留空标题或 `#XXXX` 占位符。
 2. **保持小而聚焦**：一个 PR 只做一件事，方便审阅。
 3. **确保测试**：新增/变更功能需自测，确保没问题。
 4. **更新文档**：公共 API 或行为变更必须同步更新文档。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,17 +4,17 @@
 
 ## Monorepo 结构
 
-| 包               | 路径                  | 职责                                                                                    |
-| ---------------- | --------------------- | --------------------------------------------------------------------------------------- |
-| `@md/web`        | `apps/web`            | Vue 3 主应用、WXT 浏览器扩展（Chrome/Firefox）、CF Workers 部署                         |
-| `@md/api`        | `apps/api`            | 账户、云同步、计费、上传代理、分享链接、主题/组件市场（Cloudflare Workers + Hono + D1） |
-| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID 为 `doocs.doocs-md`）                        |
-| `@md/utools`     | `apps/utools`         | uTools 插件打包壳（构建产物来自 `@md/web`）                                             |
-| `@md/core`       | `packages/core`       | Markdown → HTML 渲染引擎                                                                |
-| `@md/shared`     | `packages/shared`     | 配置、类型、CodeMirror 编辑器封装、主题 CSS                                             |
-| `@md/config`     | `packages/config`     | 共享 TypeScript 配置                                                                    |
-| `@doocs/md-cli`  | `packages/md-cli`     | 已发布 npm CLI（Express 静态服务）                                                      |
-| `@md/mcp-server` | `packages/mcp-server` | MCP 服务（`render_markdown` 等工具）                                                    |
+| 包               | 路径                  | 职责                                                                                            |
+| ---------------- | --------------------- | ----------------------------------------------------------------------------------------------- |
+| `@md/web`        | `apps/web`            | Vue 3 主应用、WXT 浏览器扩展（Chrome/Firefox）、CF Workers 部署                                 |
+| `@md/api`        | `apps/api`            | 账户、云同步、计费、上传代理、分享链接、主题/组件市场、表情包（Cloudflare Workers + Hono + D1） |
+| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID 为 `doocs.doocs-md`）                                |
+| `@md/utools`     | `apps/utools`         | uTools 插件打包壳（构建产物来自 `@md/web`）                                                     |
+| `@md/core`       | `packages/core`       | Markdown → HTML 渲染引擎                                                                        |
+| `@md/shared`     | `packages/shared`     | 配置、类型、CodeMirror 编辑器封装、主题 CSS                                                     |
+| `@md/config`     | `packages/config`     | 共享 TypeScript 配置                                                                            |
+| `@doocs/md-cli`  | `packages/md-cli`     | 已发布 npm CLI（Express 静态服务）                                                              |
+| `@md/mcp-server` | `packages/mcp-server` | MCP 服务（`render_markdown` 等工具）                                                            |
 
 独立示例（不在 pnpm workspace 内）：
 


### PR DESCRIPTION
﻿## Summary

- Correct leftover contributor docs: four UI locales, `@md/api` coverage (upload/share/marketplace/emoji), remove Stylelint, and spell out that Related Issue is not in the PR template.
- Stop agent skills from recommending interactive git (`rebase -i`, `add -p`) and add PowerShell examples for resolving `BASE_BRANCH`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor
- [x] Documentation / workflow update
- [ ] Test

## Test Procedure

- [x] Confirmed `AGENTS.md` / `CONTRIBUTING.md` / `docs/architecture.md` describe the same API surface
- [x] Confirmed CONTRIBUTING no longer mentions Stylelint
- [x] Confirmed `create-pr` and `git-commit` skills warn against interactive git commands
- [ ] CI lint passes on this PR

## Pre-flight Checklist

- [x] Self-review of the diff
- [x] `pnpm run lint` passes
- [x] Tests added or updated when behavior changes
- [x] User-facing copy updated in zh-CN, zh-TW, en-US, and ja-JP when UI text changes
- [x] Docs updated when public API or contributor workflow changes
