### PR TITLE
fix: paste layout, publish HTML, and stale documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ Details: [docs/architecture.md](../docs/architecture.md).
 
 - **`@md/core` and `@md/shared` export TypeScript source** (`src/index.ts`). Do not pre-build them; consumers (Vite/webpack) compile them.
 - **UI:** Shadcn-Vue components in `apps/web/src/components/ui`. Prefer these over raw HTML/CSS.
-- **Stores:** Domain Pinia stores in `apps/web/src/stores` (`useEditorStore`, `useThemeStore`, `useUiStore`, `useLocaleStore`, …).
+- **Stores:** Domain Pinia stores in `apps/web/src/stores` (`useEditorStore`, `useThemeStore`, `useUIStore`, `useLocaleStore`, …).
 - **Comments:** English only. Explain non-obvious why / constraints; do not narrate the next line. Do not rewrite user-facing i18n copy unless asked.
 
 ### Internationalization (`@md/web`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## 项目概览
 
-**doocs/md** — 一款微信 Markdown 编辑器，将 Markdown 渲染为微信公众号文章格式。支持自定义主题样式、多图床、AI 助手、浏览器扩展、**简体中文 / English 界面**等特性。
+**doocs/md** — 一款微信 Markdown 编辑器，将 Markdown 渲染为微信公众号文章格式。支持自定义主题样式、多图床、AI 助手、浏览器扩展、**zh-CN / zh-TW / en-US / ja-JP 界面**等特性。
 
 - **在线地址:** https://md.doocs.org
 - **Node 版本:** >= 22.22.2（`.nvmrc`: v22.22.2）
@@ -13,17 +13,17 @@
 
 ## Monorepo 结构
 
-| 工作区           | 路径                  | 说明                                                                 |
-| ---------------- | --------------------- | -------------------------------------------------------------------- |
-| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox）                    |
-| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID: `doocs.doocs-md`）       |
-| `@md/utools`     | `apps/utools`         | uTools 插件打包                                                      |
-| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）                        |
-| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置                                 |
-| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                                              |
-| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 服务托管构建产物）                                 |
-| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                                       |
-| `@md/api`        | `apps/api`            | 后端 API：账户登录 + 云同步 + 计费（Cloudflare Workers + Hono + D1） |
+| 工作区           | 路径                  | 说明                                                                       |
+| ---------------- | --------------------- | -------------------------------------------------------------------------- |
+| `@md/web`        | `apps/web`            | 主应用，Vue 3 + 浏览器扩展（WXT: Chrome/Firefox）                          |
+| `doocs-md`       | `apps/vscode`         | VS Code 扩展（webpack 构建，marketplace ID: `doocs.doocs-md`）             |
+| `@md/utools`     | `apps/utools`         | uTools 插件打包                                                            |
+| `@md/core`       | `packages/core`       | 核心 Markdown 渲染引擎（marked + 自定义扩展）                              |
+| `@md/shared`     | `packages/shared`     | 共享工具函数、配置、类型、编辑器配置                                       |
+| `@md/config`     | `packages/config`     | TypeScript 配置基础文件                                                    |
+| `@doocs/md-cli`  | `packages/md-cli`     | CLI 工具（Express 代理线上编辑器 + 本地上传）                              |
+| `@md/mcp-server` | `packages/mcp-server` | MCP 服务，为 AI Agent 暴露接口                                             |
+| `@md/api`        | `apps/api`            | 后端 API：账户、云同步、计费、分享与市场（Cloudflare Workers + Hono + D1） |
 
 独立示例（不在 workspace 内）：`docs/examples/wechat-openapi-worker/` — 微信公众号 OpenAPI 代理 Worker。
 
@@ -35,7 +35,7 @@
 pnpm install          # 安装所有依赖
 pnpm start            # 等同于 `pnpm web dev`
 pnpm run lint         # ESLint --fix 全项目检查
-pnpm run type-check   # vue-tsc 类型检查
+pnpm run type-check   # Web vue-tsc + 各包 TypeScript 检查
 pnpm run build:cli    # 构建 web + 复制到 md-cli + npm pack
 pnpm run release:cli  # 通过 scripts/release.js 发布 CLI
 pnpm utools:package   # 打包 uTools 插件
@@ -80,10 +80,10 @@ pnpm mcp dev          # MCP Server 监听模式
 
 ### 渲染管线
 
-1. `@md/core` 封装 `marked`，实现自定义扩展（Mermaid、PlantUML、Ruby、KaTeX、TOC、alert 块、infographic、slider、markup、emoji、脚注）
-2. `juice` 内联 CSS 以兼容微信
-3. `isomorphic-dompurify` 净化输出
-4. 主题系统（`@md/core/src/theme/`）注入 CSS 变量
+1. `@md/core` 封装 `marked`，实现自定义扩展（Mermaid、PlantUML、Ruby、MathJax、TOC、alert 块、infographic、slider、markup、emoji、脚注）
+2. `isomorphic-dompurify` 净化输出（`sanitizeHtml`）
+3. 主题系统（`@md/core/src/theme/`）注入 CSS 变量
+4. `juice` 内联 CSS（仅复制到微信 / 发布时，在 `@md/web` 导出层）
 
 ### 构建系统
 
@@ -94,11 +94,11 @@ pnpm mcp dev          # MCP Server 监听模式
 
 - Web 应用使用 Tailwind CSS 4 + PostCSS
 - 主题 CSS 文件位于 `packages/shared/src/configs/theme-css/`（default.css、grace.css、simple.css）
-- 部分主题文件使用 Less
+- 应用 UI 部分样式使用 Less（`apps/web/src/assets/less/`），主题包为纯 CSS
 
 ### 状态管理
 
-- Pinia store 位于 `apps/web/src/stores/`（按领域划分：`useEditorStore`、`useThemeStore`、`useUiStore`、`useLocaleStore` 等）
+- Pinia store 位于 `apps/web/src/stores/`（按领域划分：`useEditorStore`、`useThemeStore`、`useUIStore`、`useLocaleStore` 等）
 - UI 组件遵循 Shadcn-Vue 模式，位于 `apps/web/src/components/ui`
 - 跨 feature 通用组件位于 `apps/web/src/components/shared`
 - 架构详情见 [docs/architecture.md](./docs/architecture.md)
@@ -108,7 +108,7 @@ pnpm mcp dev          # MCP Server 监听模式
 Web 主应用与部分浏览器扩展 UI 支持 **zh-CN**、**zh-TW**、**en-US**、**ja-JP**；VS Code 扩展、uTools、CLI、MCP **未**国际化。
 
 - **库**：`vue-i18n`（composition API，`legacy: false`），在 `apps/web/vite.config.ts` 中通过 `unplugin-auto-import` 自动导入 `useI18n`
-- **文案**：`apps/web/src/i18n/messages/{zh-CN,zh-TW,en-US,ja-JP}/`（`common`、`editor`、`dialog`、`store`、`ai`、`upload`、`chrome`）
+- **文案**：`apps/web/src/i18n/messages/{zh-CN,zh-TW,en-US,ja-JP}/`（`common`、`editor`、`dialog`、`store`、`ai`、`upload`、`chrome`、`marketplace`、`notifications`）
 - **组件内**：`useI18n()` + `t('key')`；**Store / 工具函数**：`@/i18n/translate` 的 `t()` / `getLocale()` / `formatLocalDateTime()`
 - **语言状态**：`useLocaleStore`（持久化 key：`locale`）；用户可在 **偏好设置**（`Ctrl+,`）→ General 切换
 - **启动**：`await initStorage()` → `setupI18n(detectInitialLocale())` → Pinia → `useLocaleStore()`（见 `apps/web/src/bootstrap.ts`）；`index.html` 启动屏从 `localStorage` 读取 locale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@
 | `@md/core`       | `packages/core`       | Markdown 渲染引擎                  |
 | `@md/shared`     | `packages/shared`     | 共享配置、类型与工具               |
 | `@md/config`     | `packages/config`     | 共享 TypeScript 配置               |
-| `@doocs/md-cli`  | `packages/md-cli`     | CLI（托管构建产物）                |
+| `@doocs/md-cli`  | `packages/md-cli`     | CLI（代理线上编辑器 + 本地上传）   |
 | `@md/mcp-server` | `packages/mcp-server` | MCP 服务                           |
 
 独立示例（不在 pnpm workspace 内）：`docs/examples/wechat-openapi-worker/`。
@@ -105,7 +105,7 @@ pnpm web dev
 
 ## 代码规范
 
-- 遵循项目自带的 **ESLint**、**Prettier** 与 **Stylelint** 配置。
+- 遵循项目自带的 **ESLint**（`@antfu/eslint-config`）与 **Prettier**（固定 `2.8.8`）配置。
 - 所有提交必须通过 `pnpm run lint` 检查，无警告、无错误。
 - 推荐在 IDE 中启用 **ESLint** 与 **Prettier** 自动修复。
 - **代码注释统一使用英文。** 只写非显而易见的 why / 约束 / 坑；删除复述代码的噪音注释。用户可见文案（i18n）不受此限制。

--- a/README-EN.md
+++ b/README-EN.md
@@ -34,12 +34,12 @@ Pull requests are welcome. You can also share ideas in [Discussions](https://git
 
 ## Features
 
-- Standard Markdown syntax and math formulas (KaTeX)
+- Standard Markdown syntax and math formulas (MathJax)
 - Mermaid diagrams, PlantUML, and [GFM alert blocks](https://github.com/orgs/community/discussions/16925)
 - Ruby annotation extension: `[text]{ruby}` and `[text]^(ruby)` formats
 - Multiple code highlight themes; customizable theme colors and CSS
 - Local draft management with auto-save
-- Sync editor preferences after sign-in ([cloud sync](/docs/cloud-sync.md))
+- Sync editor preferences after sign-in ([cloud sync](./docs/cloud-sync.md))
 - Multiple image hosting options (GitHub, Alibaba Cloud OSS, Tencent COS, Qiniu, MinIO, S3, Cloudflare R2, and more)
 - File import and export
 - AI assistant integration (DeepSeek, OpenAI, Tongyi Qianwen, Tencent Hunyuan, Volcengine, 302.AI, etc.)
@@ -53,14 +53,14 @@ Pull requests are welcome. You can also share ideas in [Discussions](https://git
 | 3   | [Alibaba Cloud OSS](https://www.aliyun.com/product/oss) | `AccessKey ID`, `AccessKey Secret`, `Bucket`, `Region`           | [Docs](https://help.aliyun.com/document_detail/31883.html)                                                               |
 | 4   | [Tencent COS](https://cloud.tencent.com/act/pro/cos)    | `SecretId`, `SecretKey`, `Bucket`, `Region`                      | [Docs](https://cloud.tencent.com/document/product/436/38484)                                                             |
 | 5   | [Qiniu Kodo](https://www.qiniu.com/products/kodo)       | `AccessKey`, `SecretKey`, `Bucket`, `Domain`, `Region`           | [Docs](https://developer.qiniu.com/kodo)                                                                                 |
-| 6   | [MinIO](https://min.io/)                                | `Endpoint`, `Port`, `UseSSL`, `Bucket`, `AccessKey`, `SecretKey` | [Docs](http://docs.minio.org.cn/docs/master/)                                                                            |
+| 6   | [MinIO](https://min.io/)                                | `Endpoint`, `Port`, `UseSSL`, `Bucket`, `AccessKey`, `SecretKey` | [Docs](https://min.io/docs/minio/linux/index.html)                                                                       |
 | 7   | [S3-compatible](https://aws.amazon.com/s3/)             | `Endpoint`, `Region`, `Bucket`, `AccessKey`, `SecretKey`         | Supports AWS S3, Oracle, DigitalOcean, and other S3-compatible storage                                                   |
 | 8   | [WeChat Official Account](https://mp.weixin.qq.com/)    | `appID`, `appsecret`, proxy domain                               | [Tutorial](https://md-pages.doocs.org/tutorial)                                                                          |
 | 9   | [Cloudflare R2](https://developers.cloudflare.com/r2/)  | `AccountId`, `AccessKey`, `SecretKey`, `Bucket`, `Domain`        | [S3 API docs](https://developers.cloudflare.com/r2/api/s3/api/)                                                          |
 | 10  | [Upyun](https://www.upyun.com/)                         | `Bucket`, `Operator`, `Password`, `Domain`                       | [Docs](https://help.upyun.com/)                                                                                          |
 | 11  | [Telegram](https://core.telegram.org/api)               | `Bot Token`, `Chat ID`                                           | [Usage guide](https://github.com/doocs/md/blob/main/docs/telegram-usage.md)                                              |
-| 12  | [Cloudinary](https://cloudinary.com/)                   | `Cloud Name`, `API Key`, `API Secret`                            | [Docs](https://cloudinary.com/documentation/upload_images)                                                               |
-| 13  | Custom upload                                           | Yes                                                              | [How to configure](/docs/custom-upload.md)                                                                               |
+| 12  | [Cloudinary](https://cloudinary.com/)                   | `Cloud Name`, `API Key`, and `API Secret` or `Upload Preset`     | [Docs](https://cloudinary.com/documentation/upload_images)                                                               |
+| 13  | Custom upload                                           | Yes                                                              | [How to configure](./docs/custom-upload.md)                                                                              |
 
 ## Demo
 
@@ -117,6 +117,8 @@ pnpm web wrangler:deploy
 
 ### Option 1: npm CLI
 
+`@doocs/md-cli` starts a local proxy: the UI is forwarded to [https://md.doocs.org/](https://md.doocs.org/), and a local `/upload` endpoint is served. The process binds to `127.0.0.1` only.
+
 ```sh
 # Install globally
 npm i -g @doocs/md-cli
@@ -131,7 +133,7 @@ md-cli port=8899
 Supported CLI options:
 
 - `port`: Listening port. Defaults to `8800`; a random port is chosen if occupied.
-- `spaceId`: dcloud service space ID
+- `spaceId`: optional dcloud service space ID (for uniCloud uploads)
 - `clientSecret`: dcloud service space secret
 
 ### Option 2: Docker

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@
 
 ## 功能特性
 
-- 支持标准 Markdown 语法及数学公式（KaTeX）
+- 支持标准 Markdown 语法及数学公式（MathJax）
 - 支持 Mermaid 图表、PlantUML、[GFM 警告块](https://github.com/orgs/community/discussions/16925)
 - 支持 Ruby 注音扩展，格式兼容 `[文字]{注音}` 与 `[文字]^(注音)`
 - 代码块提供多种高亮主题，可自定义主题色与 CSS 样式
 - 内置本地草稿管理，支持内容自动保存
-- 登录账户后可同步编辑器偏好（[云同步说明](/docs/cloud-sync.md)）
+- 登录账户后可同步编辑器偏好（[云同步说明](./docs/cloud-sync.md)）
 - 支持多种图床（GitHub、阿里云、腾讯云、七牛云、MinIO、S3、Cloudflare R2 等）
 - 支持文件导入与导出
 - 集成主流 AI 模型（DeepSeek、OpenAI、通义千问、腾讯混元、火山方舟、302.AI 等），辅助内容创作
@@ -53,14 +53,14 @@
 | 3   | [阿里云](https://www.aliyun.com/product/oss)           | 配置 `AccessKey ID`、`AccessKey Secret`、`Bucket`、`Region` 参数           | [如何使用阿里云 OSS？](https://help.aliyun.com/document_detail/31883.html)                                             |
 | 4   | [腾讯云](https://cloud.tencent.com/act/pro/cos)        | 配置 `SecretId`、`SecretKey`、`Bucket`、`Region` 参数                      | [如何使用腾讯云 COS？](https://cloud.tencent.com/document/product/436/38484)                                           |
 | 5   | [七牛云](https://www.qiniu.com/products/kodo)          | 配置 `AccessKey`、`SecretKey`、`Bucket`、`Domain`、`Region` 参数           | [如何使用七牛云 Kodo？](https://developer.qiniu.com/kodo)                                                              |
-| 6   | [MinIO](https://min.io/)                               | 配置 `Endpoint`、`Port`、`UseSSL`、`Bucket`、`AccessKey`、`SecretKey` 参数 | [如何使用 MinIO？](http://docs.minio.org.cn/docs/master/)                                                              |
+| 6   | [MinIO](https://min.io/)                               | 配置 `Endpoint`、`Port`、`UseSSL`、`Bucket`、`AccessKey`、`SecretKey` 参数 | [如何使用 MinIO？](https://min.io/docs/minio/linux/index.html)                                                         |
 | 7   | [S3 协议](https://aws.amazon.com/s3/)                  | 配置 `Endpoint`、`Region`、`Bucket`、`AccessKey`、`SecretKey` 参数         | 支持 AWS S3、Oracle、DigitalOcean 等兼容 S3 的存储服务                                                                 |
 | 8   | [公众号](https://mp.weixin.qq.com/)                    | 配置 `appID`、`appsecret`、`代理域名` 参数                                 | [如何使用公众号图床？](https://md-pages.doocs.org/tutorial)                                                            |
 | 9   | [Cloudflare R2](https://developers.cloudflare.com/r2/) | 配置 `AccountId`、`AccessKey`、`SecretKey`、`Bucket`、`Domain` 参数        | [如何使用 S3 API 操作 R2？](https://developers.cloudflare.com/r2/api/s3/api/)                                          |
 | 10  | [又拍云](https://www.upyun.com/)                       | 配置 `Bucket`、`Operator`、`Password`、`Domain` 参数                       | [如何使用 又拍云？](https://help.upyun.com/)                                                                           |
 | 11  | [Telegram](https://core.telegram.org/api)              | 配置 `Bot Token`、`Chat ID` 参数                                           | [如何使用 Telegram 图床？](https://github.com/doocs/md/blob/main/docs/telegram-usage.md)                               |
-| 12  | [Cloudinary](https://cloudinary.com/)                  | 配置 `Cloud Name`、`API Key`、`API Secret` 参数                            | [如何使用 Cloudinary？](https://cloudinary.com/documentation/upload_images)                                            |
-| 13  | 自定义上传                                             | 是                                                                         | [如何自定义上传？](/docs/custom-upload.md)                                                                             |
+| 12  | [Cloudinary](https://cloudinary.com/)                  | 配置 `Cloud Name`、`API Key`，以及 `API Secret` 或 `Upload Preset`         | [如何使用 Cloudinary？](https://cloudinary.com/documentation/upload_images)                                            |
+| 13  | 自定义上传                                             | 是                                                                         | [如何自定义上传？](./docs/custom-upload.md)                                                                            |
 
 ## 产品演示
 
@@ -116,6 +116,8 @@ pnpm web wrangler:deploy
 
 ### 方式一：npm cli
 
+`@doocs/md-cli` 在本机启动一个代理服务：界面转发到 [https://md.doocs.org/](https://md.doocs.org/)，并提供本地 `/upload` 上传接口。进程只监听 `127.0.0.1`。
+
 ```sh
 # 全局安装
 npm i -g @doocs/md-cli
@@ -130,7 +132,7 @@ md-cli port=8899
 支持的命令行参数：
 
 - `port`：监听端口，默认 `8800`，端口被占用时自动随机选取
-- `spaceId`：dcloud 服务空间配置
+- `spaceId`：dcloud 服务空间配置（可选，用于将上传转发到 uniCloud）
 - `clientSecret`：dcloud 服务空间配置
 
 ### 方式二：Docker

--- a/apps/utools/README.md
+++ b/apps/utools/README.md
@@ -10,12 +10,12 @@ pnpm utools:package
 
 该命令将完成以下动作：
 
-1. 调用 `pnpm --filter @md/web run build:utools` 构建前端资源至 `apps/utools/dist`，该构建将自动使用相对路径，确保在 uTools 的 `file://` 协议下能够正常加载。MathJax 从 `node_modules` 复制到构建产物中，Mermaid 作为 npm 模块打包。
+1. 调用 `pnpm --filter @md/web run build:utools` 构建前端资源至 `apps/utools/dist`，该构建将自动使用相对路径，确保在 uTools 的 `file://` 协议下能够正常加载。MathJax 在构建时从 CDN 下载到产物中，Mermaid 作为 npm 模块打包。
 2. 将仓库根目录的版本号写入 `apps/utools/plugin.json`，保持与主项目同步。
 3. 从 `apps/web/public/mpmd/icon-256.png` 拷贝插件图标至 `apps/utools/logo.png`。
 4. 生成形如 `apps/utools/release/md-utools-vX.Y.Z.zip` 的安装包，可直接导入到 uTools。
 
-> 注意：命令执行前请确认已安装 pnpm 10+ 与 Node.js 22+，并在仓库根目录执行 `pnpm install` 安装依赖。
+> 注意：命令执行前请确认已安装 pnpm 10+ 与 Node.js ≥ 22.22.2，并在仓库根目录执行 `pnpm install` 安装依赖。
 
 ## 手动导入调试
 

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -37,7 +37,7 @@
 
 ## 开发
 
-- **Node.js ≥ 22**
+- **Node.js ≥ 22.22.2**（与仓库 `.nvmrc` 一致）
 - 在 monorepo 根目录安装依赖：`pnpm install`
 
 ```sh

--- a/apps/vscode/scripts/smoke-test.mjs
+++ b/apps/vscode/scripts/smoke-test.mjs
@@ -48,7 +48,11 @@ runCase(`countStatus enabled`, { countStatus: true }, [
 ])
 
 runCase(`mac code block`, { isMacCodeBlock: true }, [
-  [`enables mac-sign style`, html => html.includes(`.mac-sign`) && html.includes(`display: flex`)],
+  [`includes mac-sign`, html => html.includes(`class="mac-sign"`) && html.includes(`display: flex`)],
+])
+
+runCase(`mac code block disabled`, { isMacCodeBlock: false }, [
+  [`omits mac-sign`, html => !html.includes(`mac-sign`)],
 ])
 
 console.log(`\nAll VSCode extension smoke tests passed.`)

--- a/apps/web/src/components/editor/EditorPanel.vue
+++ b/apps/web/src/components/editor/EditorPanel.vue
@@ -12,6 +12,11 @@ import { useLocalizedAllComponents } from '@/composables/useLocalizedBuiltinComp
 import { useLocalizedUploadHostOptions } from '@/composables/useLocalizedUploadHosts'
 import { useSlashCommand } from '@/composables/useSlashCommand'
 import { CONTENT_FONT_LANG } from '@/i18n/constants'
+import {
+  collectPlaceholderReplacements,
+  hasMarkdownRemoteImages,
+  rewriteMarkdownImagesToPlaceholders,
+} from '@/lib/editor/pasteMarkdownImages'
 import { toStoredDateTime } from '@/lib/format/datetime'
 import { jumpToAdjacentHeading } from '@/lib/markdown/headingNavigation'
 import { contentHasMath, loadMathJax, MATHJAX_READY_EVENT } from '@/lib/preview/mathjax'
@@ -388,70 +393,45 @@ function createPasteHandler() {
     }
 
     const text = event.clipboardData?.getData('text/plain')
-    if (text) {
-      const mdImgRegex = /!\[(.*?)\]\((https?:\/\/[^)]+)\)/g
-      const matches = [...text.matchAll(mdImgRegex)]
+    if (text && hasMarkdownRemoteImages(text)) {
+      // Native paste keeps CodeMirror's height map intact. Only intercept when
+      // we actually need to rewrite remote image URLs through the uploader.
+      if (!enableImageReupload.value)
+        return false
 
-      if (matches.length > 0) {
-        isImgLoading.value = true
+      isImgLoading.value = true
 
-        let previewText = text
-        const placeholderMap = new Map<string, { originalUrl: string, originalAlt: string }>()
+      const placeholderLabel = t('editorPanel.reuploading')
+      const { previewText, placeholders } = rewriteMarkdownImagesToPlaceholders(text, placeholderLabel)
 
-        let matchIndex = 0
-        previewText = previewText.replace(mdImgRegex, (_, alt, url) => {
-          const id = `LOADING_${Date.now()}_${matchIndex++}`
-          placeholderMap.set(id, { originalUrl: url, originalAlt: alt })
-          return `![${t('editorPanel.reuploading')}](${id})`
-        })
+      view.dispatch(view.state.replaceSelection(previewText))
 
-        view.dispatch(view.state.replaceSelection(previewText))
+      const uniqueUrls = [...new Set(placeholders.map(item => item.originalUrl))]
+      const urlByOriginal = new Map<string, string>()
 
-        const uniqueUrls = [...new Set(matches.map(m => m[2]))]
+      Promise.all(uniqueUrls.map(async (url) => {
+        try {
+          urlByOriginal.set(url, await upload(url))
+        }
+        catch (e) {
+          console.error(`转存失败: ${url}`, e)
+          toast.error(t('editorPanel.reuploadFailed'))
+        }
+      })).then(() => {
+        const changes = collectPlaceholderReplacements(
+          view.state.doc.toString(),
+          placeholderLabel,
+          placeholders,
+          urlByOriginal,
+        )
+        if (changes.length > 0)
+          view.dispatch({ changes })
+        view.requestMeasure()
+      }).finally(() => {
+        isImgLoading.value = false
+      })
 
-        Promise.all(uniqueUrls.map(async (url) => {
-          try {
-            const newUrl = enableImageReupload.value ? await upload(url) : url
-
-            for (const [id, info] of placeholderMap.entries()) {
-              if (info.originalUrl === url) {
-                const searchStr = `![${t('editorPanel.reuploading')}](${id})`
-                const currentDoc = view.state.doc.toString()
-                const pos = currentDoc.indexOf(searchStr)
-
-                if (pos !== -1) {
-                  const newText = `![${info.originalAlt}](${newUrl})`
-                  view.dispatch({
-                    changes: { from: pos, to: pos + searchStr.length, insert: newText },
-                  })
-                }
-              }
-            }
-          }
-          catch (e) {
-            console.error(`转存失败: ${url}`, e)
-            for (const [id, info] of placeholderMap.entries()) {
-              if (info.originalUrl === url) {
-                const searchStr = `![${t('editorPanel.reuploading')}](${id})`
-                const currentDoc = view.state.doc.toString()
-                const pos = currentDoc.indexOf(searchStr)
-
-                if (pos !== -1) {
-                  const newText = `![${info.originalAlt}](${info.originalUrl})`
-                  view.dispatch({
-                    changes: { from: pos, to: pos + searchStr.length, insert: newText },
-                  })
-                }
-              }
-            }
-            toast.error(t('editorPanel.reuploadFailed'))
-          }
-        })).finally(() => {
-          isImgLoading.value = false
-        })
-
-        return true
-      }
+      return true
     }
     return false
   }

--- a/apps/web/src/components/editor/editor-header/PostInfo.vue
+++ b/apps/web/src/components/editor/editor-header/PostInfo.vue
@@ -2,8 +2,10 @@
 import type { Post, PostAccount } from '@md/shared/types'
 import { Check, ChevronDown, ChevronRight, Info, Loader2, Minus } from '@lucide/vue'
 import { CheckboxIndicator, CheckboxRoot, Primitive } from 'reka-ui'
+import { processClipboardContent } from '@/services/export'
 import { useEditorStore } from '@/stores/editor'
 import { useRenderStore } from '@/stores/render'
+import { useThemeStore } from '@/stores/theme'
 import { useUIStore } from '@/stores/ui'
 
 defineOptions({
@@ -16,6 +18,9 @@ const { editor } = storeToRefs(editorStore)
 
 const renderStore = useRenderStore()
 const { output } = storeToRefs(renderStore)
+
+const themeStore = useThemeStore()
+const { primaryColor } = storeToRefs(themeStore)
 
 const uiStore = useUIStore()
 const { isMobile } = storeToRefs(uiStore)
@@ -110,6 +115,18 @@ async function prePost() {
   }
   const accounts = allAccounts.value.filter(a => ![`ipfs`].includes(a.type))
   try {
+    let content = output.value
+    try {
+      const prepared = await processClipboardContent(primaryColor.value, {
+        includeWeChatSpacers: false,
+      })
+      if (prepared.html)
+        content = prepared.html
+    }
+    catch (error) {
+      console.warn(`Failed to prepare publish HTML, falling back to preview output`, error)
+    }
+
     auto = {
       thumb: document.querySelector<HTMLImageElement>(`#output img`)?.src ?? ``,
       title: [1, 2, 3, 4, 5, 6]
@@ -117,7 +134,7 @@ async function prePost() {
         .find(h => h)
         ?.textContent ?? ``,
       desc: document.querySelector(`#output p`)?.textContent?.trim() ?? ``,
-      content: output.value,
+      content,
       markdown: editor.value?.state.doc.toString() ?? ``,
       accounts,
     }

--- a/apps/web/src/lib/editor/pasteMarkdownImages.test.ts
+++ b/apps/web/src/lib/editor/pasteMarkdownImages.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectPlaceholderReplacements,
+  hasMarkdownRemoteImages,
+  rewriteMarkdownImagesToPlaceholders,
+} from './pasteMarkdownImages'
+
+describe(`hasMarkdownRemoteImages`, () => {
+  it(`detects markdown images with http(s) urls`, () => {
+    expect(hasMarkdownRemoteImages(`![alt](https://example.com/a.png)`)).toBe(true)
+    expect(hasMarkdownRemoteImages(`![alt](http://example.com/a.png)`)).toBe(true)
+  })
+
+  it(`ignores local paths and plain text`, () => {
+    expect(hasMarkdownRemoteImages(`![alt](./local.png)`)).toBe(false)
+    expect(hasMarkdownRemoteImages(`no images here`)).toBe(false)
+  })
+})
+
+describe(`rewriteMarkdownImagesToPlaceholders`, () => {
+  it(`replaces each remote image with a unique placeholder`, () => {
+    const { previewText, placeholders } = rewriteMarkdownImagesToPlaceholders(
+      `see ![one](https://a.com/1.png) and ![two](https://b.com/2.png)`,
+      `uploading`,
+      42,
+    )
+
+    expect(placeholders).toEqual([
+      { id: `LOADING_42_0`, originalUrl: `https://a.com/1.png`, originalAlt: `one` },
+      { id: `LOADING_42_1`, originalUrl: `https://b.com/2.png`, originalAlt: `two` },
+    ])
+    expect(previewText).toBe(`see ![uploading](LOADING_42_0) and ![uploading](LOADING_42_1)`)
+  })
+})
+
+describe(`collectPlaceholderReplacements`, () => {
+  it(`maps placeholders back in a single change list`, () => {
+    const placeholders = [
+      { id: `LOADING_1_0`, originalUrl: `https://a.com/1.png`, originalAlt: `one` },
+      { id: `LOADING_1_1`, originalUrl: `https://b.com/2.png`, originalAlt: `two` },
+    ]
+    const doc = `see ![uploading](LOADING_1_0) and ![uploading](LOADING_1_1)`
+    const urls = new Map([
+      [`https://a.com/1.png`, `https://cdn.example/1.png`],
+    ])
+
+    const changes = collectPlaceholderReplacements(doc, `uploading`, placeholders, urls)
+    expect(changes).toHaveLength(2)
+    expect(doc.slice(changes[0].from, changes[0].to)).toBe(`![uploading](LOADING_1_0)`)
+    expect(changes[0].insert).toBe(`![one](https://cdn.example/1.png)`)
+    expect(doc.slice(changes[1].from, changes[1].to)).toBe(`![uploading](LOADING_1_1)`)
+    expect(changes[1].insert).toBe(`![two](https://b.com/2.png)`)
+  })
+
+  it(`skips placeholders the user already edited away`, () => {
+    const placeholders = [
+      { id: `LOADING_1_0`, originalUrl: `https://a.com/1.png`, originalAlt: `one` },
+    ]
+    expect(collectPlaceholderReplacements(`plain text`, `uploading`, placeholders, new Map())).toEqual([])
+  })
+})

--- a/apps/web/src/lib/editor/pasteMarkdownImages.ts
+++ b/apps/web/src/lib/editor/pasteMarkdownImages.ts
@@ -1,0 +1,52 @@
+const MARKDOWN_REMOTE_IMAGE_RE = /!\[(.*?)\]\((https?:\/\/[^)]+)\)/g
+
+function markdownRemoteImageRe(): RegExp {
+  return new RegExp(MARKDOWN_REMOTE_IMAGE_RE.source, `g`)
+}
+
+export function hasMarkdownRemoteImages(text: string): boolean {
+  return markdownRemoteImageRe().test(text)
+}
+
+export interface ImagePlaceholder {
+  id: string
+  originalUrl: string
+  originalAlt: string
+}
+
+export function rewriteMarkdownImagesToPlaceholders(
+  text: string,
+  placeholderLabel: string,
+  now = Date.now(),
+): { previewText: string, placeholders: ImagePlaceholder[] } {
+  const placeholders: ImagePlaceholder[] = []
+  let matchIndex = 0
+  const previewText = text.replace(markdownRemoteImageRe(), (_, alt: string, url: string) => {
+    const id = `LOADING_${now}_${matchIndex++}`
+    placeholders.push({ id, originalUrl: url, originalAlt: alt })
+    return `![${placeholderLabel}](${id})`
+  })
+  return { previewText, placeholders }
+}
+
+export function collectPlaceholderReplacements(
+  doc: string,
+  placeholderLabel: string,
+  placeholders: ImagePlaceholder[],
+  urlByOriginal: Map<string, string>,
+): { from: number, to: number, insert: string }[] {
+  const changes: { from: number, to: number, insert: string }[] = []
+  for (const info of placeholders) {
+    const searchStr = `![${placeholderLabel}](${info.id})`
+    const from = doc.indexOf(searchStr)
+    if (from === -1)
+      continue
+    const newUrl = urlByOriginal.get(info.originalUrl) ?? info.originalUrl
+    changes.push({
+      from,
+      to: from + searchStr.length,
+      insert: `![${info.originalAlt}](${newUrl})`,
+    })
+  }
+  return changes
+}

--- a/apps/web/src/services/export/clipboard.ts
+++ b/apps/web/src/services/export/clipboard.ts
@@ -16,6 +16,11 @@ const JUICE_OPTIONS = {
   resolveCSSVariables: false,
 } as const
 
+export interface ProcessClipboardOptions {
+  /** WeChat copy inserts empty spacer nodes; omit them for publish HTML. Default true. */
+  includeWeChatSpacers?: boolean
+}
+
 async function mergeCss(html: string): Promise<string> {
   const { default: juice } = await import(`juice`)
   const sanitized = sanitizeHtmlCssForJuice(html)
@@ -42,7 +47,10 @@ async function mergeCss(html: string): Promise<string> {
  * Diagrams are exported in light theme structure, but dark ink colors are remapped
  * to currentColor so WeChat reader dark mode can follow text color.
  */
-export async function processClipboardContent(primaryColor: string) {
+export async function processClipboardContent(
+  primaryColor: string,
+  options: ProcessClipboardOptions = {},
+) {
   const outputElement = document.getElementById(`output`)
   if (!outputElement) {
     return {
@@ -109,10 +117,12 @@ export async function processClipboardContent(primaryColor: string) {
 
     solveWeChatImage(clipboardDiv)
 
-    const beforeNode = createEmptyNode()
-    const afterNode = createEmptyNode()
-    clipboardDiv.insertBefore(beforeNode, clipboardDiv.firstChild)
-    clipboardDiv.appendChild(afterNode)
+    if (options.includeWeChatSpacers !== false) {
+      const beforeNode = createEmptyNode()
+      const afterNode = createEmptyNode()
+      clipboardDiv.insertBefore(beforeNode, clipboardDiv.firstChild)
+      clipboardDiv.appendChild(afterNode)
+    }
 
     promoteSvgHtmlLabels(clipboardDiv)
     sanitizeSvgsForWeChat(clipboardDiv)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@
 | `@md/core`       | `packages/core`       | Markdown → HTML 渲染引擎                                                                |
 | `@md/shared`     | `packages/shared`     | 配置、类型、CodeMirror 编辑器封装、主题 CSS                                             |
 | `@md/config`     | `packages/config`     | 共享 TypeScript 配置                                                                    |
-| `@doocs/md-cli`  | `packages/md-cli`     | 已发布 npm CLI（Express 静态服务）                                                      |
+| `@doocs/md-cli`  | `packages/md-cli`     | 已发布 npm CLI（Express 代理线上编辑器 + 本地上传）                                     |
 | `@md/mcp-server` | `packages/mcp-server` | MCP 服务（`render_markdown` 等工具）                                                    |
 
 独立示例（不在 pnpm workspace 内）：
@@ -41,8 +41,8 @@ Markdown 原文
   → isomorphic-dompurify 净化
   → 注入主题 CSS 变量 (@md/core/theme)
   → HTML 输出（预览）
-  → juice 内联 CSS（仅复制到微信时，在 `@md/web` 导出层）
-  → 剪贴板 HTML（公众号）
+  → juice 内联 CSS（复制到微信或发布到第三方平台时，在 `@md/web` 导出层）
+  → 剪贴板 HTML（公众号） / 发布 HTML（头条等）
 ```
 
 Web 端入口：
@@ -51,23 +51,23 @@ Web 端入口：
 2. `useThemeStore` 通过 `applyTheme` 将主题 CSS 写入 `<style>` 标签
 3. 编辑器内容变更经 debounce 后触发 `render()`
 
-扩展列表见 `packages/core/src/extensions/`（Mermaid、PlantUML、KaTeX、Ruby、alert、脚注等）。
+扩展列表见 `packages/core/src/extensions/`（Mermaid、PlantUML、MathJax、Ruby、alert、脚注等）。数学公式由 MathJax 渲染，输出仍使用历史 `katex-*` CSS 类名。
 
 ## Web 应用目录约定（`apps/web/src`）
 
-| 目录                 | 职责                                                                    |
-| -------------------- | ----------------------------------------------------------------------- |
-| `i18n/`              | vue-i18n 配置、locale 检测、按领域拆分的 message 模块                   |
-| `stores/`            | Pinia 全局状态，按领域划分                                              |
-| `composables/`       | 跨组件复用的响应式逻辑                                                  |
-| `services/`          | 外部 API 与领域服务（account / sync / share / upload / export）         |
-| `storage/`           | IndexedDB 抽象层、键前缀与安全读写                                      |
-| `lib/`               | 纯函数与浏览器辅助（bootstrap / browser / format / markdown / preview） |
-| `components/ui/`     | Shadcn-Vue 设计系统（无业务逻辑）                                       |
-| `components/editor/` | 编辑器主界面                                                            |
-| `components/ai/`     | AI 相关 UI                                                              |
-| `components/shared/` | 跨 feature 通用组件                                                     |
-| `entrypoints/`       | WXT 浏览器扩展入口                                                      |
+| 目录                 | 职责                                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `i18n/`              | vue-i18n 配置、locale 检测、按领域拆分的 message 模块                                                 |
+| `stores/`            | Pinia 全局状态，按领域划分                                                                            |
+| `composables/`       | 跨组件复用的响应式逻辑                                                                                |
+| `services/`          | 外部 API 与领域服务（account / sync / share / upload / export / emoji / marketplace / notifications） |
+| `storage/`           | IndexedDB 抽象层、键前缀与安全读写                                                                    |
+| `lib/`               | 纯函数与浏览器辅助（bootstrap / browser / format / markdown / preview）                               |
+| `components/ui/`     | Shadcn-Vue 设计系统（无业务逻辑）                                                                     |
+| `components/editor/` | 编辑器主界面                                                                                          |
+| `components/ai/`     | AI 相关 UI                                                                                            |
+| `components/shared/` | 跨 feature 通用组件                                                                                   |
+| `entrypoints/`       | WXT 浏览器扩展入口                                                                                    |
 
 ## 状态管理（Web）
 
@@ -124,7 +124,7 @@ Pinia stores 按领域划分：
 
 ## 构建
 
-- Web：Vite 8，`manualChunks` 拆分 codemirror、katex、highlight 等
+- Web：Vite 8，`manualChunks` 拆分 codemirror、highlight、prettier 等
 - VSCode 扩展：webpack，预览渲染复用 `@md/core`（见 `apps/vscode/src/previewRenderer.ts`）
 - 浏览器扩展：WXT，`src/entrypoints/` 为入口
 - Core / Shared：**直接导出 TypeScript 源码**，由消费方构建工具编译

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ Markdown 渲染引擎：将 Markdown 转为适合微信公众号的 HTML。
 | --------------------- | --------------------------------------------------------- |
 | `@md/core`            | 主入口：`initRenderer`、`renderMarkdown`、`applyTheme` 等 |
 | `@md/core/renderer`   | 渲染器实现                                                |
-| `@md/core/extensions` | marked 扩展（Mermaid、KaTeX、alert 等）                   |
+| `@md/core/extensions` | marked 扩展（Mermaid、MathJax、alert 等）                 |
 | `@md/core/utils`      | `postProcessHtml`、`renderMarkdown` 辅助                  |
 | `@md/core/theme`      | 主题注入与 CSS 变量                                       |
 
@@ -42,7 +42,7 @@ const html = postProcessHtml(renderMarkdown(renderer, markdown))
 - **highlight.js** — 代码高亮
 - **mermaid / @antv/infographic** — 图表（按需加载仍建议在消费方做 code-splitting）
 - **isomorphic-dompurify** — HTML 净化（`sanitizeHtml`）
-- **juice** — CSS 内联（仅 Web 端复制到微信时使用，不在本包内）
+- **juice** — CSS 内联（仅 Web 端复制到微信 / 发布时使用，不在本包内）
 
 ## 相关文档
 

--- a/packages/core/src/renderer/renderer-impl.ts
+++ b/packages/core/src/renderer/renderer-impl.ts
@@ -113,11 +113,17 @@ const macCodeSvg = `
   </svg>
 `.trim()
 
+function renderMacSign(isMacCodeBlock: boolean): string {
+  if (!isMacCodeBlock)
+    return ``
+  return `<span class="mac-sign" style="display: flex; padding: 10px 14px 0;">${macCodeSvg}</span>`
+}
+
 /**
  * Render diff-{lang} code blocks: + lines green (added), - lines red (deleted),
  * other lines highlighted normally.
  */
-function renderDiffCode(text: string, baseLang: string): string {
+function renderDiffCode(text: string, baseLang: string, isMacCodeBlock: boolean): string {
   const isLangRegistered = hljs.getLanguage(baseLang)
   const lang = isLangRegistered ? baseLang : `plaintext`
 
@@ -156,7 +162,7 @@ function renderDiffCode(text: string, baseLang: string): string {
     })
     .join(``)
 
-  const span = `<span class="mac-sign" style="padding: 10px 14px 0;">${macCodeSvg}</span>`
+  const span = renderMacSign(isMacCodeBlock)
   // Same -webkit-box wrapper as normal code blocks (see highlightAndFormatCode)
   return `<pre class="hljs code__pre">${span}<code class="language-diff-${baseLang}"><span class="code-block__inner" style="display:block">${rendered}</span></code></pre>`
 }
@@ -306,7 +312,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
       const langText = lang.split(` `)[0]
 
       if (langText.startsWith(`diff-`)) {
-        return renderDiffCode(text, langText.slice(5))
+        return renderDiffCode(text, langText.slice(5), !!opts.isMacCodeBlock)
       }
 
       const isLanguageRegistered = hljs.getLanguage(langText)
@@ -314,7 +320,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
       const highlighted = highlightAndFormatCode(text, language, hljs, !!opts.isShowLineNumber)
 
-      const span = `<span class="mac-sign" style="padding: 10px 14px 0;">${macCodeSvg}</span>`
+      const span = renderMacSign(!!opts.isMacCodeBlock)
       // Defer highlighting until grammar loads from CDN
       let pendingAttr = ``
       if (!isLanguageRegistered && langText !== `plaintext`) {

--- a/packages/core/src/renderer/renderer.test.ts
+++ b/packages/core/src/renderer/renderer.test.ts
@@ -46,6 +46,18 @@ describe('initRenderer', () => {
 
     expect(output).toContain(`words`)
     expect(output).toContain(`Hi`)
+    expect(output).not.toContain(`mac-sign`)
+  })
+
+  it('emits an inline mac-sign only when isMacCodeBlock is enabled', () => {
+    const withMac = initRenderer({ isMacCodeBlock: true })
+    const withMacHtml = renderMarkdown('```js\nconsole.log(1)\n```', withMac).html
+    expect(withMacHtml).toContain(`class="mac-sign"`)
+    expect(withMacHtml).toContain(`display: flex`)
+
+    const withoutMac = initRenderer({ isMacCodeBlock: false })
+    const withoutMacHtml = renderMarkdown('```js\nconsole.log(1)\n```', withoutMac).html
+    expect(withoutMacHtml).not.toContain(`mac-sign`)
   })
 
   it('uses injected renderMessages for footnotes and unknown components', () => {

--- a/packages/core/src/utils/markdownHelpers.ts
+++ b/packages/core/src/utils/markdownHelpers.ts
@@ -63,13 +63,6 @@ export function postProcessHtml(baseHtml: string, reading: ReadTimeResults, rend
   html += renderer.buildAddition()
   html += `
     <style>
-      .hljs.code__pre > .mac-sign {
-        display: ${renderer.getOpts().isMacCodeBlock ? `flex` : `none`};
-      }
-    </style>
-  `
-  html += `
-    <style>
       h2 strong {
         color: inherit !important;
       }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -7,7 +7,7 @@ Exposes the `doocs/md` markdown rendering engine and AI service configuration to
 ## Prerequisites
 
 - **Node.js** ≥ 22.22.2（与 monorepo 根目录 `.nvmrc` 一致）
-- **pnpm** ≥ 9（monorepo workspace）
+- **pnpm** ≥ 10（monorepo workspace；根目录 `packageManager` 为 pnpm 11）
 - Clone the monorepo and install dependencies:
 
 ```bash
@@ -22,41 +22,47 @@ pnpm install
 
 Convert Markdown text to styled HTML using the full doocs/md rendering pipeline.
 
-| Parameter          | Type                               | Default     | Description                                            |
-| ------------------ | ---------------------------------- | ----------- | ------------------------------------------------------ |
-| `markdown`         | `string`                           | —           | Markdown source text                                   |
-| `theme`            | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)                      |
-| `primaryColor`     | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)               |
-| `fontFamily`       | `string`                           | 无衬线预设  | Font family stack (see `list_fonts`)                   |
-| `fontSize`         | `string (px)`                      | `"16px"`    | Base font size (see `list_font_sizes`)                 |
-| `legend`           | `string`                           | `"alt"`     | Image caption format (see `list_legend_formats`)       |
-| `isMacCodeBlock`   | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar        |
-| `isShowLineNumber` | `boolean`                          | `false`     | Show line numbers in code blocks                       |
-| `citeStatus`       | `boolean`                          | `false`     | Convert links to footnote-style citations              |
-| `countStatus`      | `boolean`                          | `false`     | Prepend a reading-time estimate                        |
-| `themeMode`        | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions                      |
-| `isUseIndent`      | `boolean`                          | `false`     | Indent paragraph first lines                           |
-| `isUseJustify`     | `boolean`                          | `false`     | Justify paragraph text                                 |
-| `headingStyles`    | `object`                           | `{}`        | Per-level heading styles (see `list_heading_styles`)   |
-| `codeBlockTheme`   | preset URL                         | GitHub 主题 | highlight.js preset from `list_code_block_themes` only |
-| `customCSS`        | `string`                           | `""`        | Additional custom CSS (highest priority)               |
+| Parameter              | Type                               | Default     | Description                                               |
+| ---------------------- | ---------------------------------- | ----------- | --------------------------------------------------------- |
+| `markdown`             | `string`                           | —           | Markdown source text                                      |
+| `theme`                | `"default" \| "grace" \| "simple"` | `"default"` | Visual theme (经典 / 优雅 / 简洁)                         |
+| `primaryColor`         | `string (hex)`                     | `"#0F4C81"` | Primary accent color (see `list_colors`)                  |
+| `fontFamily`           | `string`                           | 无衬线预设  | Font family stack (see `list_fonts`)                      |
+| `fontSize`             | `string (px)`                      | `"16px"`    | Base font size (see `list_font_sizes`)                    |
+| `lineHeight`           | `string (unitless)`                | `"1.75"`    | Body line height (see `list_spacing_options`)             |
+| `blockSpacing`         | `string (unitless)`                | `"1"`       | Theme vertical-margin multiplier (`list_spacing_options`) |
+| `linkColor`            | `string (colour)`                  | `"#576b95"` | Link colour (see `list_color_options`)                    |
+| `blockquoteBackground` | `string (colour)`                  | `"default"` | Blockquote background; `"default"` keeps the theme        |
+| `legend`               | `string`                           | `"alt"`     | Image caption format (see `list_legend_formats`)          |
+| `isMacCodeBlock`       | `boolean`                          | `false`     | Render code blocks with a macOS-style title bar           |
+| `isShowLineNumber`     | `boolean`                          | `false`     | Show line numbers in code blocks                          |
+| `citeStatus`           | `boolean`                          | `false`     | Convert links to footnote-style citations                 |
+| `countStatus`          | `boolean`                          | `false`     | Prepend a reading-time estimate                           |
+| `themeMode`            | `"light" \| "dark"`                | `"light"`   | Color mode for diagram extensions                         |
+| `isUseIndent`          | `boolean`                          | `false`     | Indent paragraph first lines                              |
+| `isUseJustify`         | `boolean`                          | `false`     | Justify paragraph text                                    |
+| `headingStyles`        | `object`                           | `{}`        | Per-level heading styles (see `list_heading_styles`)      |
+| `codeBlockTheme`       | preset URL                         | GitHub 主题 | highlight.js preset from `list_code_block_themes` only    |
+| `customCSS`            | `string`                           | `""`        | Additional custom CSS (highest priority)                  |
 
 Returns `{ html, frontMatter, readingTime: { words, minutes } }`.
 
 ### Other tools
 
-| Tool                     | Description                                                                       |
-| ------------------------ | --------------------------------------------------------------------------------- |
-| `list_themes`            | List all available visual themes with labels and authors                          |
-| `list_colors`            | List all available primary accent colors                                          |
-| `list_fonts`             | List preset font family options                                                   |
-| `list_font_sizes`        | List preset font size options                                                     |
-| `list_legend_formats`    | List image caption format options                                                 |
-| `list_heading_styles`    | List heading style presets                                                        |
-| `list_code_block_themes` | List highlight.js code block theme URLs                                           |
-| `list_ai_services`       | List all built-in AI service providers with endpoints and models                  |
-| `explain_extensions`     | Describe every Markdown extension beyond CommonMark (KaTeX, Mermaid, PlantUML, …) |
-| `get_renderer_options`   | Describe all renderer configuration options                                       |
+| Tool                     | Description                                                                         |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| `list_themes`            | List all available visual themes with labels and authors                            |
+| `list_colors`            | List all available primary accent colors                                            |
+| `list_fonts`             | List preset font family options                                                     |
+| `list_font_sizes`        | List preset font size options                                                       |
+| `list_legend_formats`    | List image caption format options                                                   |
+| `list_heading_styles`    | List heading style presets                                                          |
+| `list_spacing_options`   | List preset line height and block spacing options                                   |
+| `list_color_options`     | List preset link colour and blockquote background options                           |
+| `list_code_block_themes` | List highlight.js code block theme URLs                                             |
+| `list_ai_services`       | List all built-in AI service providers with endpoints and models                    |
+| `explain_extensions`     | Describe every Markdown extension beyond CommonMark (MathJax, Mermaid, PlantUML, …) |
+| `get_renderer_options`   | Describe all renderer configuration options                                         |
 
 ## Setup
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -153,7 +153,7 @@ server.registerTool(
     description:
       `Render Markdown text to styled HTML using the doocs/md rendering engine. `
       + `The output is ready to be used in WeChat Official Accounts (公众号) and other platforms. `
-      + `Supports standard Markdown plus: KaTeX math, Mermaid diagrams, PlantUML, footnotes, alerts, `
+      + `Supports standard Markdown plus: MathJax math, Mermaid diagrams, PlantUML, footnotes, alerts, `
       + `ruby annotations, sliders, and table-of-contents.`,
     inputSchema: renderMarkdownInputSchema,
   },
@@ -333,8 +333,8 @@ server.registerTool(
   () => jsonText({
     extensions: [
       {
-        name: `KaTeX Math`,
-        description: `Inline and block LaTeX math expressions rendered via KaTeX.`,
+        name: `MathJax Math`,
+        description: `Inline and block LaTeX math expressions rendered via MathJax (output still uses katex-* CSS class names).`,
         inlineExample: `$E = mc^2$`,
         blockExample: `$$\n\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}\n$$`,
       },
@@ -356,7 +356,7 @@ server.registerTool(
           + `Obsidian-style: abstract, summary, tldr, todo, success, done, question, help, faq, failure, fail, missing, danger, error, bug, example, quote, cite; `
           + `Academic: theorem, lemma, corollary, proposition, definition, axiom, postulate, assumption, proof, remark. `
           + `Any other name (including non-ASCII, e.g. "::: 推论") renders with a neutral fallback style using the name as the title. `
-          + `Bodies support full Markdown and KaTeX math.`,
+          + `Bodies support full Markdown and MathJax math.`,
         example: `> [!NOTE] 自定义标题\n> This is a note.\n\n::: theorem 勾股定理\n$a^2 + b^2 = c^2$\n:::\n\n::: 推论\n任意名称都会渲染为方框。\n:::`,
       },
       {

--- a/packages/md-cli/README.md
+++ b/packages/md-cli/README.md
@@ -1,14 +1,16 @@
 # md-cli
 
-A powerful yet simple tool for rendering Markdown documents locally during development.
+Local CLI for [doocs/md](https://github.com/doocs/md). It starts an Express process that:
+
+- proxies the editor UI to [https://md.doocs.org/](https://md.doocs.org/)
+- serves a local `/upload` endpoint (and `/public` static files)
+- binds to `127.0.0.1` only
+
+It does **not** render Markdown by itself. Offline / fully private hosting should use the Docker image instead.
 
 ## Installation
 
-To get started with `md-cli`, you can install it either globally or locally, depending on your needs.
-
 ### Install locally
-
-If you only need it for a specific project, you can install it locally by running:
 
 ```bash
 npm install @doocs/md-cli
@@ -16,30 +18,32 @@ npm install @doocs/md-cli
 
 ### Install globally
 
-For global access across all your projects, install it globally with:
-
 ```bash
 npm install -g @doocs/md-cli
 ```
 
 ## Usage
 
-Once installed, running `md-cli` is a breeze. Here’s how to get started:
-
 ### Default setup
-
-To launch `md-cli` with the default settings, simply run:
 
 ```bash
 md-cli
 ```
 
-### Custom port
+Then open `http://127.0.0.1:8800`.
 
-If you prefer to run `md-cli` on a different port, say `8899`, just specify it like this:
+### Custom port
 
 ```bash
 md-cli port=8899
+```
+
+### Optional uniCloud upload
+
+If `spaceId` and `clientSecret` are set, `/upload` forwards files to a dcloud service space. Otherwise files stay under `public/upload`.
+
+```bash
+md-cli spaceId=<id> clientSecret=<secret>
 ```
 
 ## Maintainers

--- a/packages/shared/src/editor/themes.ts
+++ b/packages/shared/src/editor/themes.ts
@@ -31,6 +31,9 @@ const customStyles = EditorView.theme({
   '&.cm-editor .cm-gutters:hover .cm-foldGutter .cm-gutterElement span': {
     opacity: `1`,
   },
+  '.cm-line': {
+    overflowWrap: `anywhere`,
+  },
 })
 
 export function lightTheme() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audit of current docs and the remaining labeled bugs found several real mismatches with the codebase.

**Documentation**
- README GitHub links for cloud-sync / custom-upload were absolute (`/docs/...`) and 404 on GitHub
- Math formulas are rendered with **MathJax**, not KaTeX (legacy `katex-*` class names remain)
- `@doocs/md-cli` proxies `https://md.doocs.org/` and binds to `127.0.0.1`; it does not serve a local `dist`
- Agent / contributing guides: four UI locales, `useUIStore`, no Stylelint, correct render pipeline, MCP tools

**Code**
- Paste of Markdown with remote images always rewrote the document through async placeholder replacements, even when image reupload was off. That matches [#1734](https://github.com/doocs/md/issues/1734) (blank bands / unclickable caret after paste). Native paste is used unless reupload is enabled
- Mac traffic-light chrome was always in the HTML and hidden only by a `<style>` tag. Platforms that strip styles (Toutiao, etc.) left a first-line gap. The node is omitted when Mac style is off, and `display: flex` is inlined when it is on
- Publish HTML now goes through the same juice + SVG pipeline as WeChat copy so Mermaid markers survive ([#1856](https://github.com/doocs/md/issues/1856))

## Related Issue

Closes #1734
Refs #1856

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor
- [x] Documentation / workflow update
- [x] Test

## Test Procedure

- [x] `pnpm --filter @md/core test` (157 passed, including mac-sign emission)
- [x] `pnpm --filter @md/web exec vitest run src/lib/editor/pasteMarkdownImages.test.ts`
- [x] `pnpm --prefix ./apps/vscode test` (smoke: mac-sign on/off)
- [x] `pnpm --filter @md/web run type-check` and package `tsc --noEmit`
- [x] Browser: paste Markdown with long image URLs (reupload off) — URLs stay as markdown, no `LOADING_` placeholders, caret and typing still work
- [x] Browser: toggle Mac code block off — traffic lights disappear with no leftover gap in preview

## Pre-flight Checklist

- [x] Self-review of the diff
- [x] `pnpm run lint` passes (eslint --fix on changed files)
- [x] Tests added or updated when behavior changes
- [x] User-facing copy updated in zh-CN, zh-TW, en-US, and ja-JP when UI text changes (no new UI strings)
- [x] Docs updated when public API or contributor workflow changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e39e8ea-61c9-4fa1-a9de-19378313a589?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e39e8ea-61c9-4fa1-a9de-19378313a589&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

